### PR TITLE
Fix redesign error on firefox

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/agentsOverviewCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/agentsOverviewCtrl.js
@@ -359,7 +359,7 @@ define(['../../module'], function (app) {
     /**
     * Shows the extensions list to enable or disable them
     */
-    showExtensionsLists = card => {
+    showExtensionsLists(card){
       try {
         this.scope.extensionsLists[card] ? this.scope.extensionsLists[card] = false : this.scope.extensionsLists[card] = true
       } catch (error) {

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
@@ -40,7 +40,7 @@ define(['../../module'], function (controllers) {
     /**
     * Shows the extensions list to enable or disable them
     */
-    showExtensionsLists = card => {
+    showExtensionsLists(card){
       try {
         this.scope.extensionsLists[card] ? this.scope.extensionsLists[card] = false : this.scope.extensionsLists[card] = true
       } catch (error) {


### PR DESCRIPTION
Hi team,

This PR solves #806 , there was an error when using the APP on Firefox that was being caused by the redesign. We can now use the APP as usually