### PR TITLE
Fix 'and' operator in API requests

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -97,7 +97,7 @@ class api(controllers.BaseController):
     # /custom/SplunkAppForWazuh/api/node
     # This will perform an HTTP request to Wazuh API
     # It will return the full API response with including its error codes
-    @expose_page(must_login=False, methods=['GET'])
+    @expose_page(must_login=False, methods=['POST'])
     def request(self, **kwargs):
         try:
             if 'id' not in kwargs or 'endpoint' not in kwargs:

--- a/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
@@ -83,7 +83,7 @@ define(['../module'], function(module) {
         if (opts && typeof opts === `object`) {
           Object.assign(payload, opts)
         }
-        const result = await httpReq(`GET`, `/api/request`, payload)
+        const result = await httpReq(`POST`, `/api/request`, payload)
         return result
       } catch (err) {
         return Promise.reject(err)


### PR DESCRIPTION
Hi team, this PR enables the ability to send 'and' statement in `q` parameters in the Splunk app backend.
Related issue: #405 
Regards