### PR TITLE
Permit special charsets in API credentials

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -50,7 +50,7 @@ class api(controllers.BaseController):
                 opt_password = api['data']["passapi"]
                 opt_base_url = api['data']["url"]
                 opt_base_port = api['data']["portapi"]
-                url = opt_base_url + ":" + opt_base_port
+                url = str(opt_base_url) + ":" + str(opt_base_port)
                 auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)
                 verify = False
                 return url, auth, verify

--- a/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
@@ -216,9 +216,10 @@ define(['../module'], function (module) {
           api.userapi &&
           api.passapi
         ) {
-          const checkConnectionEndpoint = `/manager/check_connection?ip=${
-            api.url
-            }&port=${api.portapi}&user=${api.userapi}&pass=${api.passapi}`
+          // Encode user and password, this prevent fails with special charsets
+          const user = encodeURIComponent(api.userapi)
+          const pass = encodeURIComponent(api.passapi)
+          const checkConnectionEndpoint = `/manager/check_connection?ip=${api.url}&port=${api.portapi}&user=${user}&pass=${pass}`
           const result = await $requestService.httpReq(
             'GET',
             checkConnectionEndpoint

--- a/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
@@ -285,6 +285,7 @@ define(['../module'], function (module) {
     const checkApiConnection = async id => {
       try {
         const api = await select(id)//Before update cluster or not cluster
+        const connect = await checkRawConnection(api)
         const apiSaved = { ...api }
         const updatedApi = await updateApiFilter(api)
         let equal = true


### PR DESCRIPTION
Hi team,

This PR implements the capability to using special charsets like `";,/?:@&=+$#"` in the API credentials on the APP, also prevent select an API with check connection refused.

Solves this issue: https://github.com/wazuh/wazuh-splunk/issues/577

Regards,