### PR TITLE
3.7 issue 350(Agents status monitoring doesn't draw timeline properly)

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -177,12 +177,13 @@ define([
           } index=wazuh-monitoring-3x`
         }
 
+        this.spanTime = '1h'
         this.vizz.push(
           new LinearChart(
             `agentStatusHistory`,
             `${
               this.agentsStatusFilter
-            } status=* | timechart span=1h count by status usenull=f`,
+            } status=* | timechart span=${this.spanTime} count by status usenull=f | eval now = relative_time(now(),"-${this.spanTime}") | where _time < now  | fields - now`,
             `agentStatus`
           )
         )

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -183,7 +183,7 @@ define([
             `agentStatusHistory`,
             `${
               this.agentsStatusFilter
-            } status=* | timechart span=${this.spanTime} count by status usenull=f`,
+            } status=* | timechart span=${this.spanTime} cont=FALSE count by status usenull=f`,
             `agentStatus`
           )
         )

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -183,7 +183,7 @@ define([
             `agentStatusHistory`,
             `${
               this.agentsStatusFilter
-            } status=* | timechart span=${this.spanTime} count by status usenull=f | eval now = relative_time(now(),"-${this.spanTime}") | where _time < now  | fields - now`,
+            } status=* | timechart span=${this.spanTime} count by status usenull=f`,
             `agentStatus`
           )
         )

--- a/SplunkAppForWazuh/default/inputs.conf
+++ b/SplunkAppForWazuh/default/inputs.conf
@@ -4,5 +4,5 @@ connection_host = ip
 [script:///opt/splunk/etc/apps/SplunkAppForWazuh/bin/get_agents_status.py]
 disabled = false
 index = wazuh-monitoring-3x
-interval = 3600
+interval = 0 * * * *
 sourcetype = _json


### PR DESCRIPTION
Hi team, 

This PR fixes the visualization of the agents status cleaning blank results.

Solved => https://github.com/wazuh/wazuh-splunk/issues/350

Regards,