### PR TITLE
3.8 Fixed unhandled error with trim() method

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-tag-filter/wz-tag-filter.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-tag-filter/wz-tag-filter.js
@@ -42,7 +42,7 @@ define(['../module'], function(app) {
             )
             input.blur()
             const term = $scope.newTag.split(':')
-            const obj = { name: term[0].trim(), value: term[1].trim() }
+            const obj = { name: term[0].trim(), value: term[1] ? term[1].trim() : '' }
             const isFilter = obj.value
             if (
               (isFilter &&


### PR DESCRIPTION
Hi team,

This PR fix a typo in the new tags bar filter when the key typed doesn't exist.

Regards!