### PR TITLE
Bugfix/950 remove run scan agents policy

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
@@ -60,12 +60,6 @@
       </div>
     </div>
     <div ng-show="!loadingVizz">
-      <!-- Launch scan -->
-      <div layout="row" class="sca-switch-div wz-padding-top-0">
-        <span flex></span>
-        <button ng-click="launchRootcheckScan()" class="btn-invisible-sca"><i class="fa fa-fw fa-play"></i> Run
-          scan</button>
-      </div>
       <!-- Alerts visualizations -->
       <div layout="row" layout-align="center stretch" class="height-390">
         <md-card flex="50" class="wz-md-card" ng-class="{'fullscreen': expandArray[0]}">


### PR DESCRIPTION
Hi team.
This PR, remove the run scan button action in agents Policiy monitoring. Rootcheck endpoints is deprecated in 4.0 api