### PR TITLE
Bump Splunk version (v7.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
-## Wazuh v3.7.0 - Splunk Enterprise v7.2.0 - Splunk app v3.7.0-rev-17
+## Wazuh v3.7.0 - Splunk Enterprise v7.2.0 / Splunk Enterprise v7.2.1 - Splunk app v3.7.0-rev-17
 ### Added
 - Osquery integration ([#252](https://github.com/wazuh/wazuh-splunk/pull/252)).
 - Cluster monitoring ([#246](https://github.com/wazuh/wazuh-splunk/pull/246)).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 |      7.1.2     |       3.6.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.6.0_7.1.2.tar.gz> |
 |      7.1.3     |       3.6.1       | <https://packages.wazuh.com/3.x/splunkapp/v3.6.1_7.1.3.tar.gz> |
 |      7.2.0     |       3.7.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.7.0_7.2.0.tar.gz> |
+|      7.2.1     |       3.7.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.7.0_7.2.1.tar.gz> |
 
 ## Upgrade
 

--- a/SplunkAppForWazuh/default/app.conf
+++ b/SplunkAppForWazuh/default/app.conf
@@ -3,7 +3,7 @@ is_visible = 1
 label = Wazuh
 
 [launcher]
-version = 3.6.1
+version = 3.7.0
 author = info@wazuh.com
 description = Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level.
 

--- a/SplunkAppForWazuh/default/package.conf
+++ b/SplunkAppForWazuh/default/package.conf
@@ -6,4 +6,4 @@ revision = 17
 version = 3.7.0
 
 [splunk]
-version = 7.2.0
+version = 7.2.1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wazuh-splunk",
   "version": "3.7.0",
   "revision": "17",
-  "code": "17-3",
+  "code": "17-4",
   "description": "Splunk app for Wazuh",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This PR releases the v3.7.0-7.2.1 version of Splunk app.