### PR TITLE
Fix help urls

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
@@ -62,7 +62,7 @@ define([
       isAdmin
     ) {
       this.$scope = $scope
-      this.appDocuVersion = $appVersionService.getDocumentacionVersion()
+      this.appDocuVersion = $appVersionService.getDocumentationVersion()
       this.request = $requestService
       this.$window = $window
       this.appState = $navigationService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/dev-tools/devToolsCtrl.js
@@ -57,10 +57,12 @@ define([
       $window,
       $navigationService,
       $notificationService,
+      $appVersionService,
       $document,
       isAdmin
     ) {
       this.$scope = $scope
+      this.appDocuVersion = $appVersionService.getDocumentacionVersion()
       this.request = $requestService
       this.$window = $window
       this.appState = $navigationService
@@ -155,7 +157,7 @@ define([
 
         this.$scope.help = () => {
           this.$window.open(
-            'https://documentation.wazuh.com/current/user-manual/api/reference.html'
+            `https://documentation.wazuh.com/${this.appDocuVersion}/user-manual/api/reference.html`
           )
         }
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/active-response/active-response.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/active-response/active-response.html
@@ -109,9 +109,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/active-response/index.html">Active
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/active-response/index.html">Active
           response documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/active-response.html">Active
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/active-response.html">Active
           response reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/active-response/agents-active-response.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/active-response/agents-active-response.html
@@ -75,9 +75,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/active-response/index.html">Active
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/active-response/index.html">Active
           response documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/active-response.html">Active
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/active-response.html">Active
           response reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/agentless/agentless.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/agentless/agentless.html
@@ -94,9 +94,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/agentless-monitoring/index.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/agentless-monitoring/index.html">How
           to monitor agentless devices</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/agentless.html">Agentless
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/agentless.html">Agentless
           reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
@@ -114,11 +114,11 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/manager/manual-email-report/index.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-email-report/index.html">How
           to configure email alerts</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/manager/manual-email-report/smtp_authentication.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-email-report/smtp_authentication.html">How
           to configure authenticated SMTP server</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/email_alerts.html">Email
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/email_alerts.html">Email
           alerts reference</md-list-item>
       </md-list>
     </md-sidenav>
@@ -185,9 +185,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/getting-started/use-cases.html">Use
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/getting-started/use-cases.html">Use
           cases about alerts generation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/alerts.html">Alerts
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/alerts.html">Alerts
           reference</md-list-item>
       </md-list>
     </md-sidenav>
@@ -259,9 +259,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/labels.html">Labels
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/labels.html">Labels
           documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/labels.html">Labels
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/labels.html">Labels
           reference</md-list-item>
       </md-list>
     </md-sidenav>
@@ -361,9 +361,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/manager/automatic-reports.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/automatic-reports.html">How
           to generate automatic reports</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/reports.html">Reports
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/reports.html">Reports
           reference</md-list-item>
       </md-list>
     </md-sidenav>
@@ -449,9 +449,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/manager/manual-syslog-output.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-syslog-output.html">How
           to configure the syslog output</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syslog-output.html">Syslog
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/syslog-output.html">Syslog
           output reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/amazon-s3/amazon-s3.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/amazon-s3/amazon-s3.html
@@ -227,9 +227,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/amazon/index.html">Using
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/amazon/index.html">Using
           Wazuh to monitor AWS</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-s3.html">Amazon
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-s3.html">Amazon
           S3 module reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cis-cat/cis-cat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cis-cat/cis-cat.html
@@ -158,9 +158,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html">CIS-CAT
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html">CIS-CAT
           module documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-ciscat.html">CIS-CAT
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-ciscat.html">CIS-CAT
           module reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/client-buffer/client-buffer.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/client-buffer/client-buffer.html
@@ -78,9 +78,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/antiflooding.html">Anti-flooding
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/antiflooding.html">Anti-flooding
           mechanism</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/agent_buffer.html">Client
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/agent_buffer.html">Client
           buffer reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/client/client.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/client/client.html
@@ -110,9 +110,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/agents/agent-connection.html">Checking
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/agents/agent-connection.html">Checking
           connection with manager</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html">Client
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/client.html">Client
           reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cluster/cluster.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cluster/cluster.html
@@ -82,7 +82,7 @@
         <md-subheader>More info about this section</md-subheader>
         <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/3.10/user-manual/configuring-cluster/index.html">How
           to configure the Wazuh cluster</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/cluster.html">Wazuh
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/cluster.html">Wazuh
           cluster reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/configurationCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/configurationCtrl.js
@@ -9,6 +9,7 @@ define(['../../module', '../../../utils/config-handler'], function(
       $scope,
       $requestService,
       $beautifierJson,
+      $appVersionService,
       $notificationService,
       isAdmin,
       clusterInfo
@@ -18,6 +19,7 @@ define(['../../module', '../../../utils/config-handler'], function(
       this.apiReq = $requestService
       this.scope.load = false
       this.scope.isArray = Array.isArray
+      this.scope.appDocuVersion = $appVersionService.getDocumentacionVersion()
       this.configurationHandler = new ConfigHandler(
         this.apiReq,
         $beautifierJson,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/configurationCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/configurationCtrl.js
@@ -19,7 +19,7 @@ define(['../../module', '../../../utils/config-handler'], function(
       this.apiReq = $requestService
       this.scope.load = false
       this.scope.isArray = Array.isArray
-      this.scope.appDocuVersion = $appVersionService.getDocumentacionVersion()
+      this.scope.appDocuVersion = $appVersionService.getDocumentationVersion()
       this.configurationHandler = new ConfigHandler(
         this.apiReq,
         $beautifierJson,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/database-output/database-output.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/database-output/database-output.html
@@ -75,7 +75,7 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/database-output.html">Database
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/database-output.html">Database
           output reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/docker-listener/docker-listener.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/docker-listener/docker-listener.html
@@ -69,9 +69,9 @@
       <md-sidenav class="md-sidenav-right" md-is-locked-open="true">
         <md-list>
           <md-subheader>More info about this section</md-subheader>
-          <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/docker/index.html">Docker
+          <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/docker/index.html">Docker
             information</md-list-item>
-          <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-docker.html">Docker listener
+          <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-docker.html">Docker listener
             module reference</md-list-item>
         </md-list>
       </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/global-configuration/global-configuration.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/global-configuration/global-configuration.html
@@ -169,9 +169,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item ng-if="!agent || agent.id === '000'" target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/global.html">Global
+        <md-list-item ng-if="!agent || agent.id === '000'" target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/global.html">Global
           reference</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/logging.html">Logging
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/logging.html">Logging
           reference</md-list-item>
       </md-list>
     </md-sidenav>
@@ -267,9 +267,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/daemons/ossec-remoted.html">Remote
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/daemons/ossec-remoted.html">Remote
           daemon reference</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/remote.html">Remote
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/remote.html">Remote
           configuration reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrations/integrations.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrations/integrations.html
@@ -107,11 +107,11 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/manager/manual-integration.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-integration.html">How
           to integrate Wazuh with external APIs</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/index.html">VirusTotal
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/virustotal-scan/index.html">VirusTotal
           integration documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/integration.html">Integration
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/integration.html">Integration
           reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrity-monitoring/integrity-monitoring.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrity-monitoring/integrity-monitoring.html
@@ -532,7 +532,7 @@
           <div class="wz-padding-top-10" ng-show="!currentConfig['syscheck-syscheck'].syscheck.whodata">
             <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> No audit keys were found. Visit the documentation
             on
-            <a href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#whodata">this
+            <a href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/syscheck.html#whodata">this
               link</a> to enable it.
           </div>
           <div class="wz-padding-top-10" ng-show="currentConfig['syscheck-syscheck'].syscheck.whodata.audit_key">
@@ -618,10 +618,10 @@
       <md-list>
         <md-subheader>More info about this section</md-subheader>
         <md-list-item target="_blank" class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html">Integrity
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/file-integrity/index.html">Integrity
           monitoring documentation</md-list-item>
         <md-list-item target="_blank" class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html">Syscheck
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/syscheck.html">Syscheck
           reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/log-collection/log-collection.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/log-collection/log-collection.html
@@ -127,10 +127,10 @@
     <md-list>
       <md-subheader>More info about this section</md-subheader>
       <md-list-item target="_blank" class="wz-text-link"
-        ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/index.html">Log
+        ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/log-data-collection/index.html">Log
         data collection documentation</md-list-item>
       <md-list-item target="_blank" class="wz-text-link"
-        ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/localfile.html">Localfile
+        ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/localfile.html">Localfile
         reference</md-list-item>
     </md-list>
   </md-sidenav>
@@ -237,10 +237,10 @@
     <md-list>
       <md-subheader>More info about this section</md-subheader>
       <md-list-item target="_blank" class="wz-text-link"
-        ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/index.html">Log
+        ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/log-data-collection/index.html">Log
         data collection documentation</md-list-item>
       <md-list-item target="_blank" class="wz-text-link"
-        ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/localfile.html">Localfile
+        ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/localfile.html">Localfile
         reference</md-list-item>
     </md-list>
   </md-sidenav>
@@ -338,11 +338,11 @@
     <md-list>
       <md-subheader>More info about this section</md-subheader>
       <md-list-item target="_blank" class="wz-text-link"
-        ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/log-data-configuration.html#using-multiple-outputs">
+        ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/log-data-collection/log-data-configuration.html#using-multiple-outputs">
         Using
         multiple outputs</md-list-item>
       <md-list-item target="_blank" class="wz-text-link"
-        ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/socket.html">Socket
+        ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/socket.html">Socket
         reference</md-list-item>
     </md-list>
   </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/open-scap/open-scap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/open-scap/open-scap.html
@@ -140,9 +140,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/openscap/index.html">OpenSCAP
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/policy-monitoring/openscap/index.html">OpenSCAP
           module documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-openscap.html">OpenSCAP
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-openscap.html">OpenSCAP
           module reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/osquery/osquery.html
@@ -113,9 +113,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/osquery.html">Osquery
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/osquery.html">Osquery
           module documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-osquery.html">Osquery
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-osquery.html">Osquery
           module reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/policy-monitoring/policy-monitoring.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/policy-monitoring/policy-monitoring.html
@@ -306,11 +306,11 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/anomalies-detection/index.html">Anomaly
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/anomalies-detection/index.html">Anomaly
           and malware detection documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/index.html">Policy
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/policy-monitoring/index.html">Policy
           monitoring documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html">Rootcheck
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/rootcheck.html">Rootcheck
           reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
@@ -110,9 +110,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html">How
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/registering/use-registration-service.html">How
           to use the registration service</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html">Registration
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/auth.html">Registration
           service reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/ruleset/ruleset.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/ruleset/ruleset.html
@@ -273,9 +273,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/ruleset/index.html">Ruleset
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/ruleset/index.html">Ruleset
           documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/ruleset.html">Ruleset
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/ruleset.html">Ruleset
           reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/syscollector/syscollector.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/syscollector/syscollector.html
@@ -106,9 +106,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/syscollector.html">Syscollector
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/syscollector.html">Syscollector
           module documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-syscollector.html">Syscollector
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-syscollector.html">Syscollector
           module reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
@@ -166,9 +166,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection.html">Vulnerability
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/vulnerability-detection.html">Vulnerability
           detector documentation</md-list-item>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-vuln-detector.html">Vulnerability
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-vuln-detector.html">Vulnerability
           detector reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/wazuh-commands/wazuh-commands.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/wazuh-commands/wazuh-commands.html
@@ -78,9 +78,9 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
     <md-list>
       <md-subheader>More info about this section</md-subheader>
-      <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/active-response/index.html">Active
+      <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/active-response/index.html">Active
         response documentation</md-list-item>
-      <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/commands.html">Commands
+      <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/commands.html">Commands
         reference</md-list-item>
     </md-list>
   </md-sidenav>
@@ -199,7 +199,7 @@
     <md-sidenav ng-show="showingInfo" class="md-sidenav-right" md-is-locked-open="true">
       <md-list>
         <md-subheader>More info about this section</md-subheader>
-        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-command.html">Command
+        <md-list-item target="_blank" class="wz-text-link" ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-command.html">Command
           module reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/welcome/welcome.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/welcome/welcome.html
@@ -287,13 +287,13 @@
       <md-list>
         <md-subheader>More info about this section</md-subheader>
         <md-list-item target="_blank" class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/current/user-manual/manager/index.html">Wazuh
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/index.html">Wazuh
           administration documentation</md-list-item>
         <md-list-item target="_blank" class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/current/user-manual/capabilities/index.html">Wazuh
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/index.html">Wazuh
           capabilities documentation</md-list-item>
         <md-list-item target="_blank" class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/index.html">Local
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/index.html">Local
           configuration reference</md-list-item>
       </md-list>
     </md-sidenav>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoring.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoring.html
@@ -34,7 +34,7 @@
           <md-divider class="wz-margin-top-10"></md-divider>
           <div layout="column" class="wz-padding-top-10">
             <p>The cluster is disabled. Visit the documentation on <a target="_blank"
-                href="https://documentation.wazuh.com/current/user-manual/configuring-cluster/index.html">this link</a> to
+              href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/configuring-cluster/index.html">this link</a> to
               learn about how to enable it.
             </p>
           </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoringCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoringCtrl.js
@@ -32,7 +32,7 @@ define([
       this.currentDataService = $currentDataService
 
       this.scope.showConfig = $stateParams.isClusterRunning || false
-      this.scope.appDocuVersion = $appVersionService.getDocumentacionVersion()
+      this.scope.appDocuVersion = $appVersionService.getDocumentationVersion()
       this.scope.showNodes = $stateParams.showNodes || false
       this.scope.currentNode = $stateParams.currentNode || null
       this.filters = this.currentDataService.getSerializedFilters()

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoringCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoringCtrl.js
@@ -23,6 +23,7 @@ define([
       $scope,
       $currentDataService,
       $requestService,
+      $appVersionService,
       $notificationService,
       monitoringInfo
     ) {
@@ -31,6 +32,7 @@ define([
       this.currentDataService = $currentDataService
 
       this.scope.showConfig = $stateParams.isClusterRunning || false
+      this.scope.appDocuVersion = $appVersionService.getDocumentacionVersion()
       this.scope.showNodes = $stateParams.showNodes || false
       this.scope.currentNode = $stateParams.currentNode || null
       this.filters = this.currentDataService.getSerializedFilters()

--- a/SplunkAppForWazuh/appserver/static/js/run/run.js
+++ b/SplunkAppForWazuh/appserver/static/js/run/run.js
@@ -6,6 +6,8 @@ define(['./module'], function(module) {
     '$transitions',
     '$navigationService',
     '$currentDataService',
+    '$requestService',
+    '$appVersionService',
     '$notificationService',
     function(
       $rootScope,
@@ -13,11 +15,26 @@ define(['./module'], function(module) {
       $transitions,
       $navigationService,
       $currentDataService,
+      $requestService,
+      $appVersionService,
       $notificationService
     ) {
       //Go to last state or to a specified tab if "currentTab" param is specified in the url
       $navigationService.manageState()
-
+      async function getAppVersion(){
+        try {
+          const result = await $requestService.httpReq(
+            'GET',
+            '/manager/app_info'
+          )
+          console.log('result',result)
+          $appVersionService.setAppInfo(result.data);
+          return result;
+        } catch (error) {
+          $state.go('settings.api')
+        }
+      }
+      getAppVersion();
       async function checkBeforeTransition(state) {
         try {
           const { api } = await $currentDataService.checkSelectedApiConnection()

--- a/SplunkAppForWazuh/appserver/static/js/run/run.js
+++ b/SplunkAppForWazuh/appserver/static/js/run/run.js
@@ -27,7 +27,6 @@ define(['./module'], function(module) {
             'GET',
             '/manager/app_info'
           )
-          console.log('result',result)
           $appVersionService.setAppInfo(result.data);
           return result;
         } catch (error) {

--- a/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
@@ -3,28 +3,25 @@ define(['../module'], function (module) {
 
     module.service('$appVersionService', function (
     ) {
-        let appInfo = {revision:'',version:'',splunk_version:''};
-        let documentationAppVersion='';
+        let appInfo = { revision: '', version: '', splunk_version: '' };
+        let documentationAppVersion = '';
         const getAppVersion = () => {
             return appInfo;
         }
 
         /**
-         * Generates and returns the browser base URL + Splunk Port
+         * Set the info about the app and splunk
          */
         const setAppInfo = (info) => {
             let appInfo = info;
             const [major, minor] = appInfo.version.split('.');
-            documentationAppVersion = [major, minor].join('.'); 
+            documentationAppVersion = [major, minor].join('.');
         }
-        
+
         const getDocumentacionVersion = () => {
             return documentationAppVersion;
         }
 
-        const getDocuUrl = (url) => {
-            return url.replace('/current/',`/${documentationAppVersion}/`)
-        }
         const service = {
             getAppVersion: getAppVersion,
             setAppInfo: setAppInfo,

--- a/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
@@ -18,14 +18,14 @@ define(['../module'], function (module) {
             documentationAppVersion = [major, minor].join('.');
         }
 
-        const getDocumentacionVersion = () => {
+        const getDocumentationVersion = () => {
             return documentationAppVersion;
         }
 
         const service = {
             getAppVersion: getAppVersion,
             setAppInfo: setAppInfo,
-            getDocumentacionVersion: getDocumentacionVersion
+            getDocumentationVersion: getDocumentationVersion
         }
         return service
     })

--- a/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
@@ -1,0 +1,35 @@
+define(['../module'], function (module) {
+    'use strict'
+
+    module.service('$appVersionService', function (
+    ) {
+        let appInfo = {revision:'',version:'',splunk_version:''};
+        let documentationAppVersion='';
+        const getAppVersion = () => {
+            return appInfo;
+        }
+
+        /**
+         * Generates and returns the browser base URL + Splunk Port
+         */
+        const setAppInfo = (info) => {
+            let appInfo = info;
+            const [major, minor] = appInfo.version.split('.');
+            documentationAppVersion = [major, minor].join('.'); 
+        }
+        
+        const getDocumentacionVersion = () => {
+            return documentationAppVersion;
+        }
+
+        const getDocuUrl = (url) => {
+            return url.replace('/current/',`/${documentationAppVersion}/`)
+        }
+        const service = {
+            getAppVersion: getAppVersion,
+            setAppInfo: setAppInfo,
+            getDocumentacionVersion: getDocumentacionVersion
+        }
+        return service
+    })
+})

--- a/SplunkAppForWazuh/appserver/static/js/services/index.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/index.js
@@ -23,5 +23,6 @@ define([
   './file-editor/file-editor',
   './cdb-editor/cdb-editor',
   './restartService/restartService',
-  './checkDaemons/checkDaemonsService'
+  './checkDaemons/checkDaemonsService',
+  './app-version/appVersionService'
 ], function() {})


### PR DESCRIPTION
Hi teams this PR solves:
- "help" references to` /current/` instead of the app version. 

Related Issue #953 