### PR TITLE
Fix polling agents state

### DIFF
--- a/SplunkAppForWazuh/bin/db.py
+++ b/SplunkAppForWazuh/bin/db.py
@@ -99,10 +99,11 @@ class database():
             self.logger.error("Error removing an API in DB module: %s" % (e))
             raise e
 
-    def all(self):
+    def all(self, session_key=False):
         try:
             kvstoreUri = self.kvstoreUri+'?output_mode=json'
-            result = self.session.get(kvstoreUri, headers={"Authorization": "Splunk %s" % splunk.getSessionKey(), "Content-Type": "application/json"}, verify=False).json()
+            auth_key = session_key if session_key else splunk.getSessionKey()
+            result = self.session.get(kvstoreUri, headers={"Authorization": "Splunk %s" % auth_key, "Content-Type": "application/json"}, verify=False).json()
             return jsonbak.dumps(result)
         except Exception as e:
             self.logger.error('Error returning all API rows in DB module: %s ' % (e))

--- a/SplunkAppForWazuh/bin/get_agents_status.py
+++ b/SplunkAppForWazuh/bin/get_agents_status.py
@@ -20,6 +20,7 @@ import requestsbak
 import datetime
 from db import database
 from log import log
+import sys
 
 db = database()
 logger = log()
@@ -28,7 +29,8 @@ logger = log()
 def get_apis():
     """Obtain the list of APIs."""
     try:
-        data_temp = db.all()
+        session_key = getSplunkSessionKey()
+        data_temp = db.all(session_key)
     except Exception as e:
         return jsonbak.dumps({'error': str(e)})
     return data_temp
@@ -38,6 +40,7 @@ def check_status():
     """Check status of agents."""
     try:
         apis = get_apis()
+        apis = jsonbak.loads(apis) #get_apis() returns a JSON string, it needs to be converted as a dictionary
         date = str(datetime.datetime.utcnow())[:-7]
         # obtains
         for api in apis:
@@ -99,5 +102,10 @@ def check_status():
         logger.error("Error requesting agents status: %s" % str(e))
         pass
 
+
+def getSplunkSessionKey():
+    """Get the session key, it needs to configure in the inputs.conf that executes this script the following parameter: passAuth = splunk-system-user"""
+    session_key = sys.stdin.readline().strip()
+    return session_key
 
 check_status()


### PR DESCRIPTION
Hi team,

This PR solves when the `get_agent_status.py` script trying to fetch the Wazuh APIs saved in the KVstore of the Wazuh App for Splunk. The problem was that this script couldn't authenticate against the REST API of Splunk because it needs a session key. Now it receives the session key from the `inputs.conf` file that executes it. It necessary to add a new parameter to this file: **passAuth = splunk-system-user.**

```
[splunktcp://9997]
connection_host = ip

[script:///opt/splunk/etc/apps/SplunkAppForWazuh/bin/get_agents_status.py]
disabled = false
index = wazuh-monitoring-3x
interval = 0 * * * *
sourcetype = _json
passAuth = splunk-system-user
```

Regards,