### PR TITLE
Do not show pagination for one page tables

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb-id.html
@@ -144,7 +144,7 @@
             <tfoot>
               <td colspan="3">
                 <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items</span>
-                <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+                <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
                   <ul layout="row">
 
                     <li ng-show="currentPage > 0" class="md-padding">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
@@ -187,7 +187,7 @@
             <tfoot>
               <td colspan="3">
                 <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items</span>
-                <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+                <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
                   <ul layout="row">
                     <li ng-show="currentPage" class="md-padding">
                       <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-data-table/wz-data-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-data-table/wz-data-table.html
@@ -27,7 +27,7 @@
     <tfoot>
       <td colspan="{{keys.length}}">
         <span ng-show="!wazuh_table_loading" class="color-grey">{{ totalItems }} items</span>
-        <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+        <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
           <ul layout="row">
             <li ng-show="currentPage" class="md-padding">
               <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
@@ -330,7 +330,7 @@
     <tbody>
       <tr ng-class="allowClick ? 'cursor-pointer' : ''" class="wz-word-wrap"
         ng-repeat-start="item in pagedItems[currentPage] | filter:{item:'!'}" ng-click="expandItem(item)">
-        <td ng-repeat="key in keys | filter: showKey">
+        <td class="wz-text-truncatable-ellipsis" ng-repeat="key in keys | filter: showKey">
           <span>
             {{
             parseValue(key,item)

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
@@ -198,7 +198,7 @@
         colspan="{{ (path === '/agents' || (path === '/agents/groups' && adminMode) || (path === '/rules/files' || path === '/decoders/files' || path === '/lists/files') || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
         <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
           seconds)</span>
-        <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+        <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
           <ul layout="row">
             <li ng-show="currentPage > 0" class="md-padding">
               <a href ng-click="firstPage()">First</a>
@@ -286,7 +286,7 @@
         colspan="{{ (path === '/agents' || (path === '/agents/groups' && adminMode) || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
         <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
           seconds)</span>
-        <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+        <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
           <ul layout="row">
             <li ng-show="currentPage > 0" class="md-padding">
               <a href ng-click="firstPage()">First</a>
@@ -359,7 +359,7 @@
         colspan="{{ (path === '/agents' || (path === '/agents/groups' && adminMode) || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
         <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
           seconds)</span>
-        <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+        <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
           <ul layout="row">
             <li ng-show="currentPage > 0" class="md-padding">
               <a href ng-click="firstPage()">First</a>


### PR DESCRIPTION
Hi team, 

This PR implements the required fixes for these issues:
- Do not show pagination for one page tables https://github.com/wazuh/wazuh-splunk/issues/659
- FIM files table is broken for Windows agents https://github.com/wazuh/wazuh-splunk/issues/660

Regards,