### PR TITLE
Blue loading ring is not used anymore. Cursor changes state instead

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/main/mainCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/main/mainCtrl.js
@@ -38,8 +38,8 @@ define([
      */
     $onInit() {
       this.scope.$on('loading', (event, data) => {
-        if (data.status) this.scope.loading = true
-        else this.scope.loading = false
+        if (data.status) $(document.body).css({'cursor' : 'wait'})
+        else $(document.body).css({'cursor' : 'default'})
         if (!this.scope.$$phase) this.scope.$digest()
       })
 


### PR DESCRIPTION
Hi, this PR avoids the use of the blue loading ring, it implements a change in the cursor instead.

Related issue: #417 

Regards