### PR TITLE
3.7 New feature: admin mode

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -102,6 +102,15 @@ class api(controllers.BaseController):
         try:
             if 'id' not in kwargs or 'endpoint' not in kwargs:
                 return json.dumps({'error': 'Missing ID or endpoint.'})
+            if 'method' not in kwargs:
+                method = 'GET'
+            elif kwargs['method'] == 'GET':
+                del kwargs['method']
+                method = 'GET'
+            else:
+                method = kwargs['method']
+                del kwargs['method']
+
             the_id = kwargs['id']
             api = self.db.get(the_id)
             opt_username = api[0]["userapi"]
@@ -114,8 +123,14 @@ class api(controllers.BaseController):
             url = opt_base_url + ":" + opt_base_port
             auth = requests.auth.HTTPBasicAuth(opt_username, opt_password)
             verify = False
-            request = self.session.get(
-                url + opt_endpoint, params=kwargs, auth=auth, verify=verify).json()
+            if method == 'GET':
+                request = self.session.get(url + opt_endpoint, params=kwargs, auth=auth, verify=verify).json()
+            if method == 'POST':
+                request = self.session.post(url + opt_endpoint, data=kwargs, auth=auth, verify=verify).json()
+            if method == 'PUT':
+                request = self.session.put(url + opt_endpoint, data=kwargs, auth=auth, verify=verify).json()
+            if method == 'DELETE':
+                request = self.session.delete(url + opt_endpoint, params=kwargs, auth=auth, verify=verify).json()
             result = json.dumps(request)
             #result = self.clean_keys(request)
         except Exception as e:

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/settings-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/settings-states.js
@@ -128,7 +128,27 @@ define(['../module'], function(module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('dev-tools');
           },
-          controller: 'devToolsCtrl'
+          controller: 'devToolsCtrl',
+          resolve: {
+            extensions: [
+              '$requestService',
+              '$currentDataService',
+              async ($requestService, $currentDataService) => {
+                try {
+                  const id = $currentDataService.getApi().id;
+                  const currentExtensions = $currentDataService.getExtensions(
+                    id
+                  );
+                  const result = currentExtensions
+                    ? currentExtensions
+                    : $requestService.httpReq(`GET`, `/manager/extensions`);
+                  return await result;
+                } catch (err) {
+                  console.error('Error route: ', err);
+                }
+              }
+            ]
+          }
         })
         .state('discover', {
           templateUrl:

--- a/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
@@ -632,7 +632,7 @@ define([
           const path = req.includes('?') ? req.split('?')[0] : req;
 
           // if (typeof JSONraw === 'object') JSONraw.devTools = true
-          const output = await this.request.apiReq(path, JSONraw);
+          const output = await this.request.apiReq(path, JSONraw, method);
           const result =
             output.data && output.data.data && !output.data.error
               ? JSON.stringify(output.data.data, null, 2)

--- a/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
@@ -41,7 +41,8 @@ define([
       $document,
       $navigationService,
       $notificationService,
-      $requestService
+      $requestService,
+      extensions
     ) {
       this.$scope = $scope;
       this.request = $requestService;
@@ -52,6 +53,7 @@ define([
       this.groups = [];
       this.linesWithClass = [];
       this.widgets = [];
+      this.admin = ( extensions.data['admin'] === 'true') ? true : false;
     }
 
     unescapeBuffer(s, decodeSpaces) {
@@ -590,7 +592,9 @@ define([
             return;
           }
 
-          const method = desiredGroup.requestText.startsWith('GET')
+          let method = ''
+          if (this.admin) {
+          method = desiredGroup.requestText.startsWith('GET')
             ? 'GET'
             : desiredGroup.requestText.startsWith('POST')
               ? 'POST'
@@ -599,7 +603,9 @@ define([
                 : desiredGroup.requestText.startsWith('DELETE')
                   ? 'DELETE'
                   : 'GET';
-
+          } else {
+            method = 'GET'
+          }
           const requestCopy = desiredGroup.requestText.includes(method)
             ? desiredGroup.requestText.split(method)[1].trim()
             : desiredGroup.requestText;

--- a/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
@@ -73,14 +73,17 @@ define(['../module'], function(module) {
      * @param {String} endpoint
      * @param {Object} opts
      */
-    const apiReq = async (endpoint, opts, method='GET') => {
+    const apiReq = async (endpoint, opts=null, method='GET') => {
       try {
+        $http.defaults.headers.post['Content-Type'] =
+        'application/x-www-form-urlencoded';
         const currentApi = $apiIndexStorageService.getApi();
         const id = currentApi && currentApi.id ? currentApi.id : opts.id;
-        const payload = { id, endpoint };
+        const payload = { id, endpoint, method };
         if (opts && typeof opts === `object`) {
           Object.assign(payload, opts);
         }
+        console.log('performing request with this verb ', method)
         const result = await httpReq(`GET`, `/api/request`, payload);
         return result;
       } catch (err) {

--- a/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
@@ -73,7 +73,7 @@ define(['../module'], function(module) {
      * @param {String} endpoint
      * @param {Object} opts
      */
-    const apiReq = async (endpoint, opts) => {
+    const apiReq = async (endpoint, opts, method='GET') => {
       try {
         const currentApi = $apiIndexStorageService.getApi();
         const id = currentApi && currentApi.id ? currentApi.id : opts.id;


### PR DESCRIPTION
Hi team,

This PR implements a new feature for the Splunk app for Wazuh. This is about enabling an `admin mode` for performing  `POST`,`PUT` and `DELETE` requests to Wazuh API from the Dev-Tools section.
Just editing the `config.conf` file and then setting the `admin` field to `true` will enable this super user mode.

Related issue: #347 

Regards