### PR TITLE
Fix Agents > Inventory

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -409,7 +409,7 @@ class api(controllers.BaseController):
                 if not 'apiId' in kwargs:
                     return jsonbak.dumps(pci_requirements.pci)
                 the_id = kwargs['apiId']
-                url,auth,verify = self.get_credentials(the_id)
+                url,auth,verify,cluster_enabled = self.get_credentials(the_id)
                 opt_endpoint = '/rules/pci'
                 request = self.session.get(
                     url + opt_endpoint, params=kwargs, auth=auth,
@@ -445,7 +445,7 @@ class api(controllers.BaseController):
                 if not 'apiId' in kwargs:
                     return jsonbak.dumps(gdpr_requirements.gdpr)
                 the_id = kwargs['apiId']
-                url,auth,verify = self.get_credentials(the_id)
+                url,auth,verify,cluster_enabled = self.get_credentials(the_id)
                 opt_endpoint = '/rules/gdpr'
                 request = self.session.get(
                     url + opt_endpoint, params=kwargs, auth=auth,
@@ -468,4 +468,94 @@ class api(controllers.BaseController):
                 return jsonbak.dumps(result)
         except Exception as e:
             self.logger.error("Error getting PCI-DSS requirements: %s" % (str(e)))
+            return jsonbak.dumps({"error": str(e)})
+
+    """
+    Get basic syscollector information for a given agent.
+    """
+    @expose_page(must_login=False, methods=['GET'])
+    def getSyscollector(self, **kwargs):
+        try:
+            self.logger.info("Request to get basic syscollector information for a given agent")
+            if not 'apiId' in kwargs and not 'agentId' in kwargs:
+                raise Exception('Missing parameters.')
+            syscollectorData = {
+                'hardware' : False,
+                'os': False,
+                'netiface': False,
+                'ports': False,
+                'netaddr': False,
+                'packagesDate': False,
+                'processesDate': False
+            }
+            apiId = kwargs['apiId']
+            agentId = kwargs['agentId']
+            url,auth,verify,cluster_enabled = self.get_credentials(apiId)
+            # Hardware
+            endpoint_hardware = '/syscollector/' +  str(agentId) + '/hardware'
+            hardware_data = self.session.get(
+                    url + endpoint_hardware, params={}, auth=auth,
+                    verify=verify).json()
+            if 'error' in hardware_data and hardware_data['error'] == 0 and 'data' in hardware_data:
+                syscollectorData['hardware'] = hardware_data['data']
+            
+            # OS
+            endpoint_os = '/syscollector/' +  str(agentId) + '/os'
+            os_data = self.session.get(
+                    url + endpoint_os, params={}, auth=auth,
+                    verify=verify).json()
+            if 'error' in os_data and os_data['error'] == 0 and 'data' in os_data:
+                syscollectorData['os'] = os_data['data']
+            
+            # Ports
+            endpoint_ports = '/syscollector/' +  str(agentId) + '/ports'
+            ports_data = self.session.get(
+                    url + endpoint_ports, params={ 'limit' : 1 }, auth=auth,
+                    verify=verify).json()
+            if 'error' in ports_data and ports_data['error'] == 0 and 'data' in ports_data:
+                syscollectorData['ports'] = ports_data['data']
+
+            # Packages
+            endpoint_packages = '/syscollector/' +  str(agentId) + '/packages'
+            packages_data = self.session.get(
+                    url + endpoint_packages, params={ 'limit' : 1, 'select' : 'scan_time'}, auth=auth,
+                    verify=verify).json()
+            if 'error' in packages_data and packages_data['error'] == 0 and 'data' in packages_data:
+                if 'items' in packages_data['data'] and len(packages_data['data']['items']) > 0 and 'scan_time' in packages_data['data']['items'][0]:
+                    syscollectorData['packagesDate'] = packages_data['data']['items'][0]['scan_time']
+                else:
+                    syscollectorData['packagesDate'] = 'Unknown'
+
+            # Processes
+            endpoint_processes = '/syscollector/' +  str(agentId) + '/processes'
+            processes_data = self.session.get(
+                    url + endpoint_processes, params={ 'limit' : 1, 'select' : 'scan_time'}, auth=auth,
+                    verify=verify).json()
+            if 'error' in processes_data and processes_data['error'] == 0 and 'data' in processes_data:
+                if 'items' in processes_data['data'] and len(processes_data['data']['items']) > 0 and 'scan_time' in processes_data['data']['items'][0]:
+                    syscollectorData['processesDate'] = processes_data['data']['items'][0]['scan_time']
+                else:
+                    syscollectorData['processesDate'] = 'Unknown'
+
+            # Netiface
+            endpoint_netiface = '/syscollector/' +  str(agentId) + '/netiface'
+            netiface_data = self.session.get(
+                    url + endpoint_netiface, params={}, auth=auth,
+                    verify=verify).json()
+            if 'error' in netiface_data and netiface_data['error'] == 0 and 'data' in netiface_data:
+                syscollectorData['netiface'] = netiface_data['data']
+
+            # Netaddr
+            endpoint_netaddr = '/syscollector/' +  str(agentId) + '/netaddr'
+            netaddr_data = self.session.get(
+                    url + endpoint_netaddr, params={ 'limit' : 1 }, auth=auth,
+                    verify=verify).json()
+            if 'error' in netaddr_data and netaddr_data['error'] == 0 and 'data' in netaddr_data:
+                syscollectorData['netaddr'] = netaddr_data['data']
+
+
+
+            return jsonbak.dumps(syscollectorData)
+        except Exception as e:
+            self.logger.error("Error getting syscollector information for a given agent: %s" % (str(e)))
             return jsonbak.dumps({"error": str(e)})

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
@@ -1,10 +1,10 @@
-define(['../module'], function(module) {
+define(['../module'], function (module) {
   'use strict'
 
   module.config([
     '$stateProvider',
     'BASE_URL',
-    function($stateProvider, BASE_URL) {
+    function ($stateProvider, BASE_URL) {
       $stateProvider
 
         // agents
@@ -40,18 +40,18 @@ define(['../module'], function(module) {
                       select: 'version'
                     }),
                     responseStatus &&
-                    responseStatus.data &&
-                    responseStatus.data.data &&
-                    responseStatus.data.data.enabled === 'yes' &&
-                    responseStatus.data.data.running === 'yes'
+                      responseStatus.data &&
+                      responseStatus.data.data &&
+                      responseStatus.data.data.enabled === 'yes' &&
+                      responseStatus.data.data.running === 'yes'
                       ? $requestService.apiReq('/agents/stats/distinct', {
-                          fields: 'node_name',
-                          select: 'node_name'
-                        })
+                        fields: 'node_name',
+                        select: 'node_name'
+                      })
                       : Promise.resolve(false),
                     $requestService.apiReq('/agents/groups', {})
                   ])
-                } catch (err) {} //eslint-disable-line
+                } catch (err) { } //eslint-disable-line
               }
             ]
           }
@@ -172,6 +172,10 @@ define(['../module'], function(module) {
                     $requestService.apiReq(`/syscollector/${id}/processes`, {
                       limit: 1,
                       select: 'scan_time'
+                    }),
+                    $requestService.apiReq(`/syscollector/${id}/netiface`, {}),
+                    $requestService.apiReq(`/syscollector/${id}/netaddr`, {
+                      limit: 1
                     })
                   ])
                   return results

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
@@ -160,28 +160,11 @@ define(['../module'], function (module) {
                     $state.go('agents')
                   const apiId = $currentDataService.getApi()
                   const currentApi = apiId['_key']
-                  const output = await $requestService.httpReq('GET', `/api/getSyscollector?apiId=${currentApi}&agentId=${id}`)
-
                   const results = await Promise.all([
-                    $requestService.apiReq(`/syscollector/${id}/hardware`),
-                    $requestService.apiReq(`/syscollector/${id}/os`),
-                    $requestService.apiReq(`/syscollector/${id}/ports`, {
-                      limit: 1
-                    }),
-                    $requestService.apiReq(`/syscollector/${id}/packages`, {
-                      limit: 1,
-                      select: 'scan_time'
-                    }),
+                    $requestService.httpReq('GET', `/api/getSyscollector?apiId=${currentApi}&agentId=${id}`),
                     $requestService.apiReq(`/agents/${id}`),
-                    $requestService.apiReq(`/syscollector/${id}/processes`, {
-                      limit: 1,
-                      select: 'scan_time'
-                    }),
-                    $requestService.apiReq(`/syscollector/${id}/netiface`, {}),
-                    $requestService.apiReq(`/syscollector/${id}/netaddr`, {
-                      limit: 1
-                    })
                   ])
+                  
                   return results
                 } catch (err) {
                   $state.go('agents')

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
@@ -79,6 +79,7 @@
         <div flex>OS: <span class="wz-text-bold">{{ syscollector.os.os.name }} {{ syscollector.os.os.version }}</span>
         </div>
         <div flex>CPU: <span class="wz-text-bold">{{ syscollector.hardware.cpu.name }}</span></div>
+        <div flex>Last scan: <span class="wz-text-bold">{{ syscollector.os.scan.time }}</span></div>
       </md-card-content>
     </md-card>
   </div>
@@ -135,11 +136,10 @@
         </table>
       </md-card-content>
     </md-card>
-    <md-card flex class="wz-md-card">
+    <md-card flex class="wz-md-card" ng-if="agent && agent.os && agent.os.platform !== 'darwin'">
       <md-card-content class="wz-text-center wz-margin-bottom-40-inv"
         ng-if="syscollector.ports && !syscollector.ports.items.length">
-        <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No ports scan
-          available</span>
+        <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No network ports information available</span>
       </md-card-content>
       <md-card-content class="wz-margin-bottom-40-inv" ng-if="syscollector.ports && syscollector.ports.items.length">
         <span class="wz-headline-title"><i class="fa fa-fw fa-exchange"></i> Network ports</span>
@@ -150,7 +150,7 @@
           path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]"
           keys="[{value:'process',nosortable:true},{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
         </wazuh-table>
-        <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'"
+        <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows' && agent.os.platform !== 'darwin'"
           path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]"
           keys="[{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
         </wazuh-table>
@@ -164,7 +164,7 @@
       <md-card-content class="wz-text-center"
         ng-if="!syscollector.netaddr || !syscollector.netaddr.items || !syscollector.netaddr.items.length">
         <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No network
-          addresses scan available</span>
+          addresses information available</span>
       </md-card-content>
       <md-card-content class="wz-margin-bottom-40-inv"
         ng-if="syscollector.netaddr && syscollector.netaddr.items.length">
@@ -178,7 +178,7 @@
   </div>
 
   <div layout="row" class="layout-padding wz-padding-top-0"
-    ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
+    ng-if="agent && agent.status === 'Active' && hasSize(syscollector) && agent.os && agent.os.platform !== 'darwin'">
     <md-card flex class="wz-md-card">
       <md-card-content>
         <span class="wz-headline-title"><i class="fa fa-fw fa-terminal"></i> Processes</span>
@@ -237,9 +237,13 @@
         </div>
 
         <div layout="row" ng-if="agent && syscollector" class="wz-margin-top-10 wz-margin-bottom-40-inv">
-          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'"
+          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows' && agent.os.platform !== 'darwin'"
             path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"
             keys="[{value:'name',size:2},'architecture','version',{value:'vendor',size:2},{value:'description',size:3}]">
+          </wazuh-table>
+          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'darwin'"
+            path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"
+            keys="[{value:'name',size:3},'architecture','version',{value:'vendor',size:2}]">
           </wazuh-table>
           <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'"
             path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
@@ -144,7 +144,7 @@
       <md-card-content class="wz-margin-bottom-40-inv" ng-if="syscollector.ports && syscollector.ports.items.length">
         <span class="wz-headline-title"><i class="fa fa-fw fa-exchange"></i> Network ports</span>
         <span class="color-grey pull-right">Last scan:
-          {{setBrowserOffset(syscollector.ports.items[0].scan_time)}}</span>
+          {{setBrowserOffset(syscollector.ports.items[0].scan.time)}}</span>
         <md-divider class="wz-margin-top-10"></md-divider>
         <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'"
           path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
@@ -243,7 +243,7 @@
           </wazuh-table>
           <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'darwin'"
             path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"
-            keys="[{value:'name',size:3},'architecture','version',{value:'vendor',size:2}]">
+            keys="[{value:'name',size:3},'version','format',{value:'location',size:2}]">
           </wazuh-table>
           <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'"
             path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
@@ -4,36 +4,41 @@
     <div class='wz-breadcrumb-margin'>
       <a class="wz-text-link cursor-pointer" ui-sref='agents'>Agents</a>
       <span> / </span>
-      <span ng-if="!agent.error" ui-sref='agent-overview({id:agent.id})' class="wz-text-link cursor-pointer">{{agent.name}}
+      <span ng-if="!agent.error" ui-sref='agent-overview({id:agent.id})'
+        class="wz-text-link cursor-pointer">{{agent.name}}
         ({{agent.id}})</span>
       <span ng-if="agent.error">Unknown agent</span>
       <span> / </span>
       <span>Inventory data</span>
       <span ng-if="agent && agent.status">
-        <span class="wz-agent-status-indicator small" ng-class="getAgentStatusClass(agent.status)" aria-label="Agent status indicator">{{formatAgentStatus(agent.status)}}</span>
+        <span class="wz-agent-status-indicator small" ng-class="getAgentStatusClass(agent.status)"
+          aria-label="Agent status indicator">{{formatAgentStatus(agent.status)}}</span>
       </span>
     </div>
     <span flex class="flex"></span>
     <!-- Report button -->
-    <button  ng-if="reportingEnabled" ng-disabled="loadingReporting" md-no-ink class="btn wz-button-empty wz-button-report" ng-click="startVis2Png()" aria-label="Generate report button">
+    <button ng-if="reportingEnabled" ng-disabled="loadingReporting" md-no-ink
+      class="btn wz-button-empty wz-button-report" ng-click="startVis2Png()" aria-label="Generate report button">
       <i class="fa fa-fw fa-print" aria-hidden="true"></i>
       <md-tooltip md-direction="left" class="wz-tooltip">
         Generate report
-      </md-tooltip>      
+      </md-tooltip>
     </button>
   </div>
 
   <!-- Loading report-->
   <div align='center' ng-if='loadingReporting'>Generating PDF document...<br><i class="fa fa-fw fa-spin fa-spinner"
-    aria-hidden="true"></i></div>
-  
+      aria-hidden="true"></i></div>
+
 
   <!-- Security information management navbar -->
   <md-nav-bar class="wz-nav-bar wz-margin-10 no-margin-left" md-selected-nav-item="'inventory'">
-    <md-nav-item class="wz-nav-item" md-nav-click="stopPropagation()" ui-sref="ag-general" name="general">Security events</md-nav-item>
-    <md-nav-item class="wz-nav-item" md-nav-click="stopPropagation()" ui-sref="ag-fim" name="fim">Integrity monitoring</md-nav-item>
+    <md-nav-item class="wz-nav-item" md-nav-click="stopPropagation()" ui-sref="ag-general" name="general">Security
+      events</md-nav-item>
+    <md-nav-item class="wz-nav-item" md-nav-click="stopPropagation()" ui-sref="ag-fim" name="fim">Integrity monitoring
+    </md-nav-item>
     <md-nav-item class="wz-nav-item" md-nav-click="stopPropagation()" name="inventory">Inventory data</md-nav-item>
-  </md-nav-bar>  
+  </md-nav-bar>
 
   <div layout="row" class="layout-padding" ng-if="agent && agent.status !== 'Active'">
     <md-card flex class="wz-md-card" flex>
@@ -53,7 +58,8 @@
     </md-card>
   </div>
 
-  <div layout="row" class="layout-padding wz-padding-bottom-0" ng-if="agent && agent.status === 'Active' && hasSize(syscollector) && (!hasSize(syscollector.hardware) || !hasSize(syscollector.os))">
+  <div layout="row" class="layout-padding wz-padding-bottom-0"
+    ng-if="agent && agent.status === 'Active' && hasSize(syscollector) && (!hasSize(syscollector.hardware) || !hasSize(syscollector.os))">
     <md-card flex class="wz-md-card" flex>
       <md-card-content class="wz-text-center">
         <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">Not enough
@@ -62,96 +68,33 @@
     </md-card>
   </div>
 
-  <div layout="row" class="inventory-metrics wz-margin-9" ng-if="agent && agent.status === 'Active' && hasSize(syscollector) && hasSize(syscollector.hardware) && hasSize(syscollector.os)">
+  <div layout="row" class="inventory-metrics wz-margin-9"
+    ng-if="agent && agent.status === 'Active' && hasSize(syscollector) && hasSize(syscollector.hardware) && hasSize(syscollector.os)">
     <md-card flex class="wz-metric-color">
       <md-card-content layout="row" class="wz-padding-metric">
         <div flex="10">Cores: <span class="wz-text-bold">{{ syscollector.hardware.cpu.cores }}</span></div>
         <div flex="15">Memory: <span class="wz-text-bold">{{ (syscollector.hardware.ram.total / 1024) | number: 2 }}
             MB</span></div>
         <div flex="10">Arch: <span class="wz-text-bold">{{ syscollector.os.architecture }}</span></div>
-        <div flex>OS: <span class="wz-text-bold">{{ syscollector.os.os.name }} {{ syscollector.os.os.version }}</span></div>
+        <div flex>OS: <span class="wz-text-bold">{{ syscollector.os.os.name }} {{ syscollector.os.os.version }}</span>
+        </div>
         <div flex>CPU: <span class="wz-text-bold">{{ syscollector.hardware.cpu.name }}</span></div>
       </md-card-content>
     </md-card>
   </div>
 
-  <div layout="row" class="layout-padding wz-padding-top-0" ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
+  <div layout="row" class="layout-padding wz-padding-bottom-0"
+    ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
     <md-card flex class="wz-md-card">
-      <md-card-content>
-        <span class="wz-headline-title"><i class="fa fa-fw fa-cubes"></i> Packages</span>
-        <span class="color-grey pull-right">Last scan: {{setBrowserOffset(syscollector.packagesDate)}}</span>
-        <md-divider class="wz-margin-top-10"></md-divider>
-        <div layout="row" class="wz-margin-top-10">
-          <label class="wz-icon-loupe" style="margin-bottom: -16px;">
-            <input placeholder="Filter packages..." ng-model="packageSearch" type="text" class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid height-30 wz-width-100"
-              aria-invalid="false" wz-enter="search(packageSearch,'packages')">
-          </label>
-          <button type="submit" aria-label="Search" class="btn height-30 wz-button-empty wz-margin-left-10" ng-click="search(packageSearch,'packages')">
-              <span>Search</span>
-          </button>
-        </div>
-
-        <div layout="row" ng-if="agent && syscollector" class="wz-margin-top-10 wz-margin-bottom-40-inv">
-          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'" path="'/syscollector/' + agent.id + '/packages'"
-            row-sizes="[10,8,6]" extra-limit="100" keys="[{value:'name',size:2},'architecture','version',{value:'vendor',size:2},{value:'description',size:3}]">
-          </wazuh-table>
-          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'" path="'/syscollector/' + agent.id + '/packages'"
-            row-sizes="[10,8,6]" extra-limit="100" keys="[{value:'name',size:3},'architecture','version',{value:'vendor',size:2}]">
-          </wazuh-table>
-        </div>
-      </md-card-content>
-      <div layout="row" class="ruleset-csv-formater formatted-div-inventory">
-        <span flex></span>
-          <a class="small formatted-color" id="btnDownload" ng-click="downloadCsv('/syscollector/' + agent.id + '/packages', 'agent-' + agent.id + '-packages.csv')">
-            <wz-svg icon="download"></wz-svg>&nbsp;Formatted
-        </a>
-      </div>
-    </md-card>
-  </div>
-
-  <div layout="row" class="layout-padding wz-padding-top-0" ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
-    <md-card flex class="wz-md-card">
-      <md-card-content>
-        <span class="wz-headline-title"><i class="fa fa-fw fa-terminal"></i> Processes</span>
-        <span class="color-grey pull-right">Last scan: {{setBrowserOffset(syscollector.processesDate)}}</span>
-        <md-divider class="wz-margin-top-10"></md-divider>
-        <div layout="row" class="wz-margin-top-10">
-          <label class="wz-icon-loupe" style="margin-bottom: -16px;">
-            <input placeholder="Filter processes..." ng-model="processSearch" type="text" class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid height-30 wz-width-100"
-              aria-invalid="false" wz-enter="search(processSearch,'processes')">
-          </label>
-          <button type="submit" aria-label="Search" class="btn height-30 wz-button-empty wz-margin-left-10" ng-click="search(processSearch,'processes')">
-              <span>Search</span>
-          </button>
-        </div>
-        <div layout="row" ng-if="agent && syscollector" class="wz-margin-top-10 wz-margin-bottom-40-inv">
-          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'" path="'/syscollector/' + agent.id + '/processes'"
-            row-sizes="[10,8,6]" extra-limit="100" keys="['name','cmd','priority','nlwp']">
-          </wazuh-table>
-          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'" path="'/syscollector/' + agent.id + '/processes'"
-            row-sizes="[10,8,6]" extra-limit="100" keys="['name','euser','nice','state']">
-          </wazuh-table>
-        </div>
-      </md-card-content>
-      <div layout="row" class="ruleset-csv-formater formatted-div-inventory">
-        <span flex></span>
-          
-        <a class="small formatted-color" id="btnDownload" ng-click="downloadCsv('/syscollector/' + agent.id + '/processes', 'agent-' + agent.id + '-processes.csv')">
-          <wz-svg icon="download"></wz-svg>&nbsp;Formatted
-        </a>
-      </div>
-    </md-card>
-  </div>
-
-  <div layout="row" class="layout-padding wz-padding-bottom-0" ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
-    <md-card flex class="wz-md-card">
-      <md-card-content class="wz-text-center" ng-if="!syscollector.netiface || !syscollector.netiface.items || !syscollector.netiface.items.length">
+      <md-card-content class="wz-text-center"
+        ng-if="!syscollector.netiface || !syscollector.netiface.items || !syscollector.netiface.items.length">
         <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No interfaces scan
           available</span>
       </md-card-content>
       <md-card-content ng-if="syscollector.netiface && syscollector.netiface.items.length">
         <span class="wz-headline-title"><i class="fa fa-fw fa-sitemap"></i> Network interfaces</span>
-        <span class="color-grey pull-right">Last scan: {{setBrowserOffset(syscollector.netiface.items[0].scan.time)}}</span>
+        <span class="color-grey pull-right">Last scan:
+          {{setBrowserOffset(syscollector.netiface.items[0].scan.time)}}</span>
         <md-divider class="wz-margin-top-10"></md-divider>
 
         <table class="table table-striped table-condensed table-layout-fixed">
@@ -193,36 +136,124 @@
       </md-card-content>
     </md-card>
     <md-card flex class="wz-md-card">
-      <md-card-content class="wz-text-center wz-margin-bottom-40-inv" ng-if="syscollector.ports && !syscollector.ports.items.length">
+      <md-card-content class="wz-text-center wz-margin-bottom-40-inv"
+        ng-if="syscollector.ports && !syscollector.ports.items.length">
         <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No ports scan
           available</span>
       </md-card-content>
       <md-card-content class="wz-margin-bottom-40-inv" ng-if="syscollector.ports && syscollector.ports.items.length">
         <span class="wz-headline-title"><i class="fa fa-fw fa-exchange"></i> Network ports</span>
-        <span class="color-grey pull-right">Last scan: {{setBrowserOffset(syscollector.ports.items[0].scan_time)}}</span>
+        <span class="color-grey pull-right">Last scan:
+          {{setBrowserOffset(syscollector.ports.items[0].scan_time)}}</span>
         <md-divider class="wz-margin-top-10"></md-divider>
-        <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'" path="'/syscollector/' + agent.id + '/ports'"
-          row-sizes="[4]" keys="[{value:'process',nosortable:true},{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
+        <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'"
+          path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]"
+          keys="[{value:'process',nosortable:true},{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
         </wazuh-table>
