### PR TITLE
3.9.1 fixes

### DIFF
--- a/SplunkAppForWazuh/appserver/static/css/styles/common.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/common.css
@@ -1843,3 +1843,7 @@ label.wz-icon-loupe  input {
 .md-sidenav {
   background-color: #fafafa;
 }
+
+.md-sidenav-right {
+  background-color: #fafafa !important;
+}

--- a/SplunkAppForWazuh/appserver/static/css/styles/common.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/common.css
@@ -1656,6 +1656,10 @@ input:focus {
   color: #1278b0 !important;
 }
 
+.formatted-log {
+  margin: -10px 10px;
+}
+
 .switch-log {
   margin: 5px 10px;
 }

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
@@ -66,7 +66,6 @@ define(['../../module', 'FileSaver'], function(module) {
      */
     $onInit() {
       try {
-        this.setBrowserOffset('2019/04/24 10:59:03')
         this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
         this.scope.hasSize = obj =>
           obj && typeof obj === 'object' && Object.keys(obj).length

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/manager-logs.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/manager-logs.html
@@ -115,7 +115,7 @@
 
 <div layout="row" class="wz-margin-right-20">
   <span flex></span>
-  <a class="small formatted-color" id="btnDownload" ng-click="downloadCsv()">
+  <a class="small formatted-color formatted-log" id="btnDownload" ng-click="downloadCsv()">
     <wz-svg icon="download"></wz-svg>&nbsp;Formatted
   </a>
 </div>


### PR DESCRIPTION
Hi team,

This PR solves the found problems while testing this issue checks https://github.com/wazuh/wazuh-splunk/issues/706.

- **Manager/Agents configuration**: When clicking on help, the displayed div has a different background color, this break the aesthetics of the app.
- **Ensure "dynamic height" for editors is working as expected**: *Manager > Logs* section has a `formatted` button that provokes that the page shows a little scroll.
- Remove useless code line in `inventoryCtrl.js` -> `this.setBrowserOffset('2019/04/24 10:59:03')`

Regards,