### PR TITLE
Fix DELETE api calls

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
@@ -501,8 +501,8 @@ define(['../../module', 'FileSaver'], function(controllers) {
         // Delete agents from a group
         if (itemsToSave.deletedIds.length) {
           response = await this.apiReq(
-            `/agents/group/${this.scope.currentGroup.name}`,
-            { ids: itemsToSave.deletedIds },
+            `/agents/group/${this.scope.currentGroup.name}?ids=${itemsToSave.deletedIds}`,
+            {},
             'DELETE'
           )
           if (response.data.error !== 0) {
@@ -527,9 +527,16 @@ define(['../../module', 'FileSaver'], function(controllers) {
             } agents`
           )
         } else {
-          this.notification.showSuccessToast(
-            response.data.data.msg || 'Success. Group has been updated'
-          )
+          const responseMsg = (((response || {}).data || {}).data || {}).msg
+          if( responseMsg ){
+            this.notification.showSuccessToast(
+              responseMsg || 'Success. Group has been updated'
+            )
+          }else{
+            this.notification.showWarningToast(
+              'No agents were added or removed'
+            )
+          }
         }
         this.scope.addMultipleAgents(false)
         this.scope.multipleSelectorLoading = false


### PR DESCRIPTION
Hi team,
Some DELETE API calls were being sent using body parameters that was causing an error, these API calls have been updated to querystring as it is the accepted way in our api.
This PR solves #774 

Regards,