### PR TITLE
Replace monitoring index from wazuh-monitoring-3x to wazuh-monitoring

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -207,12 +207,12 @@ define([
               this.mngName = this.currentDataService.getFilters()[0][
                 'manager.name'
               ]
-              this.agentsStatusFilter = `manager.name=${this.mngName} index=wazuh-monitoring-3x`
+              this.agentsStatusFilter = `manager.name=${this.mngName} index=wazuh-monitoring*`
             } else {
               this.clusName = this.currentDataService.getFilters()[0][
                 'cluster.name'
               ]
-              this.agentsStatusFilter = `cluster.name=${this.clusName} index=wazuh-monitoring-3x`
+              this.agentsStatusFilter = `cluster.name=${this.clusName} index=wazuh-monitoring*`
             }
           } catch (error) {} //eslint-disable-line
 

--- a/SplunkAppForWazuh/default/inputs.conf
+++ b/SplunkAppForWazuh/default/inputs.conf
@@ -3,7 +3,7 @@ connection_host = ip
 
 [script://$SPLUNK_HOME/etc/apps/SplunkAppForWazuh/bin/get_agents_status.py]
 disabled = false
-index = wazuh-monitoring-3x
+index = wazuh-monitoring
 interval = */15 * * * *
 sourcetype = _json
 passAuth = splunk-system-user

--- a/setup/forwarder/inputs.conf
+++ b/setup/forwarder/inputs.conf
@@ -1,0 +1,5 @@
+[monitor:///var/ossec/logs/alerts/alerts.json]
+disabled = 0
+host = MANAGER_HOSTNAME
+index = wazuh
+sourcetype = wazuh

--- a/setup/forwarder/props.conf
+++ b/setup/forwarder/props.conf
@@ -1,0 +1,8 @@
+[wazuh]
+DATETIME_CONFIG =
+INDEXED_EXTRACTIONS = json
+KV_MODE = none
+NO_BINARY_CHECK = true
+category = Application
+disabled = false
+pulldown_type = true

--- a/setup/indexer/indexes.conf
+++ b/setup/indexer/indexes.conf
@@ -1,0 +1,19 @@
+[wazuh]
+coldPath = $SPLUNK_DB/wazuh/colddb
+enableDataIntegrityControl = 1
+enableTsidxReduction = 1
+homePath = $SPLUNK_DB/wazuh/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/wazuh/thaweddb
+timePeriodInSecBeforeTsidxReduction = 15552000
+tsidxReductionCheckPeriodInSec =
+
+[wazuh-monitoring]
+coldPath = $SPLUNK_DB/wazuh-monitoring/colddb
+enableDataIntegrityControl = 1
+enableTsidxReduction = 1
+homePath = $SPLUNK_DB/wazuh-monitoring/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/wazuh-monitoring/thaweddb
+timePeriodInSecBeforeTsidxReduction = 15552000
+tsidxReductionCheckPeriodInSec =

--- a/setup/indexer/inputs.conf
+++ b/setup/indexer/inputs.conf
@@ -1,0 +1,2 @@
+[splunktcp://9997]
+connection_host = ip


### PR DESCRIPTION
Hi team, this PR resolves:

Replace the monitoring index from `wazuh-monitoring-3x` to `wazuh-monitoring`
  - Modified `inputs.conf`
  - Modified the `index` filter in the agent status visualization. Now, it filters by `index=wazuh-monitoring**` that let to be usable the `wazuh-monitoring-3x` of Wazuh 3.x.
  - Added configuration files for the indexer and forwarder in root `setup` folder:
  ```
  - setup:
      - forwarder:
          - inputs.conf
          - props.conf
      - indexer:
          - indexes.conf
          - inputs.conf
  ```
  
Related Issue #954