### PR TITLE
Fix admin mode

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/config/routes/management-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/management-states.js
@@ -129,6 +129,16 @@ define(['../module'], function(module) {
                   return false
                 }
               }
+            ],
+            isAdmin: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  return await $currentDataService.isAdmin()
+                } catch (error) {
+                  return false
+                }
+              }
             ]
           }
         })
@@ -187,6 +197,16 @@ define(['../module'], function(module) {
                 try {
                   return await $currentDataService.getCurrentExtensions()
                 } catch (err) {
+                  return false
+                }
+              }
+            ],
+            isAdmin: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  return await $currentDataService.isAdmin()
+                } catch (error) {
                   return false
                 }
               }
@@ -279,6 +299,16 @@ define(['../module'], function(module) {
                 try {
                   return await $currentDataService.getCurrentExtensions()
                 } catch (err) {
+                  return false
+                }
+              }
+            ],
+            isAdmin: [
+              '$currentDataService',
+              async $currentDataService => {
+                try {
+                  return await $currentDataService.isAdmin()
+                } catch (error) {
                   return false
                 }
               }

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/management-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/management-states.js
@@ -1,10 +1,18 @@
-define(['../module'], function(module) {
+define(['../module'], function (module) {
   'use strict'
+
+  const checkAdmin = async $currentDataService => {
+    try {
+      return await $currentDataService.isAdmin()
+    } catch (error) {
+      return false
+    }
+  }
 
   module.config([
     '$stateProvider',
     'BASE_URL',
-    function($stateProvider, BASE_URL) {
+    function ($stateProvider, BASE_URL) {
       $stateProvider
         // Manager
         .state('manager', {
@@ -84,13 +92,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ]
           }
         })
@@ -132,13 +134,7 @@ define(['../module'], function(module) {
             ],
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ]
           }
         })
@@ -155,13 +151,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ]
           }
         })
@@ -203,13 +193,7 @@ define(['../module'], function(module) {
             ],
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ]
           }
         })
@@ -227,13 +211,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ]
           }
         })
@@ -251,13 +229,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ],
             cdbInfo: [
               '$cdbEditor',
@@ -305,13 +277,7 @@ define(['../module'], function(module) {
             ],
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ]
           }
         })
@@ -328,13 +294,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ],
             clusterInfo: [
               '$requestService',
@@ -380,13 +340,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ],
             clusterInfo: [
               '$requestService',
@@ -432,13 +386,7 @@ define(['../module'], function(module) {
           resolve: {
             isAdmin: [
               '$currentDataService',
-              async $currentDataService => {
-                try {
-                  return await $currentDataService.isAdmin()
-                } catch (error) {
-                  return false
-                }
-              }
+              async $currentDataService => { return await checkAdmin($currentDataService) }
             ],
             statusData: [
               '$requestService',

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/managerDecodersIdCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/managerDecodersIdCtrl.js
@@ -25,7 +25,8 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
       extensions,
       $fileEditor,
       $restartService,
-      $requestService
+      $requestService,
+      isAdmin
     ) {
       super(
         $scope,
@@ -43,6 +44,7 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
       this.restartService = $restartService
       this.requestService = $requestService
       this.currentDecoder = currentDecoder
+      this.scope.adminMode = isAdmin
     }
 
     /**
@@ -59,7 +61,6 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
         this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
         this.scope.addDetailFilter = (name, value) =>
           this.addDetailFilter(name, value)
-        this.scope.adminMode = this.extensions['admin'] === 'true'
         this.scope.isLocal = this.scope.currentDecoder.path === 'etc/decoders'
         this.scope.saveDecoderConfig = fileName =>
           this.saveDecoderConfig(fileName)

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
@@ -24,7 +24,8 @@ define(['../../module', 'FileSaver'], function(controllers) {
       $beautifierJson,
       $notificationService,
       $groupHandler,
-      extensions
+      extensions,
+      isAdmin
     ) {
       this.scope = $scope
       this.state = $state
@@ -60,6 +61,7 @@ define(['../../module', 'FileSaver'], function(controllers) {
         }
       })
       this.extensions = extensions
+      this.scope.adminMode = isAdmin
       this.scope.addingGroup = false
       this.scope.addingAgents = false
       this.scope.$on('groupsIsReloaded', () => {
@@ -229,8 +231,6 @@ define(['../../module', 'FileSaver'], function(controllers) {
 
         this.scope.saveGroupAgentConfig = content =>
           this.saveGroupAgentConfig(content)
-
-        this.scope.adminMode = this.extensions['admin'] === 'true'
 
         this.scope.$applyAsync()
       } catch (err) {

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/managerRulesetIdCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/managerRulesetIdCtrl.js
@@ -26,7 +26,8 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
       extensions,
       $fileEditor,
       $restartService,
-      $requestService
+      $requestService, 
+      isAdmin
     ) {
       super(
         $scope,
@@ -43,6 +44,7 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
       this.fileEditor = $fileEditor
       this.restartService = $restartService
       this.requestService = $requestService
+      this.scope.adminMode = isAdmin
       try {
         this.filters = JSON.parse(window.localStorage.ruleset) || []
       } catch (err) {
@@ -72,7 +74,6 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
       this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
       this.scope.addDetailFilter = (name, value) =>
         this.addDetailFilter(name, value)
-      this.scope.adminMode = this.extensions['admin'] === 'true'
       this.scope.isLocal = this.scope.ruleInfo.path === 'etc/rules'
       this.scope.saveRuleConfig = fileName => this.saveRuleConfig(fileName)
       this.scope.closeEditingFile = () => this.closeEditingFile()


### PR DESCRIPTION
Hi team, 

This PR fixes https://github.com/wazuh/wazuh-splunk/issues/736.

The problem was that after update the `config.conf` file was created a new method to check if admin mode is enabled. Some controllers as `Groups`, `Ruleset` and `Decoders` were affected. 

I've implemented the correct way to check the admin mode in these controllers to solve this problem.

Regards,