### PR TITLE
Set browser time zone to report and fix search time range 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
     ).
 - Restart agents ([#556](https://github.com/wazuh/wazuh-splunk/pull/556)).
 - Discover function on each section ([#529](https://github.com/wazuh/wazuh-splunk/pull/529)).
-- Can pined filters ([#529](https://github.com/wazuh/wazuh-splunk/pull/529)).
+- Can pined filters (
+    [#529](https://github.com/wazuh/wazuh-splunk/pull/529)
+    [#618](https://github.com/wazuh/wazuh-splunk/pull/618)).
 - Expand visualizations on the dashboard ([#570](https://github.com/wazuh/wazuh-splunk/pull/570)).
-- Reporting as extension ([#585](https://github.com/wazuh/wazuh-splunk/pull/585)).
+- Reporting as admin extension ([#585](https://github.com/wazuh/wazuh-splunk/pull/585)).
 - Delete rules, decoders and CDB lists files ([#589](https://github.com/wazuh/wazuh-splunk/pull/589)).
 - Prevent overwrite a existing file ([#589](https://github.com/wazuh/wazuh-splunk/pull/589)).
 - Unescape back slash for JSON raw content ([#599](https://github.com/wazuh/wazuh-splunk/pull/599)).
@@ -49,6 +51,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
     [#614](https://github.com/wazuh/wazuh-splunk/pull/614)
     ).
 - Cabability to expand visualizations ([#567](https://github.com/wazuh/wazuh-splunk/pull/567)).
+- Set the browser time zone to the report ([#619](https://github.com/wazuh/wazuh-splunk/pull/619)).
 
 
 ### Changed

--- a/SplunkAppForWazuh/appserver/controllers/report.py
+++ b/SplunkAppForWazuh/appserver/controllers/report.py
@@ -107,7 +107,6 @@ class report(controllers.BaseController):
             clean_images = jsonbak.dumps(data['images'])
             clean_images.replace("'", "\"")
             data['images'] = jsonbak.loads(clean_images)
-            today = datetime.datetime.now().strftime('%Y.%m.%d %H:%M')
             report_id = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
             #Get filters and other information
             filters = data['queryFilters']
@@ -116,6 +115,9 @@ class report(controllers.BaseController):
             section_title = data['sectionTitle']
             metrics = data['metrics']
             tables = data['tableResults']
+            time_diff = data['timeZone']
+            today = datetime.datetime.utcnow() - datetime.timedelta(minutes=time_diff)
+            today = today.strftime('%Y.%m.%d %H:%M')
             if metrics:
                 metrics = jsonbak.loads(metrics)
             agent_data = data['isAgents']

--- a/SplunkAppForWazuh/appserver/controllers/report.py
+++ b/SplunkAppForWazuh/appserver/controllers/report.py
@@ -142,9 +142,11 @@ class report(controllers.BaseController):
                 pdf.set_fill_color(93, 188, 210)
                 pdf.set_text_color(255,255,255)
                 pdf.set_font('Arial', '', 10)
-                pdf.cell(0, 5, ' Search time range: ' + time_range , 0, 0, 'L', 1)
-                pdf.ln(5)
-                pdf.cell(0, 5, ' Filters:' + filters , 0, 0, 'L', 1)
+                if time_range:
+                    pdf.cell(0, 5, ' Search time range: ' + time_range , 0, 0, 'L', 1)
+                    pdf.ln(5)
+                if filters:
+                    pdf.cell(0, 5, ' Filters:' + filters , 0, 0, 'L', 1)
             #Check if is agent, print agent info
             if agent_data and agent_data != 'inventory':
                 self.print_agent_info(agent_data, pdf)

--- a/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
@@ -86,6 +86,7 @@ define(['../module', 'jquery'], function(module, $) {
                 .getElementsByTagName('span')[1].innerHTML
             : ' '
 
+          const timeZone = new Date().getTimezoneOffset()
           const data = {
             images,
             tableResults,
@@ -101,7 +102,8 @@ define(['../module', 'jquery'], function(module, $) {
             tables: appliedFilters.tables,
             pdfName: tab,
             section: isAgents ? 'agents' : 'overview',
-            isAgents
+            isAgents,
+            timeZone
           }
           await this.genericReq('POST', '/report/generate', {
             data: JSON.stringify(data)
@@ -240,6 +242,8 @@ define(['../module', 'jquery'], function(module, $) {
           const packagesTable = { fields: packagesKeys, rows: packagesData }
           tableResults['Packages'] = packagesTable
 
+          const timeZone = new Date().getTimezoneOffset()
+
           const data = {
             images: [],
             tableResults,
@@ -248,7 +252,8 @@ define(['../module', 'jquery'], function(module, $) {
             queryFilters: '',
             metrics: {},
             pdfName: 'agents-inventory',
-            isAgents
+            isAgents,
+            timeZone
           }
 
           await this.genericReq('POST', '/report/generate', {

--- a/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
@@ -1,4 +1,4 @@
-define(['../module', 'jquery'], function (module, $) {
+define(['../module', 'jquery'], function(module, $) {
   'use strict'
   class ReportingService {
     constructor(
@@ -42,13 +42,24 @@ define(['../module', 'jquery'], function (module, $) {
      */
     betweenDates() {
       try {
-        let { earliest_time, latest_time } = JSON.parse(localStorage.getItem('searchTimeRange'))
+        let { earliest_time, latest_time } = JSON.parse(
+          localStorage.getItem('searchTimeRange')
+        )
         earliest_time = parseFloat(earliest_time)
         latest_time = parseFloat(latest_time)
-        if (isNaN(earliest_time) || !earliest_time || isNaN(latest_time) || !latest_time) {
+        if (
+          isNaN(earliest_time) ||
+          !earliest_time ||
+          isNaN(latest_time) ||
+          !latest_time
+        ) {
           return false
         }
-        if ((Number.isInteger(earliest_time) || this.isFloat(earliest_time) && Number.isInteger(latest_time) || this.isFloat(latest_time))) {
+        if (
+          Number.isInteger(earliest_time) ||
+          (this.isFloat(earliest_time) && Number.isInteger(latest_time)) ||
+          this.isFloat(latest_time)
+        ) {
           return this.formatBetweenDates(earliest_time, latest_time)
         }
       } catch (error) {
@@ -61,7 +72,7 @@ define(['../module', 'jquery'], function (module, $) {
      */
     formatBetweenDates(earliest, latest) {
       try {
-        //Remove milliseconds and multiply per 1000 to get a milliseconds date format 
+        //Remove milliseconds and multiply per 1000 to get a milliseconds date format
         earliest = Math.trunc(earliest) * 1000
         latest = Math.trunc(latest) * 1000
         const eDate = this.formatDate(earliest)
@@ -75,16 +86,19 @@ define(['../module', 'jquery'], function (module, $) {
     /**
      * Formats dates in YYYY-MM-DD HH:MM:SS format
      */
-    formatDate(date){
+    formatDate(date) {
       try {
         const d = new Date(date)
         const year = d.getFullYear()
-        const month = ((d.getMonth() + 1) < 10 ? `0${(d.getMonth() + 1)}` : (d.getMonth() + 1))
+        const month =
+          d.getMonth() + 1 < 10 ? `0${d.getMonth() + 1}` : d.getMonth() + 1
         const day = d.getDate() < 10 ? `0${d.getDate()}` : d.getDate()
         const hour = d.getHours() < 10 ? `0${d.getHours()}` : d.getHours()
-        const minute = d.getMinutes() < 10 ? `0${d.getMinutes()}` : d.getMinutes()
-        const second = d.getSeconds() < 10 ? `0${d.getSeconds()}` : d.getSeconds()
-        const dateFormatted = `${year}-${month}-${day} ${hour}:${minute}:${second}` 
+        const minute =
+          d.getMinutes() < 10 ? `0${d.getMinutes()}` : d.getMinutes()
+        const second =
+          d.getSeconds() < 10 ? `0${d.getSeconds()}` : d.getSeconds()
+        const dateFormatted = `${year}-${month}-${day} ${hour}:${minute}:${second}`
         return dateFormatted
       } catch (error) {
         return date
@@ -136,15 +150,17 @@ define(['../module', 'jquery'], function (module, $) {
           const images = await this.vis2png.checkArray(vizz)
           const name = `wazuh-${
             isAgents ? 'agents' : 'overview'
-            }-${tab}-${(Date.now() / 1000) | 0}.pdf`
+          }-${tab}-${(Date.now() / 1000) | 0}.pdf`
 
           let timeRange
 
           //Search time range
           try {
-            timeRange = this.betweenDates() || 
-            document.getElementById('timePicker')
-              .getElementsByTagName('span')[1].innerHTML
+            timeRange =
+              this.betweenDates() ||
+              document
+                .getElementById('timePicker')
+                .getElementsByTagName('span')[1].innerHTML
           } catch (error) {
             timeRange = false
           }
@@ -211,7 +227,17 @@ define(['../module', 'jquery'], function (module, $) {
             ])
 
             const agentInfo = agent[0].data.data
-            const { name, id, ip, version, manager, os, dateAdd, lastKeepAlive, group } = agentInfo
+            const {
+              name,
+              id,
+              ip,
+              version,
+              manager,
+              os,
+              dateAdd,
+              lastKeepAlive,
+              group
+            } = agentInfo
 
             isAgents = {
               ID: id,

--- a/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/reporting/reportingService.js
@@ -77,14 +77,16 @@ define(['../module', 'jquery'], function(module, $) {
             isAgents ? 'agents' : 'overview'
           }-${tab}-${(Date.now() / 1000) | 0}.pdf`
 
+          let timeRange
+
           //Search time range
-          const timeRange = document
+          try {
+          timeRange = document
             .getElementById('timePicker')
             .getElementsByTagName('span')[1].innerHTML
-            ? document
-                .getElementById('timePicker')
-                .getElementsByTagName('span')[1].innerHTML
-            : ' '
+          } catch (error) {
+            timeRange = false
+          }
 
           const timeZone = new Date().getTimezoneOffset()
           const data = {
@@ -247,7 +249,7 @@ define(['../module', 'jquery'], function(module, $) {
           const data = {
             images: [],
             tableResults,
-            timeRange: '',
+            timeRange: false,
             sectionTitle: 'Inventory Data',
             queryFilters: '',
             metrics: {},

--- a/SplunkAppForWazuh/appserver/static/js/services/visualizations/inputs/time-picker.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/visualizations/inputs/time-picker.js
@@ -25,6 +25,9 @@ define(['splunkjs/mvc', 'splunkjs/mvc/simpleform/input/timerange'], function(
       ).render()
       this.handleValueChange = handleValueChange
       this.input.on('change', newValue => {
+        try {
+          localStorage.setItem('searchTimeRange', JSON.stringify(newValue))
+        } catch (error) {}
         if (newValue && this.input) this.handleValueChange(this.input)
       })
     }


### PR DESCRIPTION
Hi team,

This PR implements the capability to send the browser time zone to the backend for generates the report with this time zone.

Also, when the search time range was between two dates, the report showed `Between dates`, now shows the dates in this format: `yyyy-MM-dd hh:mm:ss - yyyy-MM-dd hh:mm:ss`.

Solves this issue: https://github.com/wazuh/wazuh-splunk/issues/617

Regards,