-        <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'" path="'/syscollector/' + agent.id + '/ports'"
-          row-sizes="[4]" keys="[{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
+        <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'"
+          path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]"
+          keys="[{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
         </wazuh-table>
       </md-card-content>
     </md-card>
   </div>
 
-  <div layout="row" class="layout-padding wz-padding-top-0" ng-if="agent && agent.status === 'Active' && !agent.error && syscollector">
+  <div layout="row" class="layout-padding wz-padding-top-0"
+    ng-if="agent && agent.status === 'Active' && !agent.error && syscollector">
     <md-card flex class="wz-md-card">
-      <md-card-content class="wz-text-center" ng-if="!syscollector.netaddr || !syscollector.netaddr.items || !syscollector.netaddr.items.length">
+      <md-card-content class="wz-text-center"
+        ng-if="!syscollector.netaddr || !syscollector.netaddr.items || !syscollector.netaddr.items.length">
         <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No network
           addresses scan available</span>
       </md-card-content>
-      <md-card-content class="wz-margin-bottom-40-inv" ng-if="syscollector.netaddr && syscollector.netaddr.items.length">
+      <md-card-content class="wz-margin-bottom-40-inv"
+        ng-if="syscollector.netaddr && syscollector.netaddr.items.length">
         <span class="wz-headline-title"><i class="fa fa-fw fa-exchange"></i> Network settings</span>
         <md-divider class="wz-margin-top-10"></md-divider>
