### PR TITLE
Remove unnecesary request in the monitoring job when cluster mode is disabled

### DIFF
--- a/SplunkAppForWazuh/bin/get_agents_status.py
+++ b/SplunkAppForWazuh/bin/get_agents_status.py
@@ -82,17 +82,18 @@ def check_status():
                         timeout=1,
                         verify=verify).json()
                     cluster_status = request_cluster_status["data"]["enabled"]
-                    final_url_cluster_name = url + '/cluster/nodes'
-                    request_cluster_name = requestsbak.get(
-                        final_url_cluster_name,
-                        timeout=1,
-                        headers = {'Authorization': f'Bearer {wazuh_token}'},
-                        verify=verify).json()
+                    if request_cluster_status["data"]["enabled"] == "yes":
+                        final_url_cluster_name = url + '/cluster/local/info'
+                        request_cluster_name = requestsbak.get(
+                            final_url_cluster_name,
+                            timeout=1,
+                            headers = {'Authorization': f'Bearer {wazuh_token}'},
+                            verify=verify).json()
                     offset = offset + limit
                     for item in agent_list:
                         if cluster_status == "yes":
                             item["cluster"] = {}
-                            item["cluster"]["name"] = request_cluster_name["data"]["cluster"]
+                            item["cluster"]["name"] = request_cluster_name["data"]["affected_items"][0]["cluster"]
                         if 'manager' in item:
                             manager_name = item["manager"]
                             item["manager"] = {}


### PR DESCRIPTION
Hi, team PR resolves:
- Remove an optional request in the monitoring job when cluster mode is disabled

Related Issue #953 