### PR TITLE
Fix auth for polling agents state

### DIFF
--- a/SplunkAppForWazuh/default/inputs.conf
+++ b/SplunkAppForWazuh/default/inputs.conf
@@ -6,3 +6,4 @@ disabled = false
 index = wazuh-monitoring-3x
 interval = 0 * * * *
 sourcetype = _json
+passAuth = splunk-system-user


### PR DESCRIPTION
Hi team,

This PR fixes the `inputs.conf` file now includes the necessary parameter to get the authentication key for consulting the Splunk kvStore.

Regards,