### PR TITLE
Release v3.4.0-7.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v3.4.0 - Splunk Enterprise v7.1.2 - Splunk app v3.4.0-rev-9
+There are no changes for Splunk app for Wazuh in this version.
+
 ## Wazuh v3.3.0/v3.3.1 - Splunk Enterprise v7.1.1 - Splunk app v3.3.0-rev-8
 ### Added
 - Support for Wazuh v3.3.1

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 |      7.1.1     |       3.2.4       | <https://packages.wazuh.com/3.x/splunkapp/v3.2.4_7.1.1.tar.gz> |
 |      7.1.1     |       3.3.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.3.0_7.1.1.tar.gz> |
 |      7.1.1     |       3.3.1       | <https://packages.wazuh.com/3.x/splunkapp/v3.3.1_7.1.1.tar.gz> |
+|      7.1.2     |       3.4.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.4.0_7.1.2.tar.gz> |
 
 ## Upgrade
 

--- a/SplunkAppForWazuh/default/app.conf
+++ b/SplunkAppForWazuh/default/app.conf
@@ -3,7 +3,7 @@ is_visible = 1
 label = Wazuh
 
 [launcher]
-version = 3.3.1
+version = 3.4.0
 author = info@wazuh.com
 description = Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level.
 

--- a/SplunkAppForWazuh/default/data/ui/html/ab_general.html
+++ b/SplunkAppForWazuh/default/data/ui/html/ab_general.html
@@ -27,7 +27,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div class="dashboard-header clearfix">

--- a/SplunkAppForWazuh/default/data/ui/html/agents_configuration.html
+++ b/SplunkAppForWazuh/default/data/ui/html/agents_configuration.html
@@ -27,7 +27,7 @@
     crossorigin="anonymous"></script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body">
 

--- a/SplunkAppForWazuh/default/data/ui/html/agents_summary.html
+++ b/SplunkAppForWazuh/default/data/ui/html/agents_summary.html
@@ -27,7 +27,7 @@
   </script>
 </head>
 
-<body class='simplexml preload locale-en' data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class='simplexml preload locale-en' data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body" data-role="main">
 

--- a/SplunkAppForWazuh/default/data/ui/html/audit.html
+++ b/SplunkAppForWazuh/default/data/ui/html/audit.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/cis.html
+++ b/SplunkAppForWazuh/default/data/ui/html/cis.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/configuration.html
+++ b/SplunkAppForWazuh/default/data/ui/html/configuration.html
@@ -27,7 +27,7 @@
     crossorigin="anonymous"></script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body">
 

--- a/SplunkAppForWazuh/default/data/ui/html/fim.html
+++ b/SplunkAppForWazuh/default/data/ui/html/fim.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/gdpr.html
+++ b/SplunkAppForWazuh/default/data/ui/html/gdpr.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/groups.html
+++ b/SplunkAppForWazuh/default/data/ui/html/groups.html
@@ -25,7 +25,7 @@
   </script>
 </head>
 
-<body class='simplexml preload locale-en' data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class='simplexml preload locale-en' data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/logs.html
+++ b/SplunkAppForWazuh/default/data/ui/html/logs.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>
       <h2 class="wz-display-inline-block">Logs</h2>

--- a/SplunkAppForWazuh/default/data/ui/html/manager_decoders.html
+++ b/SplunkAppForWazuh/default/data/ui/html/manager_decoders.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">

--- a/SplunkAppForWazuh/default/data/ui/html/manager_ruleset.html
+++ b/SplunkAppForWazuh/default/data/ui/html/manager_ruleset.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/manager_status.html
+++ b/SplunkAppForWazuh/default/data/ui/html/manager_status.html
@@ -25,7 +25,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div class="dashboard-header clearfix">

--- a/SplunkAppForWazuh/default/data/ui/html/openscap.html
+++ b/SplunkAppForWazuh/default/data/ui/html/openscap.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/overview_audit.html
+++ b/SplunkAppForWazuh/default/data/ui/html/overview_audit.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/overview_fim.html
+++ b/SplunkAppForWazuh/default/data/ui/html/overview_fim.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/overview_gdpr.html
+++ b/SplunkAppForWazuh/default/data/ui/html/overview_gdpr.html
@@ -26,7 +26,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/overview_pci_dss.html
+++ b/SplunkAppForWazuh/default/data/ui/html/overview_pci_dss.html
@@ -28,7 +28,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/overview_policy_monitoring.html
+++ b/SplunkAppForWazuh/default/data/ui/html/overview_policy_monitoring.html
@@ -27,7 +27,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/overview_scap.html
+++ b/SplunkAppForWazuh/default/data/ui/html/overview_scap.html
@@ -27,7 +27,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/pcidss.html
+++ b/SplunkAppForWazuh/default/data/ui/html/pcidss.html
@@ -27,7 +27,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/data/ui/html/settings.html
+++ b/SplunkAppForWazuh/default/data/ui/html/settings.html
@@ -27,7 +27,7 @@
 
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
   <div class="dashboard-body wz-no-padding" id='dashboardBody'>
     <div id='mainFrame' class='dashboardBody'>
       <div>

--- a/SplunkAppForWazuh/default/data/ui/html/wazuh_alerts.html
+++ b/SplunkAppForWazuh/default/data/ui/html/wazuh_alerts.html
@@ -27,7 +27,7 @@
   </script>
 </head>
 
-<body class="simplexml preload locale-en" data-splunk-version="7.1.1" data-splunk-product="enterprise">
+<body class="simplexml preload locale-en" data-splunk-version="7.1.2" data-splunk-product="enterprise">
 
   <div class="dashboard-body container-fluid main-section-body" data-role="main">
     <div>

--- a/SplunkAppForWazuh/default/package.conf
+++ b/SplunkAppForWazuh/default/package.conf
@@ -1,9 +1,9 @@
 [app]
-version = 3.3.1
-revision = 8
+version = 3.4.0
+revision = 9
 
 [wazuh]
-version = 3.3.1
+version = 3.4.0
 
 [splunk]
-version = 7.1.1
+version = 7.1.2


### PR DESCRIPTION
Hi team, this PR releases the new Splunk app for Wazuh v3.4.0-7.1.2. 
This version supports Wazuh v3.4.0 and Splunk v7.1.2.