-        <wazuh-table flex path="'/syscollector/' + agent.id + '/netaddr'" row-sizes="[4]" keys="['iface', 'address', 'netmask', 'proto', 'broadcast']">
+        <wazuh-table flex path="'/syscollector/' + agent.id + '/netaddr'" row-sizes="[4]"
+          keys="['iface', 'address', 'netmask', 'proto', 'broadcast']">
         </wazuh-table>
       </md-card-content>
+    </md-card>
+  </div>
+
+  <div layout="row" class="layout-padding wz-padding-top-0"
+    ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
+    <md-card flex class="wz-md-card">
+      <md-card-content>
+        <span class="wz-headline-title"><i class="fa fa-fw fa-terminal"></i> Processes</span>
+        <span class="color-grey pull-right">Last scan: {{setBrowserOffset(syscollector.processesDate)}}</span>
+        <md-divider class="wz-margin-top-10"></md-divider>
+        <div layout="row" class="wz-margin-top-10">
+          <label class="wz-icon-loupe" style="margin-bottom: -16px;">
+            <input placeholder="Filter processes..." ng-model="processSearch" type="text"
+              class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid height-30 wz-width-100"
+              aria-invalid="false" wz-enter="search(processSearch,'processes')">
+          </label>
+          <button type="submit" aria-label="Search" class="btn height-30 wz-button-empty wz-margin-left-10"
+            ng-click="search(processSearch,'processes')">
+            <span>Search</span>
+          </button>
+        </div>
+        <div layout="row" ng-if="agent && syscollector" class="wz-margin-top-10 wz-margin-bottom-40-inv">
+          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'"
+            path="'/syscollector/' + agent.id + '/processes'" row-sizes="[10,8,6]" extra-limit="100"
+            keys="['name','cmd','priority','nlwp']">
+          </wazuh-table>
+          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'"
+            path="'/syscollector/' + agent.id + '/processes'" row-sizes="[10,8,6]" extra-limit="100"
+            keys="['name','euser','nice','state']">
+          </wazuh-table>
+        </div>
+      </md-card-content>
+      <div layout="row" class="ruleset-csv-formater formatted-div-inventory">
+        <span flex></span>
+
+        <a class="small formatted-color" id="btnDownload"
+          ng-click="downloadCsv('/syscollector/' + agent.id + '/processes', 'agent-' + agent.id + '-processes.csv')">
+          <wz-svg icon="download"></wz-svg>&nbsp;Formatted
+        </a>
+      </div>
+    </md-card>
+  </div>
+
+  <div layout="row" class="layout-padding wz-padding-top-0"
+    ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
+    <md-card flex class="wz-md-card">
+      <md-card-content>
+        <span class="wz-headline-title"><i class="fa fa-fw fa-cubes"></i> Packages</span>
+        <span class="color-grey pull-right">Last scan: {{setBrowserOffset(syscollector.packagesDate)}}</span>
+        <md-divider class="wz-margin-top-10"></md-divider>
+        <div layout="row" class="wz-margin-top-10">
+          <label class="wz-icon-loupe" style="margin-bottom: -16px;">
+            <input placeholder="Filter packages..." ng-model="packageSearch" type="text"
+              class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid height-30 wz-width-100"
+              aria-invalid="false" wz-enter="search(packageSearch,'packages')">
+          </label>
+          <button type="submit" aria-label="Search" class="btn height-30 wz-button-empty wz-margin-left-10"
+            ng-click="search(packageSearch,'packages')">
+            <span>Search</span>
+          </button>
+        </div>
+
+        <div layout="row" ng-if="agent && syscollector" class="wz-margin-top-10 wz-margin-bottom-40-inv">
+          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'"
+            path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"
+            keys="[{value:'name',size:2},'architecture','version',{value:'vendor',size:2},{value:'description',size:3}]">
+          </wazuh-table>
+          <wazuh-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'"
+            path="'/syscollector/' + agent.id + '/packages'" row-sizes="[10,8,6]" extra-limit="100"
+            keys="[{value:'name',size:3},'architecture','version',{value:'vendor',size:2}]">
+          </wazuh-table>
+        </div>
+      </md-card-content>
+      <div layout="row" class="ruleset-csv-formater formatted-div-inventory">
+        <span flex></span>
+        <a class="small formatted-color" id="btnDownload"
+          ng-click="downloadCsv('/syscollector/' + agent.id + '/packages', 'agent-' + agent.id + '-packages.csv')">
+          <wz-svg icon="download"></wz-svg>&nbsp;Formatted
+        </a>
+      </div>
     </md-card>
   </div>
 </md-content>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
