### PR TITLE
Reporting as extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 |      7.2.3     |       3.8.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.0_7.2.3.tar.gz> |
 |      7.2.3     |       3.8.1       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.1_7.2.3.tar.gz> |
 |      7.2.3     |       3.8.2       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.2_7.2.3.tar.gz> |
+|      7.2.4     |       3.8.2       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.2_7.2.4.tar.gz> |
+|      7.2.4     |       3.9.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.9.0_7.2.4.tar.gz> |
 
 ## Upgrade
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@
 |      7.2.3     |       3.8.1       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.1_7.2.3.tar.gz> |
 |      7.2.3     |       3.8.2       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.2_7.2.3.tar.gz> |
 |      7.2.4     |       3.8.2       | <https://packages.wazuh.com/3.x/splunkapp/v3.8.2_7.2.4.tar.gz> |
-|      7.2.4     |       3.9.0       | <https://packages.wazuh.com/3.x/splunkapp/v3.9.0_7.2.4.tar.gz> |
 
 ## Upgrade
 

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
@@ -191,16 +191,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -266,16 +257,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -322,16 +304,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -372,16 +345,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -422,16 +386,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -472,16 +427,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -522,16 +468,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -597,16 +534,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -664,16 +592,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -714,16 +633,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -787,16 +697,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -854,16 +755,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -904,16 +796,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -954,16 +837,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
@@ -188,6 +188,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -250,6 +263,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -293,6 +319,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -328,6 +367,19 @@ define(['../module'], function (module) {
                   return result
                 } catch (err) {
                   $state.go('agents')
+                }
+              }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
                 }
               }
             ]
@@ -367,6 +419,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -404,6 +469,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -439,6 +517,19 @@ define(['../module'], function (module) {
                   return result
                 } catch (err) {
                   $state.go('agents')
+                }
+              }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
                 }
               }
             ]
@@ -503,6 +594,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -557,6 +661,19 @@ define(['../module'], function (module) {
                   $state.go('settings.api')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -595,6 +712,19 @@ define(['../module'], function (module) {
                 }
               }
             ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
           }
         })
 
@@ -654,6 +784,19 @@ define(['../module'], function (module) {
                   $state.go('agents')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -708,8 +851,20 @@ define(['../module'], function (module) {
                   $state.go('settings.api')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
-
           }
         })
 
@@ -744,6 +899,19 @@ define(['../module'], function (module) {
                   return result
                 } catch (err) {
                   $state.go('settings.api')
+                }
+              }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
                 }
               }
             ]
