### PR TITLE
Allow APP to open empty files

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/edit-configuration/editGroupsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/edit-configuration/editGroupsCtrl.js
@@ -123,11 +123,13 @@ define(['../../../module'], function(controllers) {
           `/agents/groups/${groupName}/files/agent.conf`,
           { format: 'xml' }
         )
-        const xml = ((data || {}).data || {}).data || false
-        if (!xml) {
+        const xml = (data || {}).data || {} || false
+        if (!xml.data && xml.error !== 0) {
           throw new Error('Could not fetch agent.conf file')
+        }else if(!xml.data){
+          return " " // Force to print the XML editor
         }
-        return xml
+        return xml.data
       } catch (error) {
         return Promise.reject(error)
       }

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
@@ -346,11 +346,13 @@ define(['../../module', 'FileSaver'], function(controllers) {
           `/agents/groups/${this.scope.currentGroup.name}/files/agent.conf`,
           { format: 'xml' }
         )
-        const xml = ((data || {}).data || {}).data || false
-        if (!xml) {
+        const xml = (data || {}).data || {} || false
+        if (!xml.data && xml.error !== 0) {
           throw new Error('Could not fetch agent.conf file')
+        }else if(!xml.data){
+          xml.data = " " // Force to print the XML editor
         }
-        return xml
+        return xml.data
       } catch (error) {
         return Promise.reject(error)
       }

--- a/SplunkAppForWazuh/appserver/static/js/services/file-editor/file-editor.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/file-editor/file-editor.js
@@ -61,11 +61,12 @@ define(['../module'], function(module) {
         if (
           !result ||
           !result.data ||
-          !result.data.data ||
           result.data.error != 0
         ) {
           throw new Error(`Error fetching ${file} content.`)
         }
+        if(!result.data.data) //Force XML box to be printed when the file is empty
+          return " "
         return result.data.data
       } catch (error) {
         return Promise.reject(error)

--- a/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
@@ -155,12 +155,11 @@ define(['../module'], function(module) {
         if (
           !result ||
           !result.data ||
-          !result.data.data ||
           result.data.error !== 0 ||
           (result.data.data.error && result.data.data.error !== 0)
         ) {
           throw new Error('Cannot get file.')
-        }
+        }     
         return result
       } catch (error) {
         return Promise.reject(error)


### PR DESCRIPTION
Hi team,
An error was being thrown when a user tried to open a file that was completely empty (agent.conf/rules/decoders) .
This PR allows the APP to open empty files. Fixes #839 