@@ -70,13 +70,10 @@ define(['../../module', 'FileSaver'], function (module) {
         this.scope.hasSize = obj =>
           obj && typeof obj === 'object' && Object.keys(obj).length
 
-        this.scope.agent =
-          this.data.length &&
-            this.data.length > 1 &&
-            typeof this.data[1] === 'object' &&
-            this.data[1].data &&
-            this.data[1].data.data
-            ? this.data[1].data.data
+        const agentData  = (((this.data || {})[1] || {}).data || {}).data
+
+        this.scope.agent = agentData
+            ? agentData
             : { error: true }
         this.scope.search = (term, specificPath) => {
           this.search(term, specificPath)

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
@@ -66,7 +66,6 @@ define(['../../module', 'FileSaver'], function (module) {
      */
     $onInit() {
       try {
-        console.log("this.data ", this.data)
         this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
         this.scope.hasSize = obj =>
           obj && typeof obj === 'object' && Object.keys(obj).length

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-define(['../../module', 'FileSaver'], function(module) {
+define(['../../module', 'FileSaver'], function (module) {
   'use strict'
   class Inventory {
     /**
@@ -66,16 +66,17 @@ define(['../../module', 'FileSaver'], function(module) {
      */
     $onInit() {
       try {
+        console.log("this.data ", this.data)
         this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
         this.scope.hasSize = obj =>
           obj && typeof obj === 'object' && Object.keys(obj).length
 
         this.scope.agent =
           this.data.length &&
-          this.data.length > 4 &&
-          typeof this.data[4] === 'object' &&
-          this.data[4].data &&
-          this.data[4].data.data
+            this.data.length > 4 &&
+            typeof this.data[4] === 'object' &&
+            this.data[4].data &&
+            this.data[4].data.data
             ? this.data[4].data.data
             : { error: true }
         this.scope.search = (term, specificPath) => {
@@ -108,6 +109,10 @@ define(['../../module', 'FileSaver'], function(module) {
             Object.assign(this.packagesDate, this.data[3].data.data)
           if (this.data[5] && this.data[5].data && this.data[5].data.data)
             Object.assign(this.processesDate, this.data[5].data.data)
+          if (this.data[6] && this.data[6].data && this.data[6].data.data)
+            this.netifaceResponse = ((this.data[6] || {}).data || {}).data || false
+          if (this.data[7] && this.data[7].data && this.data[7].data.data)
+            this.netaddrResponse = ((this.data[7] || {}).data || {}).data || false
         }
         this.init()
 
@@ -131,25 +136,6 @@ define(['../../module', 'FileSaver'], function(module) {
      */
     async init() {
       try {
-        try {
-          const resultNetiface = await this.apiReq(
-            `/syscollector/${this.scope.agent.id}/netiface`,
-            {}
-          )
-          this.netifaceResponse =
-            ((resultNetiface || {}).data || {}).data || false
-        } catch (error) {} // eslint-disable-line
-
-        // This API call may fail so we put it out of Promise.all
-        try {
-          const resultNetaddrResponse = await this.apiReq(
-            `/syscollector/${this.scope.agent.id}/netaddr`,
-            { limit: 1 }
-          )
-          this.netaddrResponse =
-            ((resultNetaddrResponse || {}).data || {}).data || false
-        } catch (error) {} // eslint-disable-line
-
         this.scope.syscollector = {
           hardware: this.data[0].data.data,
           os: this.data[1].data.data,
@@ -158,8 +144,8 @@ define(['../../module', 'FileSaver'], function(module) {
           netaddr: this.netaddrResponse,
           packagesDate:
             this.packagesDate &&
-            this.packagesDate.items &&
-            this.packagesDate.items.length
+              this.packagesDate.items &&
+              this.packagesDate.items.length
               ? this.packagesDate.items[0].scan_time
               : 'Unknown',
           processesDate: ((this.processesDate || {}).items || []).length

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventoryCtrl.js
@@ -72,11 +72,11 @@ define(['../../module', 'FileSaver'], function (module) {
 
         this.scope.agent =
           this.data.length &&
-            this.data.length > 4 &&
-            typeof this.data[4] === 'object' &&
-            this.data[4].data &&
-            this.data[4].data.data
-            ? this.data[4].data.data
+            this.data.length > 1 &&
+            typeof this.data[1] === 'object' &&
+            this.data[1].data &&
+            this.data[1].data.data
+            ? this.data[1].data.data
             : { error: true }
         this.scope.search = (term, specificPath) => {
           this.search(term, specificPath)
@@ -88,31 +88,7 @@ define(['../../module', 'FileSaver'], function (module) {
             ? agentStatus
             : 'Never connected'
         }
-        if (
-          !this.data[0] ||
-          !this.data[0].data ||
-          !this.data[0].data.data ||
-          typeof this.data[0].data.data !== 'object' ||
-          !Object.keys(this.data[0].data.data).length ||
-          !this.data[1] ||
-          !this.data[1].data ||
-          !this.data[1].data.data ||
-          typeof this.data[1].data.data !== 'object' ||
-          !Object.keys(this.data[1].data.data).length
-        ) {
-          this.scope.syscollector = null
-        } else {
-          if (this.data[2] && this.data[2].data && this.data[2].data.data)
-            Object.assign(this.ports, this.data[3].data.data)
-          if (this.data[3] && this.data[3].data && this.data[3].data.data)
-            Object.assign(this.packagesDate, this.data[3].data.data)
-          if (this.data[5] && this.data[5].data && this.data[5].data.data)
-            Object.assign(this.processesDate, this.data[5].data.data)
-          if (this.data[6] && this.data[6].data && this.data[6].data.data)
-            this.netifaceResponse = ((this.data[6] || {}).data || {}).data || false
-          if (this.data[7] && this.data[7].data && this.data[7].data.data)
-            this.netaddrResponse = ((this.data[7] || {}).data || {}).data || false
-        }
+
         this.init()
 
         this.scope.startVis2Png = () =>
@@ -135,22 +111,8 @@ define(['../../module', 'FileSaver'], function (module) {
      */
     async init() {
       try {
-        this.scope.syscollector = {
-          hardware: this.data[0].data.data,
-          os: this.data[1].data.data,
-          netiface: this.netifaceResponse,
-          ports: this.ports,
-          netaddr: this.netaddrResponse,
-          packagesDate:
-            this.packagesDate &&
-              this.packagesDate.items &&
-              this.packagesDate.items.length
-              ? this.packagesDate.items[0].scan_time
-              : 'Unknown',
-          processesDate: ((this.processesDate || {}).items || []).length
-            ? this.processesDate.items[0].scan_time
-            : 'Unknown'
-        }
+        this.scope.syscollector = ((this.data || {})[0] || {}).data || {}
+
         this.scope.$applyAsync()
         return
       } catch (error) {

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-data-table/wz-data-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-data-table/wz-data-table.html
@@ -12,7 +12,7 @@
 <div ng-show="!error && !wazuh_table_loading && items.length">
   <table class="table table-striped table-condensed wz-margin-top-17" style="table-layout: fixed !important" id="wz_table">
     <thead class="wz-text-bold">
-      <th ng-repeat="key in keys" class="wz-text-left" ng-class="{ 'cursor-pointer' : !key.nosortable, 'col-lg-1' : !key.size, 'col-lg-{{key.size}}' : key.size }"
+      <th ng-repeat="key in keys" class="wz-text-left" ng-class="{ 'cursor-pointer' : !key.nosortable }"
         ng-click="!key.nosortable && sort(key)">
         {{ keyEquivalence[key.value || key] || key.value || key }}
         <i ng-if="!key.nosortable" class="fa wz-theader-sort-icon" ng-class="sortValue === (key.value || key) ? (!sortReverse ? 'fa-sort-asc' : 'fa-sort-desc') : 'fa-sort'"

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
@@ -30,7 +30,7 @@
   <table ng-class="customColumns ? 'table-resizable' : ''" class="table wz-no-outline table-condensed table-striped table-hover"
     style="table-layout: fixed; " id="table{{scapepath}}">
     <thead class="wz-text-bold">
-      <th ng-repeat="key in keys | filter: showKey" class="wz-text-left wz-nowrap" ng-class="{ 'cursor-pointer' : !key.nosortable, 'col-lg-1' : !key.size, 'col-lg-{{key.size}}' : key.size } && getWitdh(key.value || key)"
+      <th ng-repeat="key in keys | filter: showKey" class="wz-text-left wz-nowrap" ng-class="{'cursor-pointer' : !key.nosortable}"
         ng-click="!key.nosortable && sort(key)">
         {{ path === '/agents/groups' && (key.value || key) === 'count' ? 'Agents' : keyEquivalence[key.value ||
         key] || key.value || key }}
@@ -217,7 +217,7 @@
   <table ng-class="customColumns ? 'table-resizable' : ''" class="table wz-no-outline table-condensed"
     style="table-layout: fixed !important" id="table{{scapepath}}">
     <thead class="wz-text-bold">
-      <th ng-repeat="key in keys | filter: showKey" class="wz-text-left wz-nowrap" ng-class="{ 'cursor-pointer' : !key.nosortable, 'col-lg-1' : !key.size, 'col-lg-{{key.size}}' : key.size }  && getWitdh(key.value || key)"
+      <th ng-repeat="key in keys | filter: showKey" class="wz-text-left wz-nowrap" ng-class="{'cursor-pointer' : !key.nosortable}"
         ng-click="!key.nosortable && sort(key)">
         {{ path === '/agents/groups' && (key.value || key) === 'count' ? 'Agents' : keyEquivalence[key.value ||
         key] || key.value || key }}
@@ -323,7 +323,7 @@
   <table ng-class="customColumns ? 'table-resizable' : ''" ng-class="customColumns ? 'table-resizable' : ''"
     class="table wz-no-outline table-condensed" style="table-layout: fixed !important" id="table{{scapepath}}">
     <thead class="wz-text-bold">
-      <th ng-repeat="key in keys  | filter: showKey" class="wz-text-left wz-nowrap" ng-class="{ 'cursor-pointer' : !key.nosortable, 'col-lg-1' : !key.size, 'col-lg-{{key.size}}' : key.size} && getWitdh(key.value || key)"
+      <th ng-repeat="key in keys  | filter: showKey" class="wz-text-left wz-nowrap" ng-class="{'cursor-pointer' : !key.nosortable}"
         ng-click="!key.nosortable && sort(key)">
         {{ keyEquivalence[key.value || key] || key.value || key }}
         <i ng-if="!key.nosortable" class="fa wz-theader-sort-icon"


### PR DESCRIPTION
Hi team, 

This PR solves https://github.com/wazuh/wazuh-splunk/issues/744.

- Changed the distribution of the table.
- Added cursor pointer to the Wazuh table.
- Solved flick when accessing to Agents > Inventory.

The two first points only need little changes in the HTML.

To solve the flick was necessary to change the way to load the syscollector information. The problem was that when accessing the section two tables get the info after the `ng-if` makes the check. To solve this I've changed from the controller to the resolve of the `agents-states.js`, this loads the data before the controller has been instanced solving the problem.

Regards,