@@ -781,6 +949,19 @@ define(['../module'], function (module) {
                   return result
                 } catch (err) {
                   $state.go('agents')
+                }
+              }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
                 }
               }
             ]

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -1,4 +1,4 @@
-define(['../module'], function(module) {
+define(['../module'], function (module) {
   'use strict'
   module.paths = {
     root: `${window.location.href.split(/\/[a-z][a-z]-[A-Z][A-Z]\//)[0]}/`
@@ -10,7 +10,7 @@ define(['../module'], function(module) {
     '$stateProvider',
     '$mdThemingProvider',
     'BASE_URL',
-    function(
+    function (
       $mdIconProvider,
       $locationProvider,
       $stateProvider,
@@ -82,6 +82,19 @@ define(['../module'], function(module) {
                   return result
                 } catch (err) {
                   $state.go('settings.api')
+                }
+              }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
                 }
               }
             ]
@@ -169,7 +182,7 @@ define(['../module'], function(module) {
               async ($requestService, $state) => {
                 try {
                   const pciTabs = []
-                  const data = await $requestService.httpReq('GET','/api/pci?requirement=all')
+                  const data = await $requestService.httpReq('GET', '/api/pci?requirement=all')
                   if (!data) return []
                   for (const key in data.data) {
                     pciTabs.push({ title: key, content: data.data[key] })
@@ -198,7 +211,7 @@ define(['../module'], function(module) {
               async ($requestService, $state) => {
                 try {
                   const gdprTabs = []
-                  const data = await $requestService.httpReq('GET','/api/gdpr?requirement=all')
+                  const data = await $requestService.httpReq('GET', '/api/gdpr?requirement=all')
                   if (!data) return []
                   for (const key in data.data) {
                     gdprTabs.push({ title: key, content: data.data[key] })

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -84,6 +84,19 @@ define(['../module'], function (module) {
                   $state.go('settings.api')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -95,7 +108,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-pm')
           },
-          controller: 'overviewPolicyMonitoringCtrl'
+          controller: 'overviewPolicyMonitoringCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
         // Overview - FIM
         .state('ow-fim', {
@@ -105,9 +133,24 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-fim')
           },
-          controller: 'overviewFimCtrl'
+          controller: 'overviewFimCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
-        // Overview - OSQUERy
+        // Overview - Osquery
         .state('ow-osquery', {
           templateUrl:
             BASE_URL +
@@ -130,6 +173,19 @@ define(['../module'], function (module) {
                   $state.go('settings.api')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -141,7 +197,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-audit')
           },
-          controller: 'overviewAuditCtrl'
+          controller: 'overviewAuditCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
         // Overview - OpenSCAP
         .state('ow-os', {
@@ -151,7 +222,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-os')
           },
-          controller: 'overviewOpenScapCtrl'
+          controller: 'overviewOpenScapCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
         // Overview - PCI-DSS
         .state('ow-pci', {
@@ -177,6 +263,19 @@ define(['../module'], function (module) {
                   return pciTabs
                 } catch (err) {
                   $state.go('settings.api')
+                }
+              }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
                 }
               }
             ]
@@ -208,6 +307,19 @@ define(['../module'], function (module) {
                   $state.go('settings.api')
                 }
               }
+            ],
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
             ]
           }
         })
@@ -220,7 +332,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-vul')
           },
-          controller: 'overviewVulnerabilitiesCtrl'
+          controller: 'overviewVulnerabilitiesCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
         // Overview - CIS-CAT
         .state('ow-ciscat', {
@@ -230,7 +357,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-ciscat')
           },
-          controller: 'ciscatCtrl'
+          controller: 'ciscatCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
         // Overview - VirusTotal
         .state('ow-virustotal', {
@@ -240,7 +382,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-virustotal')
           },
-          controller: 'overviewVirusTotal'
+          controller: 'overviewVirusTotal',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
         // =========== AWS =========== //
         .state('ow-aws', {
@@ -250,7 +407,22 @@ define(['../module'], function (module) {
           onEnter: $navigationService => {
             $navigationService.storeRoute('ow-aws')
           },
-          controller: 'awsCtrl'
+          controller: 'awsCtrl',
+          resolve: {
+            reportingEnabled: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  const id = $currentDataService.getApi()['_key']
+                  const result = await $currentDataService.getExtensionsById(id)
+                  const status = result.reporting === 'true' ? true : false
+                  return status
+                } catch (err) {
+                  return true
+                }
+              }
+            ]
+          }
         })
     }
   ])

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -87,16 +87,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -112,16 +103,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -137,16 +119,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -176,16 +149,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -201,16 +165,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -226,16 +181,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -268,16 +214,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -310,16 +247,7 @@ define(['../module'], function (module) {
             ],
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -336,16 +264,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -361,16 +280,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -386,16 +296,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })
@@ -411,16 +312,7 @@ define(['../module'], function (module) {
           resolve: {
             reportingEnabled: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
+              async $currentDataService => { return await $currentDataService.getReportingStatus() }
             ]
           }
         })

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -84,19 +84,6 @@ define(['../module'], function (module) {
                   $state.go('settings.api')
                 }
               }
-            ],
-            reportingEnabled: [
-              '$currentDataService',
-              async $currentDataService => {
-                try {
-                  const id = $currentDataService.getApi()['_key']
-                  const result = await $currentDataService.getExtensionsById(id)
-                  const status = result.reporting === 'true' ? true : false
-                  return status
-                } catch (err) {
-                  return true
-                }
-              }
             ]
           }
         })

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
@@ -31,7 +31,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
@@ -16,7 +16,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
@@ -16,16 +16,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'Audit', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agentsAuditCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agentsAuditCtrl.js
@@ -50,11 +50,13 @@ define([
       $currentDataService,
       $state,
       agent,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.state = $state
       this.currentDataService = $currentDataService
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.reportingService = $reportingService
       this.tableResults = {}
       this.urlTokenModel = $urlTokenModel

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
@@ -15,16 +15,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'CIS-CAT', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
@@ -30,7 +30,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
@@ -15,7 +15,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agentsCiscatCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agentsCiscatCtrl.js
@@ -33,7 +33,8 @@ define([
       $state,
       $currentDataService,
       agent,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.state = $state
       this.currentDataService = $currentDataService
@@ -46,6 +47,7 @@ define([
         this.state.go('overview')
       }
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.urlTokenModel = $urlTokenModel
       this.timePicker = new TimePicker(
         '#timePicker',

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agents-ca.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agents-ca.html
@@ -32,8 +32,7 @@
   </div>
 
   <!-- Loading report-->
-  <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner"
-      aria-hidden="true"></i></div>
+  <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agents-ca.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agents-ca.html
@@ -17,17 +17,15 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
-        aria-label="Generate report button">
-        <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
-          Generate report
-        </md-tooltip>
-      </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-          class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-      <wz-discover breadcrumbs="{section: 'Agents', subSection: 'Configuration assessment', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
-    </div>
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+          aria-label="Generate report button">
+          <i class="fa fa-fw fa-print" aria-hidden="true"></i>
+          <md-tooltip md-direction="left" class="wz-tooltip">
+            Generate report
+          </md-tooltip>
+        </md-button>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
+      </div>
     <div style="margin-right:7px;" id='timePicker'></div>
   </div>
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agents-ca.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agents-ca.html
@@ -17,7 +17,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agentsConfigurationAssessmentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration-assessment/agentsConfigurationAssessmentsCtrl.js
@@ -46,11 +46,13 @@ define([
       $requestService,
       $notificationService,
       $csvRequestService,
-      $tableFilterService
+      $tableFilterService,
+      reportingEnabled
     ) {
       this.urlTokenModel = $urlTokenModel
       this.rootScope = $rootScope
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.apiReq = $requestService.apiReq
       this.scope.showPolicies = false
       this.state = $state

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
@@ -19,16 +19,14 @@
       <div flex></div>
       <!-- Report button -->
       <div style="display:flex; padding-right: 10px;">
-          <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+          <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
             aria-label="Generate report button">
             <i class="fa fa-fw fa-print" aria-hidden="true"></i>
             <md-tooltip md-direction="left" class="wz-tooltip">
               Generate report
             </md-tooltip>
           </md-button>
-          <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-              class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-          <wz-discover breadcrumbs="{section: 'Agents', subSection: 'File integrity monitoring', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+          <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
         </div>
         <div style="margin-right:7px;" id='timePicker'></div>
       </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
@@ -19,7 +19,7 @@
       <div flex></div>
       <!-- Report button -->
       <div style="display:flex; padding-right: 10px;">
-          <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+          <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
             aria-label="Generate report button">
             <i class="fa fa-fw fa-print" aria-hidden="true"></i>
             <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
@@ -34,7 +34,7 @@
       </div>
     
       <!-- Loading report-->
-      <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+      <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
     
     <!-- Wazuh filters bar -->
     <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agentsFimCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agentsFimCtrl.js
@@ -39,7 +39,8 @@ define([
       $tableFilterService,
       $csvRequestService,
       $notificationService,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.state = $state
       this.wzTableFilter = $tableFilterService
@@ -51,6 +52,7 @@ define([
       this.reportingService = $reportingService
       this.tableResults = {}
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.showFiles = false
       this.scope.showFiles = this.showFiles
       this.urlTokenModel = $urlTokenModel

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
@@ -16,16 +16,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'GDPR', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
       <div style="margin-right:7px;" id='dropDownInput'></div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
@@ -32,8 +32,8 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
-
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>
   <div layout="row" layout-align="center stretch">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
@@ -16,7 +16,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agentsGdprCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agentsGdprCtrl.js
@@ -35,9 +35,11 @@ define([
       $state,
       agent,
       $reportingService,
-      gdprTabs
+      gdprTabs,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.currentDataService = $currentDataService
       this.reportingService = $reportingService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
@@ -17,16 +17,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'General', agentName: agentInfo.name, agentId: agentInfo.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
@@ -32,7 +32,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
@@ -17,7 +17,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agentsGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agentsGeneralCtrl.js
@@ -53,11 +53,13 @@ define([
       agent,
       $state,
       $dateDiffService,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.state = $state
       this.urlTokenModel = $urlTokenModel
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.requestService = $requestService
       this.tableResults = {}
       this.notificationService = $notificationService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
@@ -14,13 +14,12 @@
       <span class="wz-agent-status-indicator small" ng-class="getAgentStatusClass(agent.status)" aria-label="Agent status indicator">{{formatAgentStatus(agent.status)}}</span>
     </div>
     <!-- Report button -->
-    <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()" aria-label="Generate report button">
+    <md-button  ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()" aria-label="Generate report button">
       <i class="fa fa-fw fa-print" aria-hidden="true"></i>
       <md-tooltip md-direction="left" class="wz-tooltip">
         Generate report
       </md-tooltip>      
     </md-button>
-    <div class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   </div>
 
   <div layout="row" class="layout-padding" ng-if="agent && agent.status !== 'Active'">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
@@ -28,9 +28,11 @@ define(['../../module'], function(module) {
       $rootScope,
       $notificationService,
       $scope,
-      $reportingService
+      $reportingService,
+      reportingEnabled      
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.data = syscollector
       this.httpReq = $requestService.httpReq
       this.apiReq = $requestService.apiReq

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
@@ -16,16 +16,14 @@
       <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'Osquery', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
@@ -16,7 +16,7 @@
       <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button  ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
@@ -31,7 +31,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
     <!-- Wazuh filters bar -->
     <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osqueryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osqueryCtrl.js
@@ -41,11 +41,13 @@ define([
       $currentDataService,
       $state,
       osquery,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.state = $state
       this.currentDataService = $currentDataService
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.urlTokenModel = $urlTokenModel
       this.notificationService = $notificationService
       this.tableResults = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
@@ -33,7 +33,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
@@ -17,16 +17,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'PCI-DSS', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
       <div style="margin-right:7px;" id='dropDownInput'></div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
@@ -17,7 +17,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button  ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agentsPciCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agentsPciCtrl.js
@@ -34,13 +34,15 @@ define([
       $currentDataService,
       agent,
       $reportingService,
-      pciTabs
+      pciTabs,
+      reportingEnabled
     ) {
       this.state = $state
       this.reportingService = $reportingService
       this.tableResults = {}
       this.currentDataService = $currentDataService
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.scope.pciTabs = (pciTabs) ? pciTabs : false
       this.urlTokenModel = $urlTokenModel
       this.timePicker = new TimePicker(

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
@@ -32,8 +32,7 @@
   </div>
 
   <!-- Loading report-->
-  <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner"
-      aria-hidden="true"></i></div>
+  <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
@@ -17,17 +17,15 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
-        aria-label="Generate report button">
-        <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
-          Generate report
-        </md-tooltip>
-      </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-          class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-      <wz-discover breadcrumbs="{section: 'Agents', subSection: 'Policity monitoring', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
-    </div>
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+          aria-label="Generate report button">
+          <i class="fa fa-fw fa-print" aria-hidden="true"></i>
+          <md-tooltip md-direction="left" class="wz-tooltip">
+            Generate report
+          </md-tooltip>
+        </md-button>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
+      </div>
     <div style="margin-right:7px;" id='timePicker'></div>
   </div>
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
@@ -17,7 +17,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agentsPolicyMonitoringCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agentsPolicyMonitoringCtrl.js
@@ -45,11 +45,13 @@ define([
       $requestService,
       $notificationService,
       $csvRequestService,
-      $tableFilterService
+      $tableFilterService,
+      reportingEnabled
     ) {
       this.urlTokenModel = $urlTokenModel
       this.rootScope = $rootScope
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.apiReq = $requestService.apiReq
       this.scope.showPolicies = false
       this.state = $state

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
@@ -15,16 +15,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'OpenSCAP', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
       <div style="margin-right:7px;" id='dropDownInput'></div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
@@ -15,7 +15,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
@@ -31,7 +31,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
@@ -50,10 +50,12 @@ define([
         $currentDataService,
         $state,
         agent,
-        $reportingService
+        $reportingService,
+        reportingEnabled
       ) {
         this.urlTokenModel = $urlTokenModel
         this.scope = $scope
+        this.scope.reportingEnabled = reportingEnabled
         this.currentDataService = $currentDataService
         this.reportingService = $reportingService
         this.tableResults = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
@@ -31,7 +31,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
@@ -16,16 +16,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'VirusTotal', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
@@ -16,7 +16,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agentsVirusTotalCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agentsVirusTotalCtrl.js
@@ -25,13 +25,15 @@ define([
       $scope,
       $currentDataService,
       agent,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.state = $state
       this.currentDataService = $currentDataService
       this.reportingService = $reportingService
       this.tableResults = {}
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       //Add filer for VirusTotal
       this.currentDataService.addFilter(
         `{"rule.groups":"virustotal", "implicit":true}`

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
@@ -16,16 +16,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Agents', subSection: 'Vulnerabilities', agentName: agent.name, agentId: agent.id, ref: 'agents', agentRef: 'agent-overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
@@ -31,7 +31,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
@@ -16,7 +16,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
@@ -46,10 +46,12 @@ define([
       $currentDataService,
       $state,
       agent,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.urlTokenModel = $urlTokenModel
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.currentDataService = $currentDataService
       this.currentDataService.addFilter(
         `{"rule.groups":"vulnerability-detector", "implicit":true, "onlyShow":true}`

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset-id.html
@@ -99,8 +99,8 @@
             <md-divider class="wz-margin-top-10"></md-divider>
             <div layout="row" class="wz-padding-top-10" ng-repeat="(key, value) in ruleInfo.details" ng-if='!isArray(value)'>
               <span class="wz-word-break-rule">{{key}}</span>
-              <span ng-if="!isObject(value)" class="wz-text-right color-grey">{{value}}</span>
-              <span ng-if="isObject(value)" class="color-grey">
+              <span style="margin-left: 5px;" ng-if="!isObject(value)" class="wz-text-right color-grey">{{value}}</span>
+              <span style="margin-left: 5px;" ng-if="isObject(value)" class="color-grey">
                 <span ng-repeat="(key, value) in value">{{key}}: {{value}} <span ng-if="!$last">|</span> </span>
               </span>
             </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'Audit', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overviewAuditCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overviewAuditCtrl.js
@@ -32,9 +32,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.tableResults = {}
       this.reportingService = $reportingService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'Amazon Web Services', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/awsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/awsCtrl.js
@@ -33,9 +33,11 @@ define([
       $currentDataService,
       $state,
       $notificationService,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.urlTokenModel = $urlTokenModel
       this.state = $state
       this.toast = $notificationService.showSimpleToast

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/ciscatCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/ciscatCtrl.js
@@ -29,9 +29,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.reportingService = $reportingService
       this.addFilter = $currentDataService.addFilter

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
@@ -7,17 +7,15 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
-        aria-label="Generate report button">
-        <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
-          Generate report
-        </md-tooltip>
-      </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-          class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-      <wz-discover breadcrumbs="{section: 'Overview', subSection: 'CIS-CAT', ref: 'overview'}"></wz-discover>
-    </div>
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+          aria-label="Generate report button">
+          <i class="fa fa-fw fa-print" aria-hidden="true"></i>
+          <md-tooltip md-direction="left" class="wz-tooltip">
+            Generate report
+          </md-tooltip>
+        </md-button>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
+      </div>
     <div style="margin-right:7px;" id='timePicker'></div>
   </div>
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
@@ -22,8 +22,7 @@
   </div>
 
   <!-- Loading report-->
-  <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner"
-      aria-hidden="true"></i></div>
+  <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'File integrity monitoring', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overviewFimCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overviewFimCtrl.js
@@ -31,9 +31,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.reportingService = $reportingService
       $currentDataService.addFilter(

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
@@ -23,7 +23,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'GDPR', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
       <div style="margin-right:7px;" id='dropDownInput'></div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overviewGdprCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overviewGdprCtrl.js
@@ -21,9 +21,11 @@ define([
       $currentDataService,
       $state,
       $reportingService,
-      gdprTabs
+      gdprTabs,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.getFilters = $currentDataService.getSerializedFilters
       this.reportingService = $reportingService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
@@ -7,14 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
         aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
         <md-tooltip md-direction="left" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </md-button>
-      <span ng-if="reportingEnabled" class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
+      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
           class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
       <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
@@ -7,14 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+      <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
         aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
         <md-tooltip md-direction="left" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
+      <span ng-if="reportingEnabled" class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
           class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
       <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
@@ -7,15 +7,13 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
         aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
         <md-tooltip md-direction="left" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-          class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
       <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
     </div>
     <div style="margin-right:7px;" id='timePicker'></div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+      <md-button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
         aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
         <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
@@ -22,7 +22,7 @@
   </div>
 
   <!-- Loading report-->
-  <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+  <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -44,11 +44,13 @@ define([
       pollingState,
       $reportingService,
       $rootScope,
+      reportingEnabled
     ) {
       this.currentDataService = $currentDataService
       this.rootScope = $rootScope
       this.filters = this.currentDataService.getSerializedFilters()
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.reportingService = $reportingService
       this.apiReq = $requestService.apiReq
       this.tableResults = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -33,7 +33,6 @@ define([
      * @param {Object} pollingState
      * @param {*} $reportingService
      * @param {*} $rootScope
-     * @param {*} reportingEnabled
      */
     constructor(
       $urlTokenModel,
@@ -45,7 +44,6 @@ define([
       pollingState,
       $reportingService,
       $rootScope,
-      reportingEnabled
     ) {
       this.currentDataService = $currentDataService
       this.rootScope = $rootScope
@@ -67,7 +65,6 @@ define([
           ? false
           : true
       this.toast = $notificationService.showSimpleToast
-      this.scope.reportingEnabled = reportingEnabled
 
       this.scope.$on('deletedFilter', () => {
         this.launchSearches()

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -33,6 +33,7 @@ define([
      * @param {Object} pollingState
      * @param {*} $reportingService
      * @param {*} $rootScope
+     * @param {*} reportingEnabled
      */
     constructor(
       $urlTokenModel,
@@ -43,7 +44,8 @@ define([
       $requestService,
       pollingState,
       $reportingService,
-      $rootScope
+      $rootScope,
+      reportingEnabled
     ) {
       this.currentDataService = $currentDataService
       this.rootScope = $rootScope
@@ -65,6 +67,7 @@ define([
           ? false
           : true
       this.toast = $notificationService.showSimpleToast
+      this.scope.reportingEnabled = reportingEnabled
 
       this.scope.$on('deletedFilter', () => {
         this.launchSearches()

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'Osquery', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osqueryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osqueryCtrl.js
@@ -26,9 +26,11 @@ define([
       $state,
       $notificationService,
       osquery,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.osquery = osquery
       this.state = $state
       this.currentDataService = $currentDataService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
@@ -7,17 +7,15 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
-        aria-label="Generate report button">
-        <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
-          Generate report
-        </md-tooltip>
-      </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-          class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-      <wz-discover breadcrumbs="{section: 'Overview', subSection: 'PCI-DSS', ref: 'overview'}"></wz-discover>
-    </div>
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+          aria-label="Generate report button">
+          <i class="fa fa-fw fa-print" aria-hidden="true"></i>
+          <md-tooltip md-direction="left" class="wz-tooltip">
+            Generate report
+          </md-tooltip>
+        </md-button>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
+      </div>
     <div style="margin-right:7px;" id='timePicker'></div>
     <div style="margin-right:7px;" id='dropDownInput'></div>
   </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
@@ -23,8 +23,7 @@
   </div>
 
   <!-- Loading report-->
-  <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner"
-      aria-hidden="true"></i></div>
+  <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overviewPciCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overviewPciCtrl.js
@@ -32,9 +32,11 @@ define([
       $currentDataService,
       $state,
       $reportingService,
-      pciTabs
+      pciTabs,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.scope.pciTabs = (pciTabs) ? pciTabs : false
       this.reportingService = $reportingService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>Ce
   
   <wazuh-bar></wazuh-bar>
   <!-- first row  -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
@@ -20,7 +20,7 @@
     </div>
   
     <!-- Loading report-->
-    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>Ce
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <wazuh-bar></wazuh-bar>
   <!-- first row  -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <wazuh-bar></wazuh-bar>
   <!-- first row  -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'Policy monitoring', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overviewPolicyMonitoringCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overviewPolicyMonitoringCtrl.js
@@ -21,9 +21,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.urlTokenModel = $urlTokenModel
       this.state = $state
       this.reportingService = $reportingService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
@@ -7,17 +7,15 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-      <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
-        aria-label="Generate report button">
-        <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
-          Generate report
-        </md-tooltip>
-      </md-button>
-      <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-          class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-      <wz-discover breadcrumbs="{section: 'Overview', subSection: 'OpenSCAP', ref: 'overview'}"></wz-discover>
-    </div>
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+          aria-label="Generate report button">
+          <i class="fa fa-fw fa-print" aria-hidden="true"></i>
+          <md-tooltip md-direction="left" class="wz-tooltip">
+            Generate report
+          </md-tooltip>
+        </md-button>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
+      </div>
     <div style="margin-right:7px;" id='timePicker'></div>
     <div style="margin-right:7px;" id='dropDownInput'></div>
   </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
@@ -23,8 +23,7 @@
   </div>
 
   <!-- Loading report-->
-  <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner"
-      aria-hidden="true"></i></div>
+  <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
 
   <!-- Filter bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overviewOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overviewOpenScapCtrl.js
@@ -36,9 +36,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.reportingService = $reportingService
       this.tableResults = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <!-- Wazuh filters bar -->
   <wazuh-bar></wazuh-bar>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'VirusTotal', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overviewVirusTotalCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overviewVirusTotalCtrl.js
@@ -33,9 +33,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.reportingService = $reportingService
       this.tableResults = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
@@ -7,16 +7,14 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-hide="loadingVizz" ng-click="startVis2Png()"
+        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">
             Generate report
           </md-tooltip>
         </md-button>
-        <span class='wz-margin-right-15 wz-margin-top-12' ng-hide='!loadingVizz'>Waiting for reporting information <i
-            class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></span>
-        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'Vulnerabilities', ref: 'overview'}"></wz-discover>
+        <wz-discover breadcrumbs="{section: 'Overview', subSection: 'General', ref: 'overview'}"></wz-discover>
       </div>
       <div style="margin-right:7px;" id='timePicker'></div>
     </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
@@ -22,7 +22,7 @@
     </div>
   
     <!-- Loading report-->
-    <div text-align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
+    <div align='center' ng-if='loadingReporting'>Generating report<br><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
   
   <wazuh-bar></wazuh-bar>
   <!-- first row  -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
@@ -7,7 +7,7 @@
     <div flex></div>
     <!-- Report button -->
     <div style="display:flex; padding-right: 10px;">
-        <md-button md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
+        <md-button ng-if="reportingEnabled" md-no-ink class="md-icon-button small wz-no-margin-padding" ng-disabled="loadingVizz" ng-click="startVis2Png()"
           aria-label="Generate report button">
           <i class="fa fa-fw fa-print" aria-hidden="true"></i>
           <md-tooltip md-direction="left" class="wz-tooltip">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
@@ -34,9 +34,11 @@ define([
       $scope,
       $currentDataService,
       $state,
-      $reportingService
+      $reportingService,
+      reportingEnabled
     ) {
       this.scope = $scope
+      this.scope.reportingEnabled = reportingEnabled
       this.state = $state
       this.reportingService = $reportingService
       this.tableResults = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/extensions/extensions.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/extensions/extensions.html
@@ -1,23 +1,28 @@
 <div layout="column" layout-align="start stretch" ng-if="!load">
-  
+
   <!-- Headline -->
   <div layout="column" layout-padding>
     <span class="font-size-18"><i class="fa fa-fw fa-check-square-o" aria-hidden="true"></i> Wazuh extensions</span>
-    <span class="md-subheader">A Wazuh extension is used to enable visualizations and dashboards that are specific to a particular use case.</span>
+    <span class="md-subheader">A Wazuh extension is used to enable visualizations and dashboards that are specific to a
+      particular use case.</span>
   </div>
   <!-- End headline -->
-  
+
   <!-- Section cards -->
   <div layout="row" layout-align="start stretch" layout-wrap>
-    
+
     <!-- PCI DSS -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-credit-card" aria-hidden="true"></i> PCI DSS</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">The Payment Card Industry Data Security Standard (PCI DSS) is a proprietary information security standard for organizations that handle branded credit cards from the major card schemes including Visa, MasterCard, American Express, Discover, and JCB.</p>
-          <p class="md-body-1 wz-padding-top-10">The PCI Standard is mandated by the card brands and administered by the Payment Card Industry Security Standards Council. The standard was created to increase controls around cardholder data to reduce credit card fraud.</p>
+          <p class="md-body-1 wz-padding-top-10">The Payment Card Industry Data Security Standard (PCI DSS) is a
+            proprietary information security standard for organizations that handle branded credit cards from the major
+            card schemes including Visa, MasterCard, American Express, Discover, and JCB.</p>
+          <p class="md-body-1 wz-padding-top-10">The PCI Standard is mandated by the card brands and administered by
+            the Payment Card Industry Security Standards Council. The standard was created to increase controls around
+            cardholder data to reduce credit card fraud.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -25,20 +30,25 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/pci-dss/index.html" class="wz-text-link cursor-pointer small" aria-label="Open Wazuh PCI DSS documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/pci-dss/index.html" class="wz-text-link cursor-pointer small"
+          aria-label="Open Wazuh PCI DSS documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- GDPR -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-list-ol" aria-hidden="true"></i> GDPR</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">The General Data Protection Regulation (GDPR) is a regulation in EU law on data protection and privacy for all individuals within the European Union. It also addresses the export of personal data outside the EU.</p>
-          <p class="md-body-1 wz-padding-top-10">The GDPR aims primarily to give control to citizens and residents over their personal data and to simplify the regulatory environment for international business by unifying the regulation within the EU.</p>
+          <p class="md-body-1 wz-padding-top-10">The General Data Protection Regulation (GDPR) is a regulation in EU
+            law on data protection and privacy for all individuals within the European Union. It also addresses the
+            export of personal data outside the EU.</p>
+          <p class="md-body-1 wz-padding-top-10">The GDPR aims primarily to give control to citizens and residents over
+            their personal data and to simplify the regulatory environment for international business by unifying the
+            regulation within the EU.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -46,20 +56,23 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/gdpr/index.html" class="wz-text-link cursor-pointer small" aria-label="Open Wazuh GDPR documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/gdpr/index.html" class="wz-text-link cursor-pointer small"
+          aria-label="Open Wazuh GDPR documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- Audit -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-balance-scale" aria-hidden="true"></i> System auditing</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">The Linux Audit system provides a way to track security-relevant information on your system.</p>
-          <p class="md-body-1 wz-padding-top-10">Based on pre-configured rules, Audit generates log entries to record as much information about the events that are happening on your system as possible.</p>
+          <p class="md-body-1 wz-padding-top-10">The Linux Audit system provides a way to track security-relevant
+            information on your system.</p>
+          <p class="md-body-1 wz-padding-top-10">Based on pre-configured rules, Audit generates log entries to record
+            as much information about the events that are happening on your system as possible.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -67,20 +80,23 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/system-calls-monitoring/index.html" class="wz-text-link cursor-pointer small" aria-label="Open Audit documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/system-calls-monitoring/index.html"
+          class="wz-text-link cursor-pointer small" aria-label="Open Audit documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- Open SCAP -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-search" aria-hidden="true"></i>OpenSCAP</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">OpenSCAP is an OVAL (Open Vulnerability Assessment Language) interpreter, that is used for system configuration and vulnerability assessment.</p>
-          <p class="md-body-1 wz-padding-top-10">Developed and supported by RedHat, it is recognized as a standardized compliance and hardening checking solution for enterprise-level infrastructure.</p>
+          <p class="md-body-1 wz-padding-top-10">OpenSCAP is an OVAL (Open Vulnerability Assessment Language)
+            interpreter, that is used for system configuration and vulnerability assessment.</p>
+          <p class="md-body-1 wz-padding-top-10">Developed and supported by RedHat, it is recognized as a standardized
+            compliance and hardening checking solution for enterprise-level infrastructure.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -88,19 +104,23 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/openscap/index.html" class="wz-text-link cursor-pointer small" aria-label="Open Open SCAP documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/openscap/index.html"
+          class="wz-text-link cursor-pointer small" aria-label="Open Open SCAP documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- CIS-CAT -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-rocket" aria-hidden="true"></i>CIS-CAT</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">CIS (Center for Internet Security) is an entity dedicated to safeguard private and public organizations against cyber threats. This entity provides CIS benchmarks guidelines, which are a recognized global standard and best practices for securing IT systems and data against cyberattacks.</p>
+          <p class="md-body-1 wz-padding-top-10">CIS (Center for Internet Security) is an entity dedicated to safeguard
+            private and public organizations against cyber threats. This entity provides CIS benchmarks guidelines,
+            which are a recognized global standard and best practices for securing IT systems and data against
+            cyberattacks.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -108,19 +128,22 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html" class="wz-text-link cursor-pointer small" aria-label="Open CIS-CAT integration documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html"
+          class="wz-text-link cursor-pointer small" aria-label="Open CIS-CAT integration documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- Osquery -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-rocket" aria-hidden="true"></i> Osquery</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">Osquery can be used to expose an operating system as a high-performance relational database. This allows you to write SQL-based queries to explore operating system data.</p>
+          <p class="md-body-1 wz-padding-top-10">Osquery can be used to expose an operating system as a
+            high-performance relational database. This allows you to write SQL-based queries to explore operating
+            system data.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -128,19 +151,22 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/osquery.html" class="wz-text-link cursor-pointer small" aria-label="Osquery integration documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/osquery.html"
+          class="wz-text-link cursor-pointer small" aria-label="Osquery integration documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- Amazon -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-amazon" aria-hidden="true"></i>Amazon AWS</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">Wazuh provides an agent module that can be used to retrieve data from S3 buckets. In combination with log analysis rules, this module provides the ability to analyze and alert on AWS Cloudtrail, GuardDuty, Macie, IAM, VPC Flow and other Amazon AWS  services data.</p>
+          <p class="md-body-1 wz-padding-top-10">Wazuh provides an agent module that can be used to retrieve data from
+            S3 buckets. In combination with log analysis rules, this module provides the ability to analyze and alert
+            on AWS Cloudtrail, GuardDuty, Macie, IAM, VPC Flow and other Amazon AWS services data.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
@@ -148,32 +174,59 @@
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/amazon/index.html" class="wz-text-link cursor-pointer small" aria-label="Open AWS integration documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/amazon/index.html" class="wz-text-link cursor-pointer small"
+          aria-label="Open AWS integration documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
-    
+
     <!-- VirusTotal -->
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-bug" aria-hidden="true"></i> VirusTotal</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <div layout="column">
-          <p class="md-body-1 wz-padding-top-10">VirusTotal is an online service that analyzes files and URLs enabling the identification of viruses, worms, trojans, and other kinds of malicious content detected by antivirus engines and website scanners. Virustotal is commonly used as a threat intelligence source to help with security analysis and incident response.</p>
+          <p class="md-body-1 wz-padding-top-10">VirusTotal is an online service that analyzes files and URLs enabling
+            the identification of viruses, worms, trojans, and other kinds of malicious content detected by antivirus
+            engines and website scanners. Virustotal is commonly used as a threat intelligence source to help with
+            security analysis and incident response.</p>
         </div>
         <span flex></span>
         <div layout="row" class="wz-padding-top-10">
-          <md-switch class="wz-switch" aria-label="VirusTotal extension switch" ng-model="extensions.virustotal" ng-change="toggleExtension('virustotal',extensions.virustotal)"></md-switch>
+          <md-switch class="wz-switch" aria-label="VirusTotal extension switch" ng-model="extensions.virustotal"
+            ng-change="toggleExtension('virustotal',extensions.virustotal)"></md-switch>
         </div>
       </md-card-content>
       <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
-        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/index.html" class="wz-text-link cursor-pointer small" aria-label="Open VirusTotal integration documentation">
+        <md-button target="_blank" href="https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/index.html"
+          class="wz-text-link cursor-pointer small" aria-label="Open VirusTotal integration documentation">
           <i class="fa fa-fw fa-info" aria-hidden="true"></i> More info
         </md-button>
       </md-card-actions>
     </md-card>
+
+    <!-- Reporting -->
+    <md-card flex="45" layout="column" class="wz-md-card">
+      <md-card-content flex="auto" layout="column">
+        <span class="wz-headline-title"><i class="fa fa-fw fa-print" aria-hidden="true"></i> Reporting</span>
+        <md-divider class="wz-margin-top-10"></md-divider>
+        <div layout="column">
+          <p class="md-body-1 wz-padding-top-10">Capability to generates reportings in PDF format, fetching the data
+            from
+            the tables and visualizations of the current section.</p>
+        </div>
+        <span flex></span>
+        <div layout="row" class="wz-padding-top-10">
+          <md-switch class="wz-switch" aria-label="Reporting" ng-model="extensions.reporting" ng-change="toggleExtension('reporting',extensions.reporting)"></md-switch>
+        </div>
+      </md-card-content>
+      <md-card-actions layout="row" layout-align="end center" class="wz-card-actions">
+        <div style="height: 35px;"></div>
+      </md-card-actions>
+    </md-card>
+
   </div>
   <!-- End section cards -->
-  
+
 </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/extensions/extensions.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/extensions/extensions.html
@@ -207,6 +207,7 @@
     </md-card>
 
     <!-- Reporting -->
+    <!--
     <md-card flex="45" layout="column" class="wz-md-card">
       <md-card-content flex="auto" layout="column">
         <span class="wz-headline-title"><i class="fa fa-fw fa-print" aria-hidden="true"></i> Reporting</span>
@@ -225,6 +226,7 @@
         <div style="height: 35px;"></div>
       </md-card-actions>
     </md-card>
+    -->
 
   </div>
   <!-- End section cards -->

--- a/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
@@ -141,6 +141,20 @@ define(['../module'], function(module) {
       }
     }
 
+    /**
+     * Gets reporting status
+     */
+     const getReportingStatus = async () => {
+       try {
+         const id = getApi()['_key']
+         const result = await getExtensionsById(id)
+         const status = result.reporting === 'true'
+         return status
+       } catch (error) {
+         return true
+       }
+     }
+
     return {
       getPollintState: getPollintState,
       getBaseUrl: getBaseUrl,
@@ -170,6 +184,7 @@ define(['../module'], function(module) {
       getExtensions: getExtensions,
       setExtensions: setExtensions,
       getExtensionsById: getExtensionsById,
+      getReportingStatus: getReportingStatus,
       addApi: addApi
     }
   })

--- a/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
@@ -1,4 +1,4 @@
-define(['../module', 'jquery'], function(module, $) {
+define(['../module', 'jquery'], function (module, $) {
   'use strict'
   class ReportingService {
     constructor(
@@ -13,7 +13,24 @@ define(['../module', 'jquery'], function(module, $) {
       this.visHandlers = $currentDataService
       this.genericReq = $requestService.httpReq
       this.apiReq = $requestService.apiReq
-      this.errorHandler = $notificationService.showSimpleToast
+      this.toast = $notificationService.showSimpleToast
+      this.warning = $notificationService.showWarningToast
+      this.error = $notificationService.showErrorToast
+      this.success = $notificationService.showSuccessToast
+    }
+
+    /**
+     * Checks if report extension is enablad
+     */
+    async reportIsEnabled() {
+      try {
+        const id = this.visHandlers.getApi()['_key']
+        const result = await this.visHandlers.getExtensionsById(id)
+        const status = result.reporting === 'true' ? true : false
+        return status
+      } catch (err) {
+        return true
+      }
     }
 
     /**
@@ -32,186 +49,196 @@ define(['../module', 'jquery'], function(module, $) {
       isAgents = false
     ) {
       try {
-        metrics = JSON.stringify(metrics)
-        this.$rootScope.$broadcast('loadingReporting', { status: true })
-        if (this.vis2png.isWorking()) {
-          this.errorHandler('Report in progress')
+        const enabled = await this.reportIsEnabled()
+        if (enabled) {
+          metrics = JSON.stringify(metrics)
+          this.$rootScope.$broadcast('loadingReporting', { status: true })
+          if (this.vis2png.isWorking()) {
+            this.toast('Report in progress')
+            return
+          }
+          if (!this.$rootScope.$$phase) this.$rootScope.$digest()
+
+          this.vis2png.clear()
+
+          for (const item of vizz) {
+            const tmpHTMLElement = $(`#${item}`)
+            this.vis2png.assignHTMLItem(item, tmpHTMLElement)
+          }
+
+          const appliedFilters = this.visHandlers.getSerializedFilters()
+
+          const images = await this.vis2png.checkArray(vizz)
+          const name = `wazuh-${
+            isAgents ? 'agents' : 'overview'
+            }-${tab}-${(Date.now() / 1000) | 0}.pdf`
+
+          //Search time range
+          const timeRange = document.getElementById('timePicker').getElementsByTagName('span')[1].innerHTML ?
+            document.getElementById('timePicker').getElementsByTagName('span')[1].innerHTML : ' '
+
+          const data = {
+            images,
+            tableResults,
+            sectionTitle,
+            timeRange,
+            queryFilters,
+            metrics,
+            name,
+            title: isAgents ? `Agents ${tab}` : `Overview ${tab}`,
+            filters: appliedFilters.filters,
+            time: appliedFilters.time,
+            searchBar: appliedFilters.searchBar,
+            tables: appliedFilters.tables,
+            pdfName: tab,
+            section: isAgents ? 'agents' : 'overview',
+            isAgents
+          }
+          await this.genericReq('POST', '/report/generate', {
+            data: JSON.stringify(data)
+          })
+
+          if (!this.$rootScope.$$phase) this.$rootScope.$digest()
+          this.success('Success. Go to Management -> Reporting')
+          this.$rootScope.$broadcast('loadingReporting', { status: false })
           return
+        } else {
+          this.warning("Reporting service disabled. Go to Settings > Extensions to enable it.")
         }
-        if (!this.$rootScope.$$phase) this.$rootScope.$digest()
-
-        this.vis2png.clear()
-
-        for (const item of vizz) {
-          const tmpHTMLElement = $(`#${item}`)
-          this.vis2png.assignHTMLItem(item, tmpHTMLElement)
-        }
-
-        const appliedFilters = this.visHandlers.getSerializedFilters()
-
-        const images = await this.vis2png.checkArray(vizz)
-        const name = `wazuh-${
-          isAgents ? 'agents' : 'overview'
-        }-${tab}-${(Date.now() / 1000) | 0}.pdf`
-
-        //Search time range
-        const timeRange = document.getElementById('timePicker').getElementsByTagName('span')[1].innerHTML ?
-          document.getElementById('timePicker').getElementsByTagName('span')[1].innerHTML : ' '
-
-        const data = {
-          images,
-          tableResults,
-          sectionTitle,
-          timeRange,
-          queryFilters,
-          metrics,
-          name,
-          title: isAgents ? `Agents ${tab}` : `Overview ${tab}`,
-          filters: appliedFilters.filters,
-          time: appliedFilters.time,
-          searchBar: appliedFilters.searchBar,
-          tables: appliedFilters.tables,
-          pdfName: tab,
-          section: isAgents ? 'agents' : 'overview',
-          isAgents
-        }
-        await this.genericReq('POST', '/report/generate', {
-          data: JSON.stringify(data)
-        })
-
-        if (!this.$rootScope.$$phase) this.$rootScope.$digest()
-        this.errorHandler('Success. Go to Management -> Reporting')
-        this.$rootScope.$broadcast('loadingReporting', { status: false })
-        return
       } catch (error) {
         this.$rootScope.reportBusy = false
         this.$rootScope.reportStatus = false
         if (error === 'Impossible fetch visualizations') {
-          this.errorHandler(`Reporting error: ${error}`)
+          this.error(`Reporting error: ${error}`)
         } else {
-          this.errorHandler('Reporting error')
+          this.error('Reporting error')
         }
       }
     }
 
     async reportInventoryData(agentId) {
       try {
-        let tableResults = {}
-        let isAgents
-        this.$rootScope.$broadcast('loadingReporting', { status: true })
-        //Get agent info and formating tables
-        try {
-          const agent = await Promise.all([
-            this.apiReq(`/agents/${agentId}`),
-            this.apiReq(`/syscheck/${agentId}/last_scan`),
-            this.apiReq(`/rootcheck/${agentId}/last_scan`),
-            this.apiReq(`/syscollector/${agentId}/hardware`),
-            this.apiReq(`/syscollector/${agentId}/os`)
-          ])
-          isAgents = {
-            ID: agent[0].data.data.id,
-            Name: agent[0].data.data.name,
-            IP: agent[0].data.data.ip,
-            Version: agent[0].data.data.version,
-            Manager: agent[0].data.data.manager,
-            OS: `${agent[0].data.data.os.name} ${
-              agent[0].data.data.os.codename
-            } ${agent[0].data.data.os.version}`,
-            dateAdd: agent[0].data.data.dateAdd,
-            lastKeepAlive: agent[0].data.data.lastKeepAlive,
-            group: agent[0].data.data.group.toString()
+        const enabled = await this.reportIsEnabled()
+        if (enabled) {
+          let tableResults = {}
+          let isAgents
+          this.$rootScope.$broadcast('loadingReporting', { status: true })
+          //Get agent info and formating tables
+          try {
+            const agent = await Promise.all([
+              this.apiReq(`/agents/${agentId}`),
+              this.apiReq(`/syscheck/${agentId}/last_scan`),
+              this.apiReq(`/rootcheck/${agentId}/last_scan`),
+              this.apiReq(`/syscollector/${agentId}/hardware`),
+              this.apiReq(`/syscollector/${agentId}/os`)
+            ])
+            isAgents = {
+              ID: agent[0].data.data.id,
+              Name: agent[0].data.data.name,
+              IP: agent[0].data.data.ip,
+              Version: agent[0].data.data.version,
+              Manager: agent[0].data.data.manager,
+              OS: `${agent[0].data.data.os.name} ${
+                agent[0].data.data.os.codename
+                } ${agent[0].data.data.os.version}`,
+              dateAdd: agent[0].data.data.dateAdd,
+              lastKeepAlive: agent[0].data.data.lastKeepAlive,
+              group: agent[0].data.data.group.toString()
+            }
+          } catch (error) {
+            isAgents = 'inventory'
           }
-        } catch (error) {
-          isAgents = 'inventory'
+  
+          //Network interfaces
+          const netiface = await this.apiReq(`/syscollector/${agentId}/netiface`)
+          const networkInterfaceKeys = ['Name', 'Mac', 'State', 'MTU', 'Type']
+          const networkInterfaceData = netiface.data.data.items.map(i => {
+            i.mtu = i.mtu ? i.mtu.toString() : 'undefined'
+            return [i.name, i.mac, i.state, i.mtu, i.type]
+          })
+          const networkInterfaceTable = {
+            fields: networkInterfaceKeys,
+            rows: networkInterfaceData
+          }
+          tableResults['Network interfaces'] = networkInterfaceTable
+  
+          //Network ports
+          const ports = await this.apiReq(`/syscollector/${agentId}/ports`)
+          const networkPortsKeys = ['Local IP', 'Local Port', 'State', 'Protocol']
+          const networkPortsData = ports.data.data.items.map(p => {
+            p.local.port = p.local.port ? p.local.port.toString() : 'undefined'
+            return [p.local.ip, p.local.port, p.state, p.protocol]
+          })
+          const networkPortsTable = {
+            fields: networkPortsKeys,
+            rows: networkPortsData
+          }
+          tableResults['Network ports'] = networkPortsTable
+  
+          //Network addresses
+          const netaddr = await this.apiReq(`/syscollector/${agentId}/netaddr`)
+          const networkAdressessKeys = [
+            'Interface',
+            'Address',
+            'Netmask',
+            'Protocol',
+            'Broadcast'
+          ]
+          const networkAdressessData = netaddr.data.data.items.map(n => {
+            return [n.iface, n.address, n.netmask, n.proto, n.broadcast]
+          })
+          const networkAdressessTable = {
+            fields: networkAdressessKeys,
+            rows: networkAdressessData
+          }
+          tableResults['Network addresses'] = networkAdressessTable
+  
+          //Processes
+          const processes = await this.apiReq(
+            `/syscollector/${agentId}/processes`
+          )
+          const processesKeys = ['Name', 'Euser', 'Nice', 'State']
+          const processesData = processes.data.data.items.map(n => {
+            n.nice = n.nice ? n.nice.toString() : 'undefined'
+            return [n.name, n.euser, n.nice, n.state]
+          })
+          const processesTable = { fields: processesKeys, rows: processesData }
+          tableResults['Processes'] = processesTable
+  
+          //Packages
+          const packages = await this.apiReq(`/syscollector/${agentId}/packages`)
+          const packagesKeys = ['Name', 'Architecture', 'Version', 'Description']
+          const packagesData = packages.data.data.items.map(p => {
+            return [p.name, p.architecture, p.version, p.description]
+          })
+          const packagesTable = { fields: packagesKeys, rows: packagesData }
+          tableResults['Packages'] = packagesTable
+  
+          const data = {
+            images: [],
+            tableResults,
+            timeRange: '',
+            sectionTitle: 'Inventory Data',
+            queryFilters: '',
+            metrics: {},
+            pdfName: 'agents-inventory',
+            isAgents
+          }
+  
+          await this.genericReq('POST', '/report/generate', {
+            data: JSON.stringify(data)
+          })
+  
+          if (!this.$rootScope.$$phase) this.$rootScope.$digest()
+          this.success('Success. Go to Management -> Reporting')
+          this.$rootScope.$broadcast('loadingReporting', { status: false })
+          return
+        } else {
+          this.warning("Reporting service disabled. Go to Settings > Extensions to enable it.")
         }
-
-        //Network interfaces
-        const netiface = await this.apiReq(`/syscollector/${agentId}/netiface`)
-        const networkInterfaceKeys = ['Name', 'Mac', 'State', 'MTU', 'Type']
-        const networkInterfaceData = netiface.data.data.items.map(i => {
-          i.mtu = i.mtu ? i.mtu.toString() : 'undefined'
-          return [i.name, i.mac, i.state, i.mtu, i.type]
-        })
-        const networkInterfaceTable = {
-          fields: networkInterfaceKeys,
-          rows: networkInterfaceData
-        }
-        tableResults['Network interfaces'] = networkInterfaceTable
-
-        //Network ports
-        const ports = await this.apiReq(`/syscollector/${agentId}/ports`)
-        const networkPortsKeys = ['Local IP', 'Local Port', 'State', 'Protocol']
-        const networkPortsData = ports.data.data.items.map(p => {
-          p.local.port = p.local.port ? p.local.port.toString() : 'undefined'
-          return [p.local.ip, p.local.port, p.state, p.protocol]
-        })
-        const networkPortsTable = {
-          fields: networkPortsKeys,
-          rows: networkPortsData
-        }
-        tableResults['Network ports'] = networkPortsTable
-
-        //Network addresses
-        const netaddr = await this.apiReq(`/syscollector/${agentId}/netaddr`)
-        const networkAdressessKeys = [
-          'Interface',
-          'Address',
-          'Netmask',
-          'Protocol',
-          'Broadcast'
-        ]
-        const networkAdressessData = netaddr.data.data.items.map(n => {
-          return [n.iface, n.address, n.netmask, n.proto, n.broadcast]
-        })
-        const networkAdressessTable = {
-          fields: networkAdressessKeys,
-          rows: networkAdressessData
-        }
-        tableResults['Network addresses'] = networkAdressessTable
-
-        //Processes
-        const processes = await this.apiReq(
-          `/syscollector/${agentId}/processes`
-        )
-        const processesKeys = ['Name', 'Euser', 'Nice', 'State']
-        const processesData = processes.data.data.items.map(n => {
-          n.nice = n.nice ? n.nice.toString() : 'undefined'
-          return [n.name, n.euser, n.nice, n.state]
-        })
-        const processesTable = { fields: processesKeys, rows: processesData }
-        tableResults['Processes'] = processesTable
-
-        //Packages
-        const packages = await this.apiReq(`/syscollector/${agentId}/packages`)
-        const packagesKeys = ['Name', 'Architecture', 'Version', 'Description']
-        const packagesData = packages.data.data.items.map(p => {
-          return [p.name, p.architecture, p.version, p.description]
-        })
-        const packagesTable = { fields: packagesKeys, rows: packagesData }
-        tableResults['Packages'] = packagesTable
-
-        const data = {
-          images: [],
-          tableResults,
-          timeRange: '',
-          sectionTitle: 'Inventory Data',
-          queryFilters: '',
-          metrics: {},
-          pdfName: 'agents-inventory',
-          isAgents
-        }
-
-        await this.genericReq('POST', '/report/generate', {
-          data: JSON.stringify(data)
-        })
-
-        if (!this.$rootScope.$$phase) this.$rootScope.$digest()
-        this.errorHandler('Success. Go to Management -> Reporting')
-        this.$rootScope.$broadcast('loadingReporting', { status: false })
-        return
       } catch (error) {
         console.error(error)
-        this.errorHandler('Reporting error')
+        this.error('Reporting error')
       }
     }
   }

--- a/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
@@ -10,7 +10,7 @@ define(['../module', 'jquery'], function (module, $) {
     ) {
       this.$rootScope = $rootScope
       this.vis2png = vis2png
-      this.visHandlers = $currentDataService
+      this.currentDataService = $currentDataService
       this.genericReq = $requestService.httpReq
       this.apiReq = $requestService.apiReq
       this.toast = $notificationService.showSimpleToast
@@ -24,8 +24,8 @@ define(['../module', 'jquery'], function (module, $) {
      */
     async reportIsEnabled() {
       try {
-        const id = this.visHandlers.getApi()['_key']
-        const result = await this.visHandlers.getExtensionsById(id)
+        const id = this.currentDataService.getApi()['_key']
+        const result = await this.currentDataService.getExtensionsById(id)
         const status = result.reporting === 'true' ? true : false
         return status
       } catch (err) {
@@ -66,7 +66,7 @@ define(['../module', 'jquery'], function (module, $) {
             this.vis2png.assignHTMLItem(item, tmpHTMLElement)
           }
 
-          const appliedFilters = this.visHandlers.getSerializedFilters()
+          const appliedFilters = this.currentDataService.getSerializedFilters()
 
           const images = await this.vis2png.checkArray(vizz)
           const name = `wazuh-${

--- a/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
@@ -103,7 +103,7 @@ define(['../module', 'jquery'], function (module, $) {
           this.$rootScope.$broadcast('loadingReporting', { status: false })
           return
         } else {
-          this.warning("Reporting service disabled. Go to Settings > Extensions to enable it.")
+          this.warning("Reporting service disabled.")
         }
       } catch (error) {
         this.$rootScope.reportBusy = false
@@ -234,7 +234,7 @@ define(['../module', 'jquery'], function (module, $) {
           this.$rootScope.$broadcast('loadingReporting', { status: false })
           return
         } else {
-          this.warning("Reporting service disabled. Go to Settings > Extensions to enable it.")
+          this.warning("Reporting service disabled.")
         }
       } catch (error) {
         console.error(error)

--- a/SplunkAppForWazuh/default/app.conf
+++ b/SplunkAppForWazuh/default/app.conf
@@ -3,7 +3,7 @@ is_visible = 1
 label = Wazuh
 
 [launcher]
-version = 3.8.2
+version = 3.9.0
 author = info@wazuh.com
 description = Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level.
 

--- a/SplunkAppForWazuh/default/config.conf
+++ b/SplunkAppForWazuh/default/config.conf
@@ -8,3 +8,4 @@ osquery = false
 ciscat = false
 gdpr = true
 admin = true
+reporting = true

--- a/SplunkAppForWazuh/default/package.conf
+++ b/SplunkAppForWazuh/default/package.conf
@@ -1,9 +1,9 @@
 [app]
-version = 3.8.2
+version = 3.9.0
 revision = 22
 
 [wazuh]
-version = 3.8.2
+version = 3.9.0
 
 [splunk]
-version = 7.2.3
+version = 7.2.4

--- a/SplunkAppForWazuh/default/package.conf
+++ b/SplunkAppForWazuh/default/package.conf
@@ -1,6 +1,6 @@
 [app]
 version = 3.9.0
-revision = 22
+revision = 23
 
 [wazuh]
 version = 3.9.0

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wazuh-splunk",
-  "version": "3.8.2",
-  "revision": "22",
-  "code": "22-0",
+  "version": "3.9.0",
+  "revision": "23",
+  "code": "23-0",
   "description": "Splunk app for Wazuh",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Hi team,

This PR adds the capability to disable the reporting. 

By default the reporting is enabled. If it's necessary to disable it, we need to change the file **config.conf** on the Wazuh App for Splunk and set to false:

```
[extensions]
aws = false
virustotal = false
pci = true
oscap = false
audit = true
osquery = false
ciscat = false
gdpr = true
admin = true
reporting = false
```

**Reporting only can be enabled or disabled editing this file.**

Related issue: https://github.com/wazuh/wazuh-splunk/issues/579
Regards,