### PR TITLE
Fix error when adding an api with invalid fields format

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/api/settingsApiCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/api/settingsApiCtrl.js
@@ -279,7 +279,7 @@ define(['../../module'], function(controllers) {
         if (!this.scope.$$phase) this.scope.$digest()
         this.notification.showSuccessToast('New API was added')
       } catch (err) {
-        if (err.startsWith('Unexpected Wazuh version')) {
+        if (typeof err === 'string' && err.startsWith('Unexpected Wazuh version')) {
           this.scope.validatingError.push(err)
         } else {
           this.notification.showErrorToast(err.message || err || 'Cannot save the API.')


### PR DESCRIPTION
Hi team,

This PR solves an error when we tried to add an api with invalid fields format and we were forced to refresh the page: https://github.com/wazuh/wazuh-splunk/issues/728

Regards,