### PR TITLE
Added queries filter by manager.name or cluster.name depending on selected API

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/agents.py
+++ b/SplunkAppForWazuh/appserver/controllers/agents.py
@@ -377,7 +377,6 @@ class agents(controllers.BaseController):
         opt_password = kwargs["pass"]
         opt_base_url = kwargs["ip"]
         opt_base_port = kwargs["port"]
-
         url = opt_base_url + ":" + opt_base_port
         auth = requests.auth.HTTPBasicAuth(opt_username, opt_password)
         verify = False
@@ -388,7 +387,6 @@ class agents(controllers.BaseController):
         request = requests.get(final_url, auth=auth, verify=verify)
         agents = json.loads(request.text)["data"]["items"]
         total_items = json.loads(request.text)["data"]["totalItems"]
-
         results = []
         for agent in agents:
           data = {}
@@ -396,10 +394,37 @@ class agents(controllers.BaseController):
             if attribute == 'name' or attribute == 'id':
               data[attribute] = value 
           results.append(data)
-
-
         response = {}
         response['data'] = {}
         response['data']['items'] = results
-
         return json.dumps(response)
+
+    # /custom/SplunkAppForWazuh/agents/agent/:id
+    @expose_page(must_login=False, methods=['GET'])
+    def agent(self, **kwargs):
+      try:
+        opt_username = kwargs["user"]
+        opt_password = kwargs["pass"]
+        opt_base_url = kwargs["ip"]
+        opt_base_port = kwargs["port"]
+        opt_agent_id = kwargs["id"]
+
+        url = opt_base_url + ":" + opt_base_port
+        auth = requests.auth.HTTPBasicAuth(opt_username, opt_password)
+        verify = False
+        final_url = url + '/agents/' + opt_agent_id
+        request = requests.get(final_url, auth=auth, verify=verify)
+        agent = json.loads(request.text)["data"]
+        results = []
+        data = {}
+        for attribute, value in agent.iteritems():
+          if attribute == 'name' or attribute == 'id':
+            data[attribute] = value 
+        results.append(data)
+
+        response = {}
+        response['data'] = {}
+        response['data'] = results
+      except Exception as e:
+        return json.dumps("{error:"+str(e)+"}")
+      return json.dumps(response)

--- a/SplunkAppForWazuh/appserver/controllers/cluster.py
+++ b/SplunkAppForWazuh/appserver/controllers/cluster.py
@@ -1,0 +1,59 @@
+#
+# Wazuh app - Cluster backend
+# Copyright (C) 2018 Wazuh, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Find more information about this on the LICENSE file.
+#
+
+import logging
+import os
+import sys
+import json
+import requests
+import re
+# from splunk import AuthorizationFailed as AuthorizationFailed
+import splunk.appserver.mrsparkle.controllers as controllers
+import splunk.appserver.mrsparkle.lib.util as util
+from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
+from splunk.appserver.mrsparkle.lib.decorators import expose_page
+_APPNAME = 'wazuh'
+def setup_logger(level):
+    """
+    Setup a logger for the REST handler.
+    """
+    logger = logging.getLogger('splunk.appserver.%s.controllers.cluster' % _APPNAME)
+    logger.propagate = False  # Prevent the log messages from being duplicated in the python.log file
+    logger.setLevel(level)
+    file_handler = logging.handlers.RotatingFileHandler(make_splunkhome_path(['var', 'log', 'splunk', 'cluster.log']), maxBytes=25000000, backupCount=5)
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    return logger
+logger = setup_logger(logging.DEBUG)
+
+class cluster(controllers.BaseController):
+
+        # /custom/SplunkAppForWazuh/cluster/node
+    @expose_page(must_login=False, methods=['GET'])
+    def node(self, **kwargs):
+      try:
+        opt_username = kwargs["user"]
+        opt_password = kwargs["pass"]
+        opt_base_url = kwargs["ip"]
+        opt_base_port = kwargs["port"]
+
+        url = opt_base_url + ":" + opt_base_port
+        auth = requests.auth.HTTPBasicAuth(opt_username, opt_password)
+        verify = False
+        final_url = url + '/cluster/node'
+        request = requests.get(final_url, auth=auth, verify=verify)
+        cluster = json.loads(request.text)["data"]
+
+      except Exception as e:
+        return json.dumps("{error:"+str(e)+"}")
+      return json.dumps(cluster)

--- a/SplunkAppForWazuh/appserver/static/js/services/credentialService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/credentialService.js
@@ -221,10 +221,14 @@ define(function (require, exports, module) {
         if (clusterData.data.enabled === "yes") {
           api.filter.push('cluster.name')
           const clusterName = await ApiService.get(getClusterNameEndpoint)
+          console.log('cluster.cluster mode',clusterName)
+
           api.filter.push(clusterName.data.cluster)
         } else {
           api.filter.push('manager.name')
           const managerName = await ApiService.get(getManagerNameEndpoint)
+          console.log('manager.name mode',managerName)
+
           api.filter.push(managerName.data[0].name)
         }
 

--- a/SplunkAppForWazuh/appserver/static/js/services/credentialService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/credentialService.js
@@ -198,23 +198,36 @@ define(function (require, exports, module) {
         if (!selectedIndex || selectedIndex === '') {
           selectedIndex = '*'
         }
-        return {api, selectedIndex}
+        return { api, selectedIndex }
       } catch (err) {
         return Promise.reject(err)
       }
     }
 
     /**
-     * Check if connection with API was successful
+     * Check if connection with API was successful, also returns the whole needed information about it
      * @param {String} key 
      */
     static async checkApiConnection(key) {
       try {
         const api = await CredentialService.select(key)
         const checkConnectionEndpoint = '/manager/check_connection?ip=' + api.url + '&port=' + api.portapi + '&user=' + api.userapi + '&pass=' + api.passapi
+        const getClusterNameEndpoint = '/cluster/node?ip=' + api.url + '&port=' + api.portapi + '&user=' + api.userapi + '&pass=' + api.passapi
+        const getManagerNameEndpoint = '/agents/agent/?id=000&ip=' + api.url + '&port=' + api.portapi + '&user=' + api.userapi + '&pass=' + api.passapi
         const clusterData = await ApiService.get(checkConnectionEndpoint)
-        console.log('clusterData',clusterData)
-        api.clusterData = clusterData
+        console.log('clusterData enabled:', clusterData.data.enabled)
+        api.filter = []
+        // If cluster is disabled, then filter by manager.name
+        if (clusterData.data.enabled === "yes") {
+          api.filter.push('cluster.name')
+          const clusterName = await ApiService.get(getClusterNameEndpoint)
+          api.filter.push(clusterName.data.cluster)
+        } else {
+          api.filter.push('manager.name')
+          const managerName = await ApiService.get(getManagerNameEndpoint)
+          api.filter.push(managerName.data[0].name)
+        }
+
         return api
       } catch (err) {
         console.error("checkApiConnection", err.message || err)

--- a/SplunkAppForWazuh/appserver/static/js/services/credentialService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/credentialService.js
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
         const currentApi = LocalStorage.get('selectedApi')
         if (!currentApi) throw new Error('No selected API in LocalStorage')
         const api = await CredentialService.checkApiConnection(JSON.parse(currentApi)._key)
-        let selectedIndex =  IndexService.get()
+        let selectedIndex = IndexService.get()
         if (!selectedIndex || selectedIndex === '') {
           selectedIndex = '*'
         }
@@ -210,12 +210,12 @@ define(function (require, exports, module) {
      */
     static async checkApiConnection(key) {
       try {
-        const manager = await CredentialService.select(key)
-        const endpoint = '/manager/check_connection?ip=' + manager.url + '&port=' + manager.portapi + '&user=' + manager.userapi + '&pass=' + manager.passapi
-        const clusterData = await ApiService.get(endpoint)
+        const api = await CredentialService.select(key)
+        const checkConnectionEndpoint = '/manager/check_connection?ip=' + api.url + '&port=' + api.portapi + '&user=' + api.userapi + '&pass=' + api.passapi
+        const clusterData = await ApiService.get(checkConnectionEndpoint)
         console.log('clusterData',clusterData)
-        manager.clusterData = clusterData
-        return manager
+        api.clusterData = clusterData
+        return api
       } catch (err) {
         console.error("checkApiConnection", err.message || err)
         return Promise.reject(err)

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/agent_summary.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/agent_summary.js
@@ -33,7 +33,7 @@ require([
 
     const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading agent list', 1000, 250, 250)
 
-    CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+    CredentialService.checkSelectedApiConnection().then(({api}) => {
 
       /**
        * Initializes agent table

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/agentsConfiguration.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/agentsConfiguration.js
@@ -28,7 +28,7 @@ require([
 
   ) {
 
-    CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+    CredentialService.checkSelectedApiConnection().then(({api}) => {
 
       const errorConnectionToast = new Toast('error', 'toast-bottom-right', 'Error when loading data', 1000, 250, 250)
       const handleError = err => errorConnectionToast.show()

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/audit.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/audit.js
@@ -95,6 +95,12 @@ require([
       SelectedCredentials.render($('#selectedCredentials'))
 
       const urlTokenModel = new UrlTokenModel()
+      
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      } 
       mvc.Components.registerInstance('url', urlTokenModel)
       const defaultTokenModel = mvc.Components.getInstance('default', { create: true })
       const submittedTokenModel = mvc.Components.getInstance('submitted', { create: true })
@@ -139,7 +145,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\" | top rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\" | top rule.groups",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -155,7 +161,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\" | top agent.name showperc=false",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\" | top agent.name showperc=false",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -171,7 +177,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\" | top audit.directory.name showperc=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\" | top audit.directory.name showperc=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -187,7 +193,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  agent.name=\"$agent$\"| top audit.file.name showperc=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  agent.name=\"$agent$\"| top audit.file.name showperc=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -203,7 +209,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  agent.name=\"$agent$\" | timechart count by rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  agent.name=\"$agent$\" | timechart count by rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -219,7 +225,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  \"rule.id\"=80787 agent.name=\"$agent$\" | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  \"rule.id\"=80787 agent.name=\"$agent$\" | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -235,7 +241,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\"  | top audit.egid",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\"  | top audit.egid",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -251,7 +257,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\"  | top audit.command",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\"  | top audit.command",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -267,7 +273,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  agent.name=\"$agent$\"| timechart count by rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  agent.name=\"$agent$\"| timechart count by rule.groups",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -283,7 +289,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80784 agent.name=\"$agent$\"| top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80784 agent.name=\"$agent$\"| top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -299,7 +305,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80781 agent.name=\"$agent$\" | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80781 agent.name=\"$agent$\" | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -315,7 +321,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80790 agent.name=\"$agent$\" | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80790 agent.name=\"$agent$\" | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -331,7 +337,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80791 agent.name=\"$agent$\"| top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  rule.id=80791 agent.name=\"$agent$\"| top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -347,7 +353,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\"| table _time, agent.name, rule.description, audit.exe, audit.file.mode, audit.egid, audit.euid",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=\"$agent$\"| table _time, agent.name, rule.description, audit.exe, audit.file.mode, audit.egid, audit.euid",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -363,7 +369,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -441,7 +447,7 @@ require([
       element3.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=* | top agent.name showperc=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit agent.name=* | top agent.name showperc=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -456,7 +462,7 @@ require([
       element4.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit | top audit.directory.name showperc=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit | top audit.directory.name showperc=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -471,7 +477,7 @@ require([
       element5.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit  | top audit.file.name showperc=f"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit  | top audit.file.name showperc=f"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -773,7 +779,7 @@ require([
       element15.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=audit | table _time, agent.name, rule.description, audit.exe, audit.file.mode, audit.egid, audit.euid"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=audit | table _time, agent.name, rule.description, audit.exe, audit.file.mode, audit.egid, audit.euid"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/audit.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/audit.js
@@ -95,8 +95,6 @@ require([
       SelectedCredentials.render($('#selectedCredentials'))
 
       const urlTokenModel = new UrlTokenModel()
-      
-      let selectedIndex = ''
       mvc.Components.registerInstance('url', urlTokenModel)
       const defaultTokenModel = mvc.Components.getInstance('default', { create: true })
       const submittedTokenModel = mvc.Components.getInstance('submitted', { create: true })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/cis.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/cis.js
@@ -92,6 +92,11 @@ require([
 
     const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading data', 1000, 250, 250)
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      } 
       SelectedCredentials.render($('#selectedCredentials'))
       
       const urlTokenModel = new UrlTokenModel()
@@ -139,7 +144,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by rule.cis{} usenull=f useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by rule.cis{} usenull=f useother=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -155,7 +160,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | rename rule.cis{} as rule.cis |chart count by rule.cis,agent.name| transpose header_field=rule.cis | rename column as agent.client",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | rename rule.cis{} as rule.cis |chart count by rule.cis,agent.name| transpose header_field=rule.cis | rename column as agent.client",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -171,7 +176,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\"| rename rule.cis{} as rule.cis |chart count by rule.cis,rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\"| rename rule.cis{} as rule.cis |chart count by rule.cis,rule.groups",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -187,7 +192,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\" | chart count by agent.name,rule.cis{} useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\" | chart count by agent.name,rule.cis{} useother=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -203,7 +208,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| timechart count(agent.name) by rule.cis{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| timechart count(agent.name) by rule.cis{}",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -219,7 +224,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| chart count(rule.cis{}) as \"Agent name\"  by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| chart count(rule.cis{}) as \"Agent name\"  by agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -235,7 +240,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| chart count by rule.cis{} | rename rule.cis{} as \"Rule CIS\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| chart count by rule.cis{} | rename rule.cis{} as \"Rule CIS\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -251,7 +256,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| stats count by _time, agent.name, rule.level, rule.cis{}, full_log",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.cis{}=* agent.name=\"$agent$\"| stats count by _time, agent.name, rule.level, rule.cis{}, full_log",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -267,7 +272,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -363,7 +368,7 @@ require([
       element4.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh | rename rule.cis{} as rule.cis |chart count by rule.cis,rule.groups"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | rename rule.cis{} as rule.cis |chart count by rule.cis,rule.groups"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -471,7 +476,7 @@ require([
       element9.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.cis{}=* | stats count by _time, agent.name, rule.level, rule.cis{}, full_log"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.cis{}=* | stats count by _time, agent.name, rule.level, rule.cis{}, full_log"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/configuration.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/configuration.js
@@ -33,7 +33,7 @@ require([
 
   ) {
 
-    CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+    CredentialService.checkSelectedApiConnection().then(({api}) => {
 
       // Toast definition
       const errorConnectionToast = new Toast('error', 'toast-bottom-right', 'Error at loading data', 1000, 250, 250)

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/fim.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/fim.js
@@ -90,6 +90,11 @@ require([
 
     let pageLoading = true
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      } 
       SelectedCredentials.render($('#selectedCredentials'))
 
       
@@ -140,7 +145,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | timechart count by rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | timechart count by rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -156,7 +161,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"was deleted\"  agent.name=\"$agent$\" | top syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"was deleted\"  agent.name=\"$agent$\" | top syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -172,7 +177,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | top agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | top agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -188,7 +193,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" \"added\" agent.name=\"$agent$\"| top syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" \"added\" agent.name=\"$agent$\"| top syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -204,7 +209,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" \"Integrity checksum changed\" agent.name=\"$agent$\"| top syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" \"Integrity checksum changed\" agent.name=\"$agent$\"| top syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -220,7 +225,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" \"Group ownership was\" agent.name=\"$agent$\" | top syscheck.gname_after",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" \"Group ownership was\" agent.name=\"$agent$\" | top syscheck.gname_after",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -236,7 +241,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\"  | top rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\"  | top rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -252,7 +257,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" AND syscheck.perm_before=* agent.name=\"$agent$\" | regex syscheck.perm_after=\"[0-7]{3}([1357]|[0-7]([1357]|[0-7][1357])).*\" | regex syscheck.perm_before!=\"[0-7]{3}([1357]|[0-7]([1357]|[0-7][1357])).*\" | top syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" AND syscheck.perm_before=* agent.name=\"$agent$\" | regex syscheck.perm_after=\"[0-7]{3}([1357]|[0-7]([1357]|[0-7][1357])).*\" | regex syscheck.perm_before!=\"[0-7]{3}([1357]|[0-7]([1357]|[0-7][1357])).*\" | top syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -268,7 +273,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | timechart count by syscheck.path span=8h",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | timechart count by syscheck.path span=8h",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -284,7 +289,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" syscheck.uid_after=0 OR \"syscheck.uid_before=0\" OR syscheck.guid_after=\"root\" OR syscheck.guid_before=0 agent.name=\"$agent$\" | top syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"syscheck\" syscheck.uid_after=0 OR \"syscheck.uid_before=0\" OR syscheck.guid_after=\"root\" OR syscheck.guid_before=0 agent.name=\"$agent$\" | top syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -300,7 +305,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"Ownership was\" agent.name=\"$agent$\" | top syscheck.uname_before",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"Ownership was\" agent.name=\"$agent$\" | top syscheck.uname_before",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -316,7 +321,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"Ownership was\" agent.name=\"$agent$\" | top syscheck.uname_after",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"Ownership was\" agent.name=\"$agent$\" | top syscheck.uname_after",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -332,7 +337,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"Group ownership was\" agent.name=\"$agent$\" | top syscheck.gname_before",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" \"Group ownership was\" agent.name=\"$agent$\" | top syscheck.gname_before",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -348,7 +353,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"Permissions changed from\" \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | top syscheck.perm_before",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"Permissions changed from\" \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | top syscheck.perm_before",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -364,7 +369,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"Permissions changed from\" \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | top syscheck.perm_after",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"Permissions changed from\" \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\" | top syscheck.perm_after",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -380,7 +385,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\"| table agent.name, syscheck.path, full_log, syscheck.mtime_after",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\" agent.name=\"$agent$\"| table agent.name, syscheck.path, full_log, syscheck.mtime_after",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -396,7 +401,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -905,7 +910,7 @@ require([
       element17.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"syscheck\"| table agent.name, syscheck.path, full_log, syscheck.mtime_after"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"syscheck\"| table agent.name, syscheck.path, full_log, syscheck.mtime_after"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/gdpr.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/gdpr.js
@@ -92,6 +92,11 @@ require([
 
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      } 
       SelectedCredentials.render($('#selectedCredentials'))
       
       const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading agent list', 1000, 250, 250)
@@ -140,7 +145,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by rule.gdpr",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by rule.gdpr",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -156,7 +161,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | top rule.gdpr{} useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | top rule.gdpr{} useother=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -172,7 +177,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=II_5.1.f agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=II_5.1.f agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -188,7 +193,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=IV_30.1.g agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=IV_30.1.g agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -204,7 +209,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=IV_32.2 agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=IV_32.2 agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -220,7 +225,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=IV_35.7.d agent.name=\"$agent$\"| timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=IV_35.7.d agent.name=\"$agent$\"| timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -236,7 +241,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\"| top rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\"| top rule.groups",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -252,7 +257,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | stats count(rule.gdpr{}) by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | stats count(rule.gdpr{}) by agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -268,7 +273,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.gdpr{}\">=10 agent.name=\"$agent$\" | timechart count(rule.level) by rule.gdpr{} useother=f usenull=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.gdpr{}\">=10 agent.name=\"$agent$\" | timechart count(rule.level) by rule.gdpr{} useother=f usenull=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -284,7 +289,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.gdpr{}\">=* agent.name=\"$agent$\"| timechart count by rule.description useother=f usenull=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.gdpr{}\">=* agent.name=\"$agent$\"| timechart count by rule.description useother=f usenull=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -300,7 +305,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by syscheck.path useother=f usenull=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by syscheck.path useother=f usenull=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -316,7 +321,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.gdpr{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.gdpr{}",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -332,7 +337,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  agent.name=\"$agent$\"| table agent.name, rule.level, rule.gdpr{}, rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  agent.name=\"$agent$\"| table agent.name, rule.level, rule.gdpr{}, rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -348,7 +353,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | stats count sparkline by agent.name, rule.gdpr{}, rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | stats count sparkline by agent.name, rule.gdpr{}, rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -364,7 +369,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -785,7 +790,7 @@ require([
       element13.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.gdpr{}"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.gdpr{}"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -805,7 +810,7 @@ require([
       element14.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  | table agent.name, rule.level, rule.gdpr{}, rule.description"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  | table agent.name, rule.level, rule.gdpr{}, rule.description"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -825,7 +830,7 @@ require([
       element15.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  | stats count sparkline by agent.name, rule.gdpr{}, rule.description"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  | stats count sparkline by agent.name, rule.gdpr{}, rule.description"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/general.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/general.js
@@ -93,8 +93,12 @@ require([
     const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading data', 1000, 250, 250)
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
-      console.log('API',api)
-      console.log('selected index',selectedIndex)
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      } 
+
       // Create token namespaces
       //const selectedIndex = SelectedCredentials.getSelectedIndex()
       SelectedCredentials.render($('#selectedCredentials'))
@@ -153,7 +157,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" | stats count",
+        "search":  "index="+selectedIndex+" "+nameFilter+" | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -169,7 +173,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.level\">=12 | chart count",
+        "search":   "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.level\">=12 | chart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -185,7 +189,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"authentication_fail*\" | stats count",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_fail*\" | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -201,7 +205,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"authentication_success\" | stats count",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_success\" | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -217,7 +221,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.level=*| timechart count by rule.level",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.level=*| timechart count by rule.level",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -233,7 +237,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | timechart span=2h count",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | timechart span=2h count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -249,7 +253,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | top \"agent.name\"",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top \"agent.name\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -265,7 +269,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | timechart span=1h limit=5 useother=f count by agent.name",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | timechart span=1h limit=5 useother=f count by agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -297,7 +301,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | top limit=1 srcuser showcount=false showperc=false",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcuser showcount=false showperc=false",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -313,7 +317,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | top limit=1 srcip showcount=false showperc=false",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcip showcount=false showperc=false",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -329,7 +333,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | top limit=1 rule.groups showcount=false showperc=false",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.groups showcount=false showperc=false",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -345,7 +349,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh | top limit=1 rule.pci_dss{} showcount=false showperc=false",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.pci_dss{} showcount=false showperc=false",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -361,7 +365,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh |stats count sparkline by rule.id, rule.description, rule.groups, rule.level | sort count DESC | head 10 | rename rule.id as \"Rule ID\", rule.description as \"Description\", rule.level as Level, count as Count, rule.groups as \"Rule group\"",
+        "search":  "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh |stats count sparkline by rule.id, rule.description, rule.groups, rule.level | sort count DESC | head 10 | rename rule.id as \"Rule ID\", rule.description as \"Description\", rule.level as Level, count as Count, rule.groups as \"Rule group\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -424,7 +428,7 @@ require([
       element1.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -456,7 +460,7 @@ require([
       element2.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh \"rule.level\">=12 "
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.level\">=12 "
           utils.redirect(url, false, "_blank")
         }
       })
@@ -487,7 +491,7 @@ require([
       element3.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"authentication_fail*\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_fail*\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -518,7 +522,7 @@ require([
       element4.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  \"rule.groups\"=\"authentication_success\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_success\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -719,7 +723,7 @@ require([
       element10.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh | top limit=1 srcuser showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcuser showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -750,7 +754,7 @@ require([
       element11.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh | top limit=1 srcip showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcip showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -781,7 +785,7 @@ require([
       element12.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh | top limit=1 rule.groups showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.groups showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -812,7 +816,7 @@ require([
       element13.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh | top limit=1 rule.pci_dss{} showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.pci_dss{} showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -832,7 +836,7 @@ require([
       element14.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh |stats count sparkline by rule.id, rule.description, rule.groups, rule.level | sort count DESC | head 10 "
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh |stats count sparkline by rule.id, rule.description, rule.groups, rule.level | sort count DESC | head 10 "
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/general.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/general.js
@@ -428,7 +428,7 @@ require([
       element1.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=\"wazuh\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -460,7 +460,7 @@ require([
       element2.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.level\">=12 "
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh \"rule.level\">=12 "
           utils.redirect(url, false, "_blank")
         }
       })
@@ -491,7 +491,7 @@ require([
       element3.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_fail*\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_fail*\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -522,7 +522,7 @@ require([
       element4.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_success\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh  \"rule.groups\"=\"authentication_success\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -723,7 +723,7 @@ require([
       element10.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcuser showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcuser showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -754,7 +754,7 @@ require([
       element11.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcip showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh | top limit=1 srcip showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -785,7 +785,7 @@ require([
       element12.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.groups showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.groups showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -816,7 +816,7 @@ require([
       element13.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.pci_dss{} showcount=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh | top limit=1 rule.pci_dss{} showcount=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -836,7 +836,7 @@ require([
       element14.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh |stats count sparkline by rule.id, rule.description, rule.groups, rule.level | sort count DESC | head 10 "
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh |stats count sparkline by rule.id, rule.description, rule.groups, rule.level | sort count DESC | head 10 "
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/general.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/general.js
@@ -877,10 +877,8 @@ require([
       DashboardController.ready()
       pageLoading = false
     }).catch((err) => { 
-      console.error('error!',err)
-      // window.location.href = '/en-US/app/SplunkAppForWazuh/settings'
+      window.location.href = '/en-US/app/SplunkAppForWazuh/settings'
      })
-
   }
 )
 // ]]>

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/groups.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/groups.js
@@ -34,7 +34,7 @@ require([
 
     const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading data', 1000, 250, 250)
     const errorClickToast = new Toast('error', 'toast-bottom-right', 'Error at clicking on row', 1000, 250, 250)
-    CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+    CredentialService.checkSelectedApiConnection().then(({api}) => {
       SelectedCredentials.render($('#selectedCredentials'))
 
       const tableFiles = new tableView()

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/logs.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/logs.js
@@ -35,7 +35,7 @@ require([
     /**
      * Check connection before load the content
      */
-    CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+    CredentialService.checkSelectedApiConnection().then(({api}) => {
       SelectedCredentials.render($('#selectedCredentials'))
 
       const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading manager logs list', 1000, 250, 250)

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/manager_decoders.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/manager_decoders.js
@@ -94,6 +94,11 @@ require([
 
    
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
       const urlTokenModel = new UrlTokenModel()
       mvc.Components.registerInstance('url', urlTokenModel)
@@ -170,7 +175,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index=\"wazuh\" sourcetype=\"wazuh\"| timechart count by \"decoder.name\" useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\"| timechart count by \"decoder.name\" useother=f",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/manager_ruleset.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/manager_ruleset.js
@@ -94,6 +94,10 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
       
       const urlTokenModel = new UrlTokenModel()
@@ -176,7 +180,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index=" + selectedIndex + " sourcetype=wazuh | top rule.id",
+        "search":  "index="+selectedIndex+" "+nameFilter+ " sourcetype=wazuh | top rule.id",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -192,7 +196,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index=" + selectedIndex + " sourcetype=wazuh | top rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+ " sourcetype=wazuh | top rule.groups",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -208,7 +212,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index=" + selectedIndex + " sourcetype=wazuh | top rule.pci_dss{} useother=f",
+        "search":  "index="+selectedIndex+" "+nameFilter+ " sourcetype=wazuh | top rule.pci_dss{} useother=f",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -224,7 +228,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index=" + selectedIndex + " sourcetype=wazuh  | top rule.level",
+        "search":  "index="+selectedIndex+" "+nameFilter+ " sourcetype=wazuh  | top rule.level",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/manager_status.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/manager_status.js
@@ -91,14 +91,14 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      SelectedCredentials.render($('#selectedCredentials'))
+      const urlTokenModel = new UrlTokenModel()
+      mvc.Components.registerInstance('url', urlTokenModel)
+      const defaultTokenModel = mvc.Components.getInstance('default', { create: true })
+      const submittedTokenModel = mvc.Components.getInstance('submitted', { create: true })
+      const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading manager status', 1000, 250, 250)
+      defaultTokenModel.set(urlTokenModel.toJSON())
       urlTokenModel.on('url:navigate', () => {
-        SelectedCredentials.render($('#selectedCredentials'))
-        const urlTokenModel = new UrlTokenModel()
-        mvc.Components.registerInstance('url', urlTokenModel)
-        const defaultTokenModel = mvc.Components.getInstance('default', { create: true })
-        const submittedTokenModel = mvc.Components.getInstance('submitted', { create: true })
-        const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading manager status', 1000, 250, 250)
-        defaultTokenModel.set(urlTokenModel.toJSON())
         if (!_.isEmpty(urlTokenModel.toJSON()) && !_.all(urlTokenModel.toJSON(), _.isUndefined)) {
           submitTokens()
         } else {
@@ -684,7 +684,9 @@ require([
 
       DashboardController.ready()
       pageLoading = false
-    }).catch((err) => { window.location.href = '/en-US/app/SplunkAppForWazuh/settings' })
+    }).catch((err) => { console.error('err',err);
+    //  window.location.href = '/en-US/app/SplunkAppForWazuh/settings' 
+    })
   }
 )
 // ]]>

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/openscap.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/openscap.js
@@ -92,6 +92,10 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       
@@ -142,7 +146,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"!=\"syslog\" agent.name=\"$agent$\"| top oscap.scan.content",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"!=\"syslog\" agent.name=\"$agent$\"| top oscap.scan.content",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -158,7 +162,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"!=\"syslog\" agent.name=\"$agent$\"| top oscap.scan.profile.title",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"!=\"syslog\" agent.name=\"$agent$\"| top oscap.scan.profile.title",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -174,7 +178,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"!=\"syslog\" agent.name=\"$agent$\"| top agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"!=\"syslog\" agent.name=\"$agent$\"| top agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -190,7 +194,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" AND \"rule.groups\"=\"errors\" agent.name=\"$agent$\" | top rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" AND \"rule.groups\"=\"errors\" agent.name=\"$agent$\" | top rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -206,7 +210,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap-report\" agent.name=\"$agent$\" | chart avg(oscap.scan.score) as Score |  eval Score=round(Score,2) |eval Score=Score + \"%\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap-report\" agent.name=\"$agent$\" | chart avg(oscap.scan.score) as Score |  eval Score=round(Score,2) |eval Score=Score + \"%\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -222,7 +226,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap-report\" agent.name=\"$agent$\"| rangemap field=oscap.scan.score \"0.1 to 15\"=0-15 \"15.01 to 30\"=15.01-30 \"30.01 to 50\"=30.1-50 \"50.1 to 70\"=50.1-70 \"70.1 to 90\"=70.1-90 \"90.1 to 100\"=90.1-100 | top range",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap-report\" agent.name=\"$agent$\"| rangemap field=oscap.scan.score \"0.1 to 15\"=0-15 \"15.01 to 30\"=15.01-30 \"30.01 to 50\"=30.1-50 \"50.1 to 70\"=50.1-70 \"70.1 to 90\"=70.1-90 \"90.1 to 100\"=90.1-100 | top range",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -238,7 +242,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap-report\" agent.name=\"$agent$\" | timechart count by oscap.scan.score",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap-report\" agent.name=\"$agent$\" | timechart count by oscap.scan.score",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -254,7 +258,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" AND \"rule.groups\"=\"errors\" agent.name=\"$agent$\"| timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" AND \"rule.groups\"=\"errors\" agent.name=\"$agent$\"| timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -270,7 +274,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"=\"oscap-result\" agent.name=\"$agent$\" | top oscap.check.result",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"=\"oscap-result\" agent.name=\"$agent$\" | top oscap.check.result",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -286,7 +290,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"=\"oscap-result\" agent.name=\"$agent$\" | top oscap.check.severity",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"=\"oscap-result\" agent.name=\"$agent$\" | top oscap.check.severity",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -302,7 +306,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"=\"oscap-result\" oscap.check.result=fail agent.name=\"$agent$\" | timechart count by oscap.check.title useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" \"rule.groups\"=\"oscap-result\" oscap.check.result=fail agent.name=\"$agent$\" | timechart count by oscap.check.title useother=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -318,7 +322,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" agent.name=\"$agent$\" | table agent.name, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title , oscap.scan.score",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" agent.name=\"$agent$\" | table agent.name, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title , oscap.scan.score",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -334,7 +338,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" agent.name=\"$agent$\" | table _time, agent.name, oscap.check.title, oscap.check.result, oscap.check.severity, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" agent.name=\"$agent$\" | table _time, agent.name, oscap.check.title, oscap.check.result, oscap.check.severity, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -350,7 +354,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -736,7 +740,7 @@ require([
       element13.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" | table agent.name, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title , oscap.scan.score"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" | table agent.name, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title , oscap.scan.score"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -757,7 +761,7 @@ require([
       element14.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"oscap\" | table _time, agent.name, oscap.check.title, oscap.check.result, oscap.check.severity, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"oscap\" | table _time, agent.name, oscap.check.title, oscap.check.result, oscap.check.severity, oscap.scan.id, oscap.scan.content, oscap.scan.profile.title"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_audit.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_audit.js
@@ -91,10 +91,11 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
-
-      
-
       const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading agent list', 1000, 250, 250)
       const urlTokenModel = new UrlTokenModel()
       mvc.Components.registerInstance('url', urlTokenModel)
@@ -147,7 +148,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80790 | stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80790 | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -163,7 +164,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80784 | stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80784 | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -179,7 +180,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80781 | stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80781 | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -195,7 +196,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80791 | stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80791 | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -211,7 +212,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.description=* rule.groups=\"audit\" | stats latest(rule.description)",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.description=* rule.groups=\"audit\" | stats latest(rule.description)",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -227,7 +228,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" | top rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" | top rule.groups",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -243,7 +244,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" agent.name=* | top agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" agent.name=* | top agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -259,7 +260,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" audit.directory.name=* | top audit.directory.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" audit.directory.name=* | top audit.directory.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -275,7 +276,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" audit.file.name=* | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" audit.file.name=* | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -291,7 +292,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" | timechart limit=10 count by rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" | timechart limit=10 count by rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -307,7 +308,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80784 | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80784 | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -323,7 +324,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80781 | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80781 | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -339,7 +340,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" | top audit.command",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" | top audit.command",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -355,7 +356,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80790 | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80790 | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -371,7 +372,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80791 | top audit.file.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80791 | top audit.file.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -387,7 +388,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" | stats count sparkline by agent.name,rule.description, audit.exe, audit.type, audit.euid | sort count DESC | rename agent.name as \"Agent name\", rule.description as Description, audit.exe as Command, audit.type as Type, audit.euid as \"Effective user id\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" | stats count sparkline by agent.name,rule.description, audit.exe, audit.type, audit.euid | sort count DESC | rename agent.name as \"Agent name\", rule.description as Description, audit.exe as Command, audit.type as Type, audit.euid as \"Effective user id\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -450,7 +451,7 @@ require([
       element1.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80790 | stats count"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80790 | stats count"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -481,7 +482,7 @@ require([
       element2.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80784 | stats count"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80784 | stats count"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -512,7 +513,7 @@ require([
       element3.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80781 | stats count"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80781 | stats count"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -543,7 +544,7 @@ require([
       element4.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80791 | stats count"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" rule.id=80791 | stats count"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -574,7 +575,7 @@ require([
       element5.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.description=* rule.groups=\"audit\" | stats latest(rule.description)"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.description=* rule.groups=\"audit\" | stats latest(rule.description)"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -934,7 +935,7 @@ require([
       element16.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.groups=\"audit\" | stats count sparkline by agent.name,rule.description, audit.exe, audit.type, audit.euid | sort count DESC | rename agent.name as \"Agent name\", rule.description as Description, audit.exe as Command, audit.type as Type, audit.euid as \"Effective user id\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"audit\" | stats count sparkline by agent.name,rule.description, audit.exe, audit.type, audit.euid | sort count DESC | rename agent.name as \"Agent name\", rule.description as Description, audit.exe as Command, audit.type as Type, audit.euid as \"Effective user id\""
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_fim.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_fim.js
@@ -91,6 +91,10 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       // Create token namespaces
@@ -143,7 +147,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=\"syscheck\" |stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=\"syscheck\" |stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -159,7 +163,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\" | stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\" | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -175,7 +179,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"was deleted\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\" | stats count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"was deleted\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\" | stats count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -191,7 +195,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\"  \"rule.groups\"=\"syscheck\" | timechart span=12h count by rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\"  \"rule.groups\"=\"syscheck\" | timechart span=12h count by rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -207,7 +211,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" uname_after| top limit=20 \"syscheck.uname_after\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" uname_after| top limit=20 \"syscheck.uname_after\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -223,7 +227,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" uname_after syscheck.gname_after!=\"\"| top limit=20 \"syscheck.gname_after\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" uname_after syscheck.gname_after!=\"\"| top limit=20 \"syscheck.gname_after\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -239,7 +243,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" syscheck.event=\"added\" AND location=\"syscheck\" | top \"syscheck.path\"  by _time showcount=false showperc=false | tail 1 | fields - _time | rename syscheck.path as \">\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" syscheck.event=\"added\" AND location=\"syscheck\" | top \"syscheck.path\"  by _time showcount=false showperc=false | tail 1 | fields - _time | rename syscheck.path as \">\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -255,7 +259,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" syscheck.event=\"modified\" AND location=\"syscheck\" | top \"syscheck.path\"  by _time showcount=false showperc=false | tail 1 | fields - _time| rename syscheck.path as \">\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" syscheck.event=\"modified\" AND location=\"syscheck\" | top \"syscheck.path\"  by _time showcount=false showperc=false | tail 1 | fields - _time| rename syscheck.path as \">\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -271,7 +275,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" syscheck.event=\"deleted\" AND location=\"syscheck\" | top \"syscheck.path\"  by _time showcount=false showperc=false | tail 1 | fields - _time| rename syscheck.path as \">\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" syscheck.event=\"deleted\" AND location=\"syscheck\" | top \"syscheck.path\"  by _time showcount=false showperc=false | tail 1 | fields - _time| rename syscheck.path as \">\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -287,7 +291,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" syscheck.path=\"*\" | top syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" syscheck.path=\"*\" | top syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -303,7 +307,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" syscheck.path=\"*\" | search root | top limit=50 syscheck.path showperc=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" syscheck.path=\"*\" | search root | top limit=50 syscheck.path showperc=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -319,7 +323,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\"  syscheck.path=* syscheck.perm_after=* | regex syscheck.perm_after=\"[0-7]{5}([2367]).*\" | top  syscheck.path",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\"  syscheck.path=* syscheck.perm_after=* | regex syscheck.perm_after=\"[0-7]{5}([2367]).*\" | top  syscheck.path",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -335,7 +339,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"agent.name\"=\"*\" | top \"agent.name\" showcount=false showperc=false |head 1",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"agent.name\"=\"*\" | top \"agent.name\" showcount=false showperc=false |head 1",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -351,7 +355,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"rule.pci_dss{}\"=\"*\"| top \"rule.pci_dss{}\"",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"rule.pci_dss{}\"=\"*\"| top \"rule.pci_dss{}\"",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -367,7 +371,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.perm_after\"=* | top \"syscheck.perm_after\" showcount=false showperc=false | head 1",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.perm_after\"=* | top \"syscheck.perm_after\" showcount=false showperc=false | head 1",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -383,7 +387,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.path\"=* | top \"syscheck.path\" showcount=false showperc=false | head 1",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.path\"=* | top \"syscheck.path\" showcount=false showperc=false | head 1",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -399,7 +403,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description, count as Count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description, count as Count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -462,7 +466,7 @@ require([
       element1.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.groups\"=\"syscheck\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.groups\"=\"syscheck\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -493,7 +497,7 @@ require([
       element2.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"Integrity checksum changed\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -524,7 +528,7 @@ require([
       element3.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"was deleted\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\" "
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"was deleted\" location!=\"syscheck-registry\" \"rule.groups\"=\"syscheck\" "
           utils.redirect(url, false, "_blank")
         }
       })
@@ -769,7 +773,7 @@ require([
       element13.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"agent.name\"=\"*\" | top \"agent.name\" showcount=false showperc=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"agent.name\"=\"*\" | top \"agent.name\" showcount=false showperc=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -800,7 +804,7 @@ require([
       element14.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"rule.pci_dss{}\"=\"*\""
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"rule.pci_dss{}\"=\"*\""
           utils.redirect(url, false, "_blank")
         }
       })
@@ -831,7 +835,7 @@ require([
       element15.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.perm_after\"=* | top \"syscheck.perm_after\" showcount=false showperc=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.perm_after\"=* | top \"syscheck.perm_after\" showcount=false showperc=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -862,7 +866,7 @@ require([
       element16.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.path\"=* | top \"syscheck.path\" showcount=false showperc=false"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\" \"syscheck.path\"=* | top \"syscheck.path\" showcount=false showperc=false"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -882,7 +886,7 @@ require([
       element17.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" rule.groups=\"syscheck\"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.groups=\"syscheck\"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_gdpr.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_gdpr.js
@@ -89,6 +89,10 @@ require([
   ) {
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       let pageLoading = true
@@ -139,7 +143,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\"  | stats count by rule.gdpr{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\"  | stats count by rule.gdpr{}",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -155,7 +159,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count by rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count by rule.groups",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -171,7 +175,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count by agent.name",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -187,7 +191,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" agent.name=*| chart  count(rule.gdpr{}) by rule.gdpr{},agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" agent.name=*| chart  count(rule.gdpr{}) by rule.gdpr{},agent.name",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -203,7 +207,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count sparkline by agent.name, rule.gdpr{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.gdpr{} as Requirement, rule.description as \"Rule description\", count as Count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count sparkline by agent.name, rule.gdpr{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.gdpr{} as Requirement, rule.description as \"Rule description\", count as Count",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -235,7 +239,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": null,
         "latest_time": "now",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"*\"| stats count by \"rule.gdpr{}\" | sort \"rule.gdpr{}\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"*\"| stats count by \"rule.gdpr{}\" | sort \"rule.gdpr{}\" ASC | fields - count",
         "earliest_time": "-24h@h",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -424,7 +428,7 @@ require([
       element5.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = TokenUtils.replaceTokenNames("{{SPLUNKWEB_URL_PREFIX}}/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count sparkline by agent.name, rule.gdpr{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.gdpr{} as Requirement, rule.description as \"Rule description\", count as Count&earliest=$when.earliest$&latest=$when.latest$", _.extend(submittedTokenModel.toJSON(), e.data), TokenUtils.getEscaper('url'), TokenUtils.getFilters(mvc.Components))
+          const url = TokenUtils.replaceTokenNames("{{SPLUNKWEB_URL_PREFIX}}/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.gdpr{}=\"$gdpr$\" | stats count sparkline by agent.name, rule.gdpr{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.gdpr{} as Requirement, rule.description as \"Rule description\", count as Count&earliest=$when.earliest$&latest=$when.latest$", _.extend(submittedTokenModel.toJSON(), e.data), TokenUtils.getEscaper('url'), TokenUtils.getFilters(mvc.Components))
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_pci_dss.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_pci_dss.js
@@ -100,6 +100,11 @@ require([
       mvc.Components.registerInstance('url', urlTokenModel)
       const defaultTokenModel = mvc.Components.getInstance('default', { create: true })
       const submittedTokenModel = mvc.Components.getInstance('submitted', { create: true })
+      let nameFilter = ""
+
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      } 
 
       urlTokenModel.on('url:navigate', function () {
         defaultTokenModel.set(urlTokenModel.toJSON())
@@ -140,7 +145,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\"  | stats count by rule.pci_dss{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\"  | stats count by rule.pci_dss{}",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -156,7 +161,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count by rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count by rule.groups",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -172,7 +177,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count by agent.name",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -188,7 +193,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" agent.name=*| chart  count(rule.pci_dss{}) by rule.pci_dss{},agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" agent.name=*| chart  count(rule.pci_dss{}) by rule.pci_dss{},agent.name",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -204,7 +209,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": 1,
         "latest_time": "$when.latest$",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count sparkline by agent.name, rule.pci_dss{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.pci_dss{} as Requirement, rule.description as \"Rule description\", count as Count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count sparkline by agent.name, rule.pci_dss{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.pci_dss{} as Requirement, rule.description as \"Rule description\", count as Count",
         "earliest_time": "$when.earliest$",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -236,7 +241,7 @@ require([
         "status_buckets": 0,
         "sample_ratio": null,
         "latest_time": "now",
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"*\"| stats count by \"rule.pci_dss{}\" | sort \"rule.pci_dss{}\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"*\"| stats count by \"rule.pci_dss{}\" | sort \"rule.pci_dss{}\" ASC | fields - count",
         "earliest_time": "-24h@h",
         "cancelOnUnload": true,
         "app": utils.getCurrentApp(),
@@ -425,7 +430,7 @@ require([
       element5.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = TokenUtils.replaceTokenNames("{{SPLUNKWEB_URL_PREFIX}}/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count sparkline by agent.name, rule.pci_dss{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.pci_dss{} as Requirement, rule.description as \"Rule description\", count as Count&earliest=$when.earliest$&latest=$when.latest$", _.extend(submittedTokenModel.toJSON(), e.data), TokenUtils.getEscaper('url'), TokenUtils.getFilters(mvc.Components))
+          const url = TokenUtils.replaceTokenNames("{{SPLUNKWEB_URL_PREFIX}}/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=\"$pci$\" | stats count sparkline by agent.name, rule.pci_dss{}, rule.description | sort count DESC | rename agent.name as \"Agent Name\", rule.pci_dss{} as Requirement, rule.description as \"Rule description\", count as Count&earliest=$when.earliest$&latest=$when.latest$", _.extend(submittedTokenModel.toJSON(), e.data), TokenUtils.getEscaper('url'), TokenUtils.getFilters(mvc.Components))
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_policy_monitoring.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_policy_monitoring.js
@@ -91,6 +91,10 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       const urlTokenModel = new UrlTokenModel()
@@ -147,7 +151,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" rule.description=* | timechart span=1h count by rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" rule.description=* | timechart span=1h count by rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -163,7 +167,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" rule.cis{}=* | top  rule.cis{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" rule.cis{}=* | top  rule.cis{}",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -179,7 +183,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" rule.pci_dss{}=* | top  rule.pci_dss{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" rule.pci_dss{}=* | top  rule.pci_dss{}",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -195,7 +199,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" | timechart span=2h count by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" | timechart span=2h count by agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -211,7 +215,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" |stats count sparkline by agent.name, rule.description, title | sort count DESC | rename rule.description as \"Rule description\", agent.name as Agent, title as Control",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" |stats count sparkline by agent.name, rule.description, title | sort count DESC | rename rule.description as \"Rule description\", agent.name as Agent, title as Control",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -399,7 +403,7 @@ require([
       element5.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" |stats count sparkline by agent.name, rule.description, title | sort count DESC | rename rule.description as \"Rule description\", agent.name as Agent, title as Control"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.groups\"=\"rootcheck\" |stats count sparkline by agent.name, rule.description, title | sort count DESC | rename rule.description as \"Rule description\", agent.name as Agent, title as Control"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_scap.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/overview_scap.js
@@ -93,6 +93,10 @@ require([
 
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       const urlTokenModel = new UrlTokenModel()
@@ -148,7 +152,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+"  sourcetype=wazuh oscap.scan.score=* | stats latest(oscap.scan.score) as Latest",
+        "search": "index="+selectedIndex+" "+nameFilter+"  sourcetype=wazuh oscap.scan.score=* | stats latest(oscap.scan.score) as Latest",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -164,7 +168,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+"  sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(agent.name) as Latest",
+        "search": "index="+selectedIndex+" "+nameFilter+"  sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(agent.name) as Latest",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -180,7 +184,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=* | stats latest(oscap.scan.profile.title) as Latest",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=* | stats latest(oscap.scan.profile.title) as Latest",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -196,7 +200,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -212,7 +216,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top oscap.scan.profile.title",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top oscap.scan.profile.title",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -228,7 +232,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top oscap.scan.content",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top oscap.scan.content",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -244,7 +248,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top oscap.check.severity",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=\"$profile$\" | top oscap.check.severity",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -260,7 +264,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.groups=\"oscap\" oscap.scan.profile.title=\"$profile$\" oscap.check.severity=\"high\" | chart count by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.groups=\"oscap\" oscap.scan.profile.title=\"$profile$\" oscap.check.severity=\"high\" | chart count by agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -276,7 +280,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups=\"oscap-result\" oscap.scan.profile.title=\"$profile$\" | top oscap.check.title",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups=\"oscap-result\" oscap.scan.profile.title=\"$profile$\" | top oscap.check.title",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -292,7 +296,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups=\"oscap-result\"  oscap.check.severity=\"high\" oscap.scan.profile.title=\"$profile$\" | top oscap.check.title",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" rule.groups=\"oscap-result\"  oscap.check.severity=\"high\" oscap.scan.profile.title=\"$profile$\" | top oscap.check.title",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -308,7 +312,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.scan.score=* | stats max(oscap.scan.score)",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.scan.score=* | stats max(oscap.scan.score)",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -324,7 +328,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.scan.score=* | stats min(oscap.scan.score)",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.scan.score=* | stats min(oscap.scan.score)",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -340,7 +344,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(oscap.check.title)",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(oscap.check.title)",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -356,7 +360,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=\"$profile$\" | stats count by agent.name, oscap.check.title, oscap.scan.profile.title, oscap.scan.id, oscap.scan.content | sort count DESC | rename agent.name as \"Agent name\", oscap.check.title as Title, oscap.scan.profile.title as Profile, oscap.scan.id as \"Scan ID\", oscap.scan.content as Content",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=\"$profile$\" | stats count by agent.name, oscap.check.title, oscap.scan.profile.title, oscap.scan.id, oscap.scan.content | sort count DESC | rename agent.name as \"Agent name\", oscap.check.title as Title, oscap.scan.profile.title as Profile, oscap.scan.id as \"Scan ID\", oscap.scan.content as Content",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -372,7 +376,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=* | stats count by oscap.scan.profile.title | sort oscap.scan.profile.title ASC|fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  rule.groups=\"oscap\" rule.groups!=\"syslog\" oscap.scan.profile.title=* | stats count by oscap.scan.profile.title | sort oscap.scan.profile.title ASC|fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -435,7 +439,7 @@ require([
       element1.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+"  sourcetype=wazuh oscap.scan.score=* | stats latest(oscap.scan.score) as Latest"
+          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+"  sourcetype=wazuh oscap.scan.score=* | stats latest(oscap.scan.score) as Latest"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -466,7 +470,7 @@ require([
       element2.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+"  sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(agent.name) as Latest"
+          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+"  sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(agent.name) as Latest"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -497,7 +501,7 @@ require([
       element3.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=* | stats latest(oscap.scan.profile.title) as Latest"
+          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=* | stats latest(oscap.scan.profile.title) as Latest"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -788,7 +792,7 @@ require([
       element13.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(oscap.check.title)"
+          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" | stats latest(oscap.check.title)"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -808,7 +812,7 @@ require([
       element14.on("click", function (e) {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=\"$profile$\" | stats count by agent.name, oscap.check.title, oscap.scan.profile.title, oscap.scan.id, oscap.scan.content | sort count DESC | rename agent.name as \"Agent name\", oscap.check.title as Title, oscap.scan.profile.title as Profile, oscap.scan.id as \"Scan ID\", oscap.scan.content as Content"
+          const url = "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh oscap.check.result=\"fail\" rule.groups=\"oscap\" oscap.scan.profile.title=\"$profile$\" | stats count by agent.name, oscap.check.title, oscap.scan.profile.title, oscap.scan.id, oscap.scan.content | sort count DESC | rename agent.name as \"Agent name\", oscap.check.title as Title, oscap.scan.profile.title as Profile, oscap.scan.id as \"Scan ID\", oscap.scan.content as Content"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/pcidss.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/pcidss.js
@@ -91,6 +91,10 @@ require([
     let pageLoading = true
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading agent list', 1000, 250, 250)
@@ -140,7 +144,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by rule.pci_dss",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by rule.pci_dss",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -156,7 +160,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | top rule.pci_dss{} useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | top rule.pci_dss{} useother=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -172,7 +176,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=11.4 agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=11.4 agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -188,7 +192,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=10.2.2 agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=10.2.2 agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -204,7 +208,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=10.2.5 agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=10.2.5 agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -220,7 +224,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh rule.pci_dss{}=10.6.1 agent.name=\"$agent$\"| timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh rule.pci_dss{}=10.6.1 agent.name=\"$agent$\"| timechart count",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -236,7 +240,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\"| top rule.groups",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\"| top rule.groups",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -252,7 +256,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | stats count(rule.pci_dss{}) by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | stats count(rule.pci_dss{}) by agent.name",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -268,7 +272,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.pci_dss{}\">=10 agent.name=\"$agent$\" | timechart count(rule.level) by rule.pci_dss{} useother=f usenull=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.pci_dss{}\">=10 agent.name=\"$agent$\" | timechart count(rule.level) by rule.pci_dss{} useother=f usenull=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -284,7 +288,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh \"rule.pci_dss{}\">=* agent.name=\"$agent$\"| timechart count by rule.description useother=f usenull=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh \"rule.pci_dss{}\">=* agent.name=\"$agent$\"| timechart count by rule.description useother=f usenull=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -300,7 +304,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by syscheck.path useother=f usenull=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | timechart count by syscheck.path useother=f usenull=f",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -316,7 +320,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.pci_dss{}",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.pci_dss{}",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -332,7 +336,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh  agent.name=\"$agent$\"| table agent.name, rule.level, rule.pci_dss{}, rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  agent.name=\"$agent$\"| table agent.name, rule.level, rule.pci_dss{}, rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -348,7 +352,7 @@ require([
         "sample_ratio": 1,
         "earliest_time": "$when.earliest$",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"$agent$\" | stats count sparkline by agent.name, rule.pci_dss{}, rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"$agent$\" | stats count sparkline by agent.name, rule.pci_dss{}, rule.description",
         "latest_time": "$when.latest$",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -364,7 +368,7 @@ require([
         "sample_ratio": null,
         "earliest_time": "-24h@h",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "app": utils.getCurrentApp(),
         "auto_cancel": 90,
@@ -785,7 +789,7 @@ require([
       element13.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.pci_dss{}"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  | stats count by syscheck.path, syscheck.md5_before, syscheck.md5_after, rule.pci_dss{}"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -805,7 +809,7 @@ require([
       element14.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  | table agent.name, rule.level, rule.pci_dss{}, rule.description"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  | table agent.name, rule.level, rule.pci_dss{}, rule.description"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -825,7 +829,7 @@ require([
       element15.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=wazuh  | stats count sparkline by agent.name, rule.pci_dss{}, rule.description"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh  | stats count sparkline by agent.name, rule.pci_dss{}, rule.description"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/settings.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/settings.js
@@ -266,7 +266,7 @@ require([
           }
         } else {
           clearTable()
-          $('#apiList').html('<h4>Any API was inserted. You must have at least one API for using Splunk app for Wazuh.</h4>')
+          $('#apiList').html('<h4>No API entries detected. You must have at least one API for using Splunk app for Wazuh.</h4>')
         }
       } catch (err) {
         Promise.reject(err)

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/wazuh_alerts.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/wazuh_alerts.js
@@ -92,6 +92,10 @@ require([
 
 
     CredentialService.checkSelectedApiConnection().then(({api,selectedIndex}) => {
+      let nameFilter = ""
+      if ( api.filter[0] && typeof api.filter[0] === "string" && api.filter[1] && typeof api.filter[1] === "string") {
+        nameFilter = api.filter[0] + '=' + api.filter[1]
+      }
       SelectedCredentials.render($('#selectedCredentials'))
 
       const errorToast = new Toast('error', 'toast-bottom-right', 'Error at loading agent list', 1000, 250, 250)
@@ -138,7 +142,7 @@ require([
       const search2 = new SearchManager({
         "id": "search2",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count by rule.description usenull=f useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count by rule.description usenull=f useother=f",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -154,7 +158,7 @@ require([
       const search3 = new SearchManager({
         "id": "search3",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count by rule.level usenull=f useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count by rule.level usenull=f useother=f",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -170,7 +174,7 @@ require([
       const search4 = new SearchManager({
         "id": "search4",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count by rule.groups usenull=f useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count by rule.groups usenull=f useother=f",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -186,7 +190,7 @@ require([
       const search5 = new SearchManager({
         "id": "search5",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | timechart count",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -202,7 +206,7 @@ require([
       const search6 = new SearchManager({
         "id": "search6",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | iplocation srcip | geostats latfield=lat longfield=lon count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | iplocation srcip | geostats latfield=lat longfield=lon count",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -218,7 +222,7 @@ require([
       const search7 = new SearchManager({
         "id": "search7",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | stats count by agent.name",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | stats count by agent.name",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -234,7 +238,7 @@ require([
       const search8 = new SearchManager({
         "id": "search8",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" rule.description=* agent.name=\"$agent$\" | stats count by rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" rule.description=* agent.name=\"$agent$\" | stats count by rule.description",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -250,7 +254,7 @@ require([
       const search9 = new SearchManager({
         "id": "search9",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | iplocation srcip| top  Country useother=f",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | iplocation srcip| top  Country useother=f",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -266,7 +270,7 @@ require([
       const search10 = new SearchManager({
         "id": "search10",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | top rule.groups limit=5",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | top rule.groups limit=5",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -282,7 +286,7 @@ require([
       const search11 = new SearchManager({
         "id": "search11",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | chart sparkline count by rule.description | sort - count | head 5",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | chart sparkline count by rule.description | sort - count | head 5",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -298,7 +302,7 @@ require([
       const search12 = new SearchManager({
         "id": "search12",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.level\">=9 agent.name=\"$agent$\" | table agent.name, rule.level, rule.description",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.level\">=9 agent.name=\"$agent$\" | table agent.name, rule.level, rule.description",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -314,7 +318,7 @@ require([
       const search13 = new SearchManager({
         "id": "search13",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | table agent.name, agent.ip, rule.id, rule.level, rule.description, full_log | sort _time",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" agent.name=\"$agent$\" | table agent.name, agent.ip, rule.id, rule.level, rule.description, full_log | sort _time",
         "latest_time": "$when.latest$",
         "cancelOnUnload": true,
         "sample_ratio": 1,
@@ -330,7 +334,7 @@ require([
       const search14 = new SearchManager({
         "id": "search14",
         "status_buckets": 0,
-        "search": "index="+selectedIndex+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
+        "search": "index="+selectedIndex+" "+nameFilter+" sourcetype=wazuh agent.name=\"*\"| stats count by \"agent.name\" | sort \"agent.name\" ASC | fields - count",
         "latest_time": "now",
         "cancelOnUnload": true,
         "sample_ratio": null,
@@ -698,7 +702,7 @@ require([
       element11.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\"  | chart sparkline count by rule.description | sort - count | head 5"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\"  | chart sparkline count by rule.description | sort - count | head 5"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -718,7 +722,7 @@ require([
       element12.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" \"rule.level\">=9 | table agent.name, rule.level, rule.description"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" \"rule.level\">=9 | table agent.name, rule.level, rule.description"
           utils.redirect(url, false, "_blank")
         }
       })
@@ -738,7 +742,7 @@ require([
       element13.on("click", (e) => {
         if (e.field !== undefined) {
           e.preventDefault()
-          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" sourcetype=\"wazuh\" | table agent.name, agent.ip, rule.id, rule.level, rule.description, full_log | sort _time"
+          const url = baseUrl + "/app/SplunkAppForWazuh/search?q=index="+selectedIndex+" "+nameFilter+" sourcetype=\"wazuh\" | table agent.name, agent.ip, rule.id, rule.level, rule.description, full_log | sort _time"
           utils.redirect(url, false, "_blank")
         }
       })

--- a/SplunkAppForWazuh/default/web.conf
+++ b/SplunkAppForWazuh/default/web.conf
@@ -1,2 +1,8 @@
+# manager endpoints
 [endpoint:manager]
+
+# cluster endpoints
+[endpoint:cluster]
+
+# agents endpoints
 [endpoint:agents]


### PR DESCRIPTION
Hi, this PR add a manager.name or cluster.name filter to the app, who will filter the queries depending on the API that was selected before. If a certain API has an enabled cluster on it, the filter will be 'cluster.name', otherwise it will be 'manager.name'. It also opens /cluster endpoints up.