### PR TITLE
Fix open app log file path when no using the `/opt/splunk` directory as base

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -23,6 +23,7 @@ import json
 from splunk.clilib import cli_common as cli
 import splunk.appserver.mrsparkle.controllers as controllers
 from splunk.appserver.mrsparkle.lib.decorators import expose_page
+from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
 from db import database
 from log import log
 from requestsbak.exceptions import ConnectionError
@@ -329,7 +330,7 @@ class manager(controllers.BaseController):
         try:
             self.logger.debug("manager: Getting last log lines.")
             lines = self.logger.get_last_log_lines(20)
-            parsed_data = jsonbak.dumps({'logs': lines})
+            parsed_data = jsonbak.dumps({'logs': lines, 'logs_path': make_splunkhome_path(['var', 'log', 'splunk', 'SplunkAppForWazuh.log'])})
         except Exception as e:
             self.logger.error("manager: Get_log_lines endpoint: %s" % (e))
             return jsonbak.dumps({"error": str(e)})

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/logs/logs.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/logs/logs.html
@@ -2,7 +2,7 @@
   <!-- Headline -->
   <div layout="column" layout-padding>
     <span class="font-size-18"><i class="fa fa-fw fa-file-text-o" aria-hidden="true"></i> Wazuh Splunk plugin log messages</span>
-    <span>Log file located at <span class="wz-text-monospace">/opt/splunk/var/log/splunk/SplunkAppForWazuh.log</span></span>
+    <span>Log file located at <span class="wz-text-monospace">{{ logs_path }}</span></span>
   </div>
 
   <div layout="row" ng-show="!loadingLogs">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/logs/logsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/logs/logsCtrl.js
@@ -18,6 +18,7 @@ define(['../../module'], function(module) {
       this.logs = logs
       this.httpReq = $requestService.httpReq
       this.root = $rootScope
+      this.scope.logs_path = ''
     }
 
     /**
@@ -31,6 +32,7 @@ define(['../../module'], function(module) {
         if (Array.isArray(this.logs.data.logs)) {
           this.parseLogs(this.logs.data.logs)
         }
+        this.scope.logs_path = this.logs.data.logs_path
       } catch (error) {
         this.scope.logs = [
           {
@@ -39,6 +41,7 @@ define(['../../module'], function(module) {
             message: 'Error when loading Wazuh app logs'
           }
         ]
+        this.scope.logs_path = ''
       }
     }
 
@@ -87,6 +90,7 @@ define(['../../module'], function(module) {
         this.scope.logs = []
         const result = await this.httpReq(`GET`, `/manager/get_log_lines`)
         this.parseLogs(result.data.logs)
+        this.scope.logs_path = result.data.logs_path
         this.scope.refreshing = false
         return
       } catch (error) {
@@ -97,6 +101,7 @@ define(['../../module'], function(module) {
             message: 'Error when loading Wazuh app logs'
           }
         ]
+        this.scope.logs_path = ''
       }
     }
   }

--- a/SplunkAppForWazuh/bin/log.py
+++ b/SplunkAppForWazuh/bin/log.py
@@ -74,8 +74,7 @@ class log():
     def get_last_log_lines(self, lines):
         """Return the last logs messages."""
         try:
-            current_tail = tailer.tail(open(
-                "/opt/splunk/var/log/splunk/SplunkAppForWazuh.log"), lines)
+            current_tail = tailer.tail(open(make_splunkhome_path(['var', 'log', 'splunk', 'SplunkAppForWazuh.log'])), lines)
             result = list(reversed(current_tail))
         except Exception as e:
             self.error('[log.py][get_last_log_lines] %s' % (e))


### PR DESCRIPTION
Hi team, this PR resolves:
- Add the relative app log file path to the Log section using the Splunk home directory as the base. This should solve the problem when Splunk is installed on macOS with the Splunk directory stating with `Application/`

Related Issue #953 