### PR TITLE
Adapting app to new API changes

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -217,9 +217,9 @@ class manager(controllers.BaseController):
           sort_chain = '-name'
       elif sorting_column == "1":
         if direction == 'asc':
-          sort_chain = '+merged_sum'
+          sort_chain = '+mergedSum'
         if direction == 'desc':
-          sort_chain = '-merged_sum'
+          sort_chain = '-mergedSum'
       
       request = requests.get(url + '/agents/groups' + '?limit=' + limit + '&offset='+offset + '&search='+search_value+'&sort='+sort_chain, auth=auth, verify=verify).json()
       result = json.dumps(request)

--- a/SplunkAppForWazuh/appserver/static/js/viewControllers/groups.js
+++ b/SplunkAppForWazuh/appserver/static/js/viewControllers/groups.js
@@ -94,11 +94,11 @@ require([
                       <hr style='margin-top:-5px'>
                       <div class="wz-flex-container wz-flex-row">
                         <p class='wz-flex-item-50' >Configuration sum</p>
-                        <p id='confSum'>${data.conf_sum}</p>
+                        <p id='confSum'>${data.configSum}</p>
                       </div>
                       <div class="wz-flex-container wz-flex-row">
                         <p class='wz-flex-item-50'>Merged sum</p>
-                        <p id='mergedSum'>${data.merged_sum}</p>
+                        <p id='mergedSum'>${data.mergedSum}</p>
                       </div>
                     </div>
                   </div>
@@ -209,7 +209,7 @@ require([
             filterVisible: false,
             columns: [
               { "data": "name", 'orderable': true, defaultContent: "-" },
-              { "data": "merged_sum", 'orderable': true, defaultContent: "-" }
+              { "data": "mergedSum", 'orderable': true, defaultContent: "-" }
             ]
           }
 

--- a/SplunkAppForWazuh/default/data/ui/html/groups.html
+++ b/SplunkAppForWazuh/default/data/ui/html/groups.html
@@ -41,7 +41,7 @@
         <thead>
           <tr>
             <th>name</th>
-            <th>merged_sum</th>
+            <th>mergedSum</th>
           </tr>
         </thead>
       </table>


### PR DESCRIPTION
Hi splunkers, this PR adapts the Splunk app for Wazuh to use new API notations in /groups endpoint.

*Before*:

- { merged_sum }

*Now*:

- { mergedSum }

Regards