### PR TITLE
Fixed osquery error message when it is installed

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
@@ -185,7 +185,7 @@ define(['../module'], function(module) {
                     $currentDataService.getCurrentAgent() ||
                     $state.go('agents')
                   const result = await $requestService.apiReq(
-                    `/agents?q=id=${id}/config/wmodules/wmodules`
+                    `/agents/${id}/config/wmodules/wmodules`
                   )
                   return result
                 } catch (err) {


### PR DESCRIPTION
Hi guys, 
We have fixed an error that told you that osquery was not configured when it was installed perfectly and the dashboards with data were shown