### PR TITLE
Fixed showing up file content in Groups tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v3.2.x - Splunk app v2.2.0
+
+### Fixed
+- Groups: now the content of each individual configuration file is showed up in pretty JSON format properly.
+
 ## Wazuh v3.2.x - Splunk app v2.1.0
 ### Added
 - New Configuration tab:

--- a/wazuh/appserver/static/wazuh_decorations.css
+++ b/wazuh/appserver/static/wazuh_decorations.css
@@ -27,3 +27,34 @@
 .custom-result-value.icon-only {
     font-size: 60px;
 }
+
+.json-key {
+  color: brown;
+}
+
+.json-value {
+  color: navy;
+}
+
+.json-string {
+  color: olive;
+}
+
+.json-beautifier {
+  background-color: ghostwhite;
+  border: 1px solid silver;
+  padding: 10px 20px;
+  margin: 20px;
+}
+
+.wz-pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  height: 200px;
+  line-height: 20px !important;
+}
+
+.jsonbeauty2 {
+  min-height: 300px;
+  margin: 0px !important;
+}

--- a/wazuh/default/data/ui/nav/default.xml
+++ b/wazuh/default/data/ui/nav/default.xml
@@ -14,7 +14,7 @@
   <view name="search_on_rules" />"
   <view name="search_on_decoders" />"
   <view name="logs" />" 
-  <view name="groups" />" 
+  <a href="groups">Groups</a> 
 
 </collection>
   <collection label="Agents">

--- a/wazuh/local/data/ui/html/groups.html
+++ b/wazuh/local/data/ui/html/groups.html
@@ -9,6 +9,7 @@
   />
   <link rel="stylesheet" type="text/css" href="{{SPLUNKWEB_URL_PREFIX}}/static/build/css/bootstrap-enterprise.css" />
   <link rel="stylesheet" type="text/css" href="{{SPLUNKWEB_URL_PREFIX}}/static/css/build/pages/dashboard-simple-bootstrap.min.css"
+  <link rel="stylesheet" type="text/css" media="all" href="{{SPLUNKWEB_URL_PREFIX}}/static/app/wazuh/wazuh_decorations.css"
   />
 
 
@@ -86,21 +87,20 @@ styles in <div> tags, similar to Bootstrap's grid system.
     </div>
 
     <!-- Uncomment when app be able to show file content -->
-    <!-- <div id="row3" class="dashboard-row dashboard-row3" data-depends="$showFileDetails$">
+    <div id="row3" class="dashboard-row dashboard-row3" data-depends="$showFileDetails$">
       <div id="panel4" class="dashboard-cell" style="width: 100%;">
-        <div class="dashboard-panel clearfix">
-
+        <div>
           <div class="panel-element-row">
-            <div id="element4" class="dashboard-element single" style="width: 100%">
+            <div style="width: 100%">
               <div class="panel-head">
                 <h3>File content</h3>
               </div>
-              <div class="panel-body"></div>
+              <pre class="wz-pre json-beautifier jsonbeauty2"> <code id='filecontent'></code></pre>
             </div>
           </div>
         </div>
       </div>
-    </div> -->
+    </div>
   </div>
 
   <!-- 
@@ -397,6 +397,29 @@ END LAYOUT
             e.preventDefault();
             setToken("showFileDetails", TokenUtils.replaceTokenNames("true", _.extend(submittedTokenModel.toJSON(), e.data)));
             setToken("filename", TokenUtils.replaceTokenNames("$row.filename$", _.extend(submittedTokenModel.toJSON(), e.data)));
+            console.log('click on element');
+            var tokens = mvc.Components.get("default");
+            var name = tokens.get("name");
+            var fileName = tokens.get("filename");
+            var ipBase = tokens.get("baseip");
+            var ipApi = tokens.get("ipapi");
+            var portApi = tokens.get("portapi");
+            var passApi = tokens.get("passwordapi");
+            var userApi = tokens.get("userapi");
+            var portBase = tokens.get("baseport");
+            var endPoint = 'http://'+ipBase + ':' + portBase + '/custom/wazuh/agents/filescontent?id=' + name + '&filename=' + fileName + '&ip=' + ipApi + '&port=' + portApi + '&user=' + userApi + '&pass=' + passApi;
+            console.log("endpoint",endPoint);
+            $.get(endPoint, function (data) {
+              var jsonObj = JSON.parse(data);
+              var jsonPretty = JSON.stringify(jsonObj[0].data, null, '\t');
+              $('#filecontent').text(jsonPretty);
+            }).done(function () {
+              console.log("second success");
+            }).fail(function () {
+              console.log("error");
+            }).always(function () {
+              console.log("finished");
+            });
           }
         });
 


### PR DESCRIPTION
Hi Wazuers, this PR fixes Groups tab in Splunk app: now the content of each individual configuration file is showed up in pretty JSON format properly.

![groups_file_content](https://user-images.githubusercontent.com/10210567/38681334-ad2079dc-3e68-11e8-80db-0ba94dd5575f.gif)
