### PR TITLE
Fix/overlaping tooltips moved to avoid blinking

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agents-audit.html
@@ -21,7 +21,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agents-ciscat.html
@@ -20,7 +20,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/docker/agents-docker.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/docker/agents-docker.html
@@ -22,7 +22,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
@@ -24,7 +24,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/gdpr/agents-gdpr.html
@@ -21,7 +21,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agents-general.html
@@ -22,7 +22,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/hipaa/agents-hipaa.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/hipaa/agents-hipaa.html
@@ -22,7 +22,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/inventory/inventory.html
@@ -21,7 +21,7 @@
     <button ng-if="reportingEnabled" ng-disabled="loadingReporting" md-no-ink
       class="btn wz-button-empty wz-button-report" ng-click="startVis2Png()" aria-label="Generate report button">
       <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-      <md-tooltip md-direction="left" class="wz-tooltip">
+      <md-tooltip md-direction="bottom" class="wz-tooltip">
         Generate report
       </md-tooltip>
     </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/nist/agents-nist.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/nist/agents-nist.html
@@ -22,7 +22,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/osquery/osquery.html
@@ -21,7 +21,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/overview.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/overview.html
@@ -206,7 +206,7 @@
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Auditing and Policy Monitoring</h3>
           <div class="extensions-eye">
-            <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+            <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('auditing')" icon="eye" color="#396e3e" class="pull-right">
             </wz-svg>
           </div>
@@ -268,7 +268,7 @@
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Threat Detection and Response</h3>
           <div class="extensions-eye">
-            <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+            <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('threadDetection')" icon="eye" color="#396e3e" class="pull-right">
             </wz-svg>
           </div>
@@ -324,7 +324,7 @@
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Regulatory Compliance</h3>
           <div class="extensions-eye">
-            <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+            <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('regulatory')" icon="eye" color="#396e3e" class="pull-right">
             </wz-svg>
           </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/pcidss/agents-pci.html
@@ -22,7 +22,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/policy-monitoring/agents-pm.html
@@ -22,7 +22,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agents-openscap.html
@@ -20,7 +20,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agents-virustotal.html
@@ -21,7 +21,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
@@ -21,7 +21,7 @@
       <button ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/discover/discover.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/discover/discover.html
@@ -16,7 +16,7 @@
     <div class="div-dash">
       <span class="btn wz-button-empty" ng-click="backToDashboard()" aria-label="Dashboard">
         <i class="fa fa-fw fa-table" aria-hidden="true"></i>&nbsp;Dashboard
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Back to the dashboard.
         </md-tooltip>
       </span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb-id.html
@@ -89,7 +89,7 @@
                     <button class="btn btn-as-i" ng-disabled="!newKey"
                       ng-click="addEntry(newKey, newValue); newKey=''; newValue=''">
                       <wz-svg icon="plus" color="#396e3e"></wz-svg>
-                      <md-tooltip md-direction="left" class="wz-tooltip">
+                      <md-tooltip md-direction="bottom" class="wz-tooltip">
                         Add new entry
                       </md-tooltip>
                     </button>
@@ -116,13 +116,13 @@
                       </wz-svg>
                       <span ng-show="editingKey === item[0]" class="fa fa-fw fa-times cursor-pointer"
                         ng-click="cancelEditingKey()">
-                        <md-tooltip md-direction="left" class="wz-tooltip">
+                        <md-tooltip md-direction="bottom" class="wz-tooltip">
                           Cancel
                         </md-tooltip>
                       </span>
                       <span ng-show="editingKey === item[0] && editingNewValue !== ''"
                         class="fa fa-fw fa-check cursor-pointer" ng-click="editKey(item[0], editingNewValue)">
-                        <md-tooltip md-direction="left" class="wz-tooltip">
+                        <md-tooltip md-direction="bottom" class="wz-tooltip">
                           Apply
                         </md-tooltip>
                       </span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
@@ -181,7 +181,7 @@
                                 <button class="btn btn-as-i" ng-disabled="!newKey"
                                   ng-click="addEntry(newKey, newValue); newKey=''; newValue=''">
                                   <wz-svg icon="plus" color="#396e3e"></wz-svg>
-                                  <md-tooltip md-direction="left" class="wz-tooltip">
+                                  <md-tooltip md-direction="bottom" class="wz-tooltip">
                                     Add new entry
                                   </md-tooltip>
                                 </button>
@@ -206,13 +206,13 @@
                                   </wz-svg>
                                   <span ng-show="editingKey === item[0]" class="fa fa-fw fa-times cursor-pointer"
                                     ng-click="cancelEditingKey()">
-                                    <md-tooltip md-direction="left" class="wz-tooltip">
+                                    <md-tooltip md-direction="bottom" class="wz-tooltip">
                                       Cancel
                                     </md-tooltip>
                                   </span>
                                   <span ng-show="editingKey === item[0] && editingNewValue !== ''"
                                     class="fa fa-fw fa-check cursor-pointer" ng-click="editKey(item[0], editingNewValue)">
-                                    <md-tooltip md-direction="left" class="wz-tooltip">
+                                    <md-tooltip md-direction="bottom" class="wz-tooltip">
                                       Apply
                                     </md-tooltip>
                                   </span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoring.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/monitoring/monitoring.html
@@ -191,7 +191,7 @@
           <!-- Nodes -->
           <div layout="row" class="wz-padding-top-10 cursor-pointer" ng-click="goNodes()">
             <span flex="25" class="wz-text-link">Nodes
-              <md-tooltip md-direction="left" class="wz-tooltip">
+              <md-tooltip md-direction="bottom" class="wz-tooltip">
                 Click to open the list of nodes
               </md-tooltip>
             </span>
@@ -204,7 +204,7 @@
           <!-- Agents -->
           <div layout="row" class="wz-padding-top-10 cursor-pointer" ui-sref='agents'>
             <span flex="25" class="wz-text-link">Agents
-              <md-tooltip md-direction="left" class="wz-tooltip">
+              <md-tooltip md-direction="bottom" class="wz-tooltip">
                 Click to open the list of agents
               </md-tooltip>
             </span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/reporting/reporting.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/reporting/reporting.html
@@ -49,7 +49,7 @@
       <span>
         <wz-svg icon="refresh"></wz-svg>
         Refresh</span>
-      <md-tooltip md-direction="left" class="wz-tooltip">
+      <md-tooltip md-direction="bottom" class="wz-tooltip">
         Refresh
       </md-tooltip>
     </md-button>
@@ -73,13 +73,13 @@
                 <td>
                   <a ng-href="/static/app/SplunkAppForWazuh/{{item.name}}" flex class="wz-text-right" target="_blank">
                     <wz-svg icon="download"></wz-svg>
-                    <md-tooltip md-direction="left" class="wz-tooltip">
+                    <md-tooltip md-direction="bottom" class="wz-tooltip">
                       Download report
                     </md-tooltip>
                   </a>
                   <a flex class="wz-text-right cursor-pointer" ng-click="deleteReport(item.name)">
                     <wz-svg icon="trash"></wz-svg>
-                    <md-tooltip md-direction="left" class="wz-tooltip">
+                    <md-tooltip md-direction="bottom" class="wz-tooltip">
                       Delete report
                     </md-tooltip>
                   </a>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overview-audit.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/aws/aws.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/overview-ciscat.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/docker/overview-docker.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/docker/overview-docker.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/fim/overview-fim.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/gdpr/overview-gdpr.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overview-general.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/hipaa/overview-hipaa.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/hipaa/overview-hipaa.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/nist/overview-nist.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/nist/overview-nist.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/osquery/osquery.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/pci/overview-pci.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/policy-monitoring/overview-pm.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/sca/overview-sca.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/sca/overview-sca.html
@@ -11,7 +11,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overview-openscap.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overview-virustotal.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overview-vulnerabilities.html
@@ -10,7 +10,7 @@
       <button ng-if="reportingEnabled" ng-if="reportingEnabled" md-no-ink class="btn wz-button-empty wz-button-report"
         ng-disabled="loadingVizz || loadingReporting" ng-click="startVis2Png()" aria-label="Generate report button">
         <i class="fa fa-fw fa-print" aria-hidden="true"></i>
-        <md-tooltip md-direction="left" class="wz-tooltip">
+        <md-tooltip md-direction="bottom" class="wz-tooltip">
           Generate report
         </md-tooltip>
       </button>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overview-welcome.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overview-welcome.html
@@ -49,7 +49,7 @@
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Security Information Management</h3>
           <div class="extensions-eye">
-            <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+            <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('security')" icon="eye" color="#396e3e" class="pull-right"></wz-svg>
           </div>
           <div ng-show="extensionsLists.security" class="extensions-list">
@@ -83,7 +83,7 @@
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Auditing and Policy Monitoring</h3>
           <div class="extensions-eye">
-            <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+            <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('auditing')" icon="eye" color="#396e3e" class="pull-right"></wz-svg>
           </div>
           <div ng-show="extensionsLists.auditing" class="extensions-list">
@@ -128,7 +128,7 @@
       <div class="euiPanel euiPanel--paddingLarge">
         <h3 class="euiTitle wc-title welcome-card-main-title">Threat Detection and Response</h3>
         <div class="extensions-eye">
-          <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+          <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
           <wz-svg ng-click="showExtensionsLists('threadDetection')" icon="eye" color="#396e3e" class="pull-right">
           </wz-svg>
         </div>
@@ -186,7 +186,7 @@
       <div class="euiPanel euiPanel--paddingLarge">
         <h3 class="euiTitle wc-title welcome-card-main-title">Regulatory Compliance</h3>
         <div class="extensions-eye">
-          <md-tooltip class="wz-tooltip" md-direction="left">Show extensions list</md-tooltip>
+          <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
           <wz-svg ng-click="showExtensionsLists('regulatory')" icon="eye" color="#396e3e" class="pull-right"></wz-svg>
         </div>
         <div ng-show="extensionsLists.regulatory" class="extensions-list">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/configuration/configuration.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/configuration/configuration.html
@@ -47,7 +47,7 @@
               <!-- switch to edit -->
               <div ng-show="!editingKey || editingKey !== key">
                 <wz-svg icon="pencil" color="#396e3e" ng-click="switchEdit(key, val)">
-                  <md-tooltip md-direction="left" class="wz-tooltip">
+                  <md-tooltip md-direction="bottom" class="wz-tooltip">
                     Edit
                   </md-tooltip>
                 </wz-svg>
@@ -55,12 +55,12 @@
               <div ng-show="editingKey === key">
                 <span style="color: #396e3e">
                   <i ng-click="cancelEdition()" class="fa fa-fw fa-times cursor-pointer">
-                    <md-tooltip md-direction="left" class="wz-tooltip">
+                    <md-tooltip md-direction="bottom" class="wz-tooltip">
                       Cancel
                     </md-tooltip>
                   </i>
                   <i ng-click="setValue(key)" class="fa fa-fw fa-check cursor-pointer">
-                    <md-tooltip md-direction="left" class="wz-tooltip">
+                    <md-tooltip md-direction="bottom" class="wz-tooltip">
                       Apply
                     </md-tooltip>
                   </i>

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-discover/wz-discover.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-discover/wz-discover.html
@@ -2,7 +2,7 @@
   <button class="btn wz-button-empty" ng-click="discoverSection()" aria-label="Discover">
     <wz-svg icon="compass"></wz-svg>
     &nbsp;Discover
-    <md-tooltip md-direction="left" class="wz-tooltip">
+    <md-tooltip md-direction="bottom" class="wz-tooltip">
       Open a search with the applied filters on this section.
     </md-tooltip>
   </button>

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-svg/wz-svg.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-svg/wz-svg.html
@@ -1,7 +1,7 @@
 <div ng-if="icon === 'spinner'" class="euiLoadingSpinner euiLoadingSpinner--medium"></div>
 
 <span ng-if="icon === 'download'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -13,7 +13,7 @@
 </span>
 
 <span ng-if="icon === 'settings'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--ghost euiIcon--app" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -28,7 +28,7 @@
 
 
 <span ng-if="icon === 'download-big'" class="cursor-pointer" style="color: {{color}}">
-    <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+    <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
       {{svgTooltip}}
     </md-tooltip>
     <svg class="euiIcon euiIcon--medium" style="width:auto; height:auto;" focusable="false" xmlns="http://www.w3.org/2000/svg" width="70" height="70"
@@ -41,7 +41,7 @@
  
 
 <span ng-if="icon === 'pencil'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--primary" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -56,7 +56,7 @@
 </span>
 
 <span ng-if="icon === 'eye'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--primary" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16"
@@ -68,7 +68,7 @@
 </span>
 
 <span ng-if="icon === 'trash'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--danger" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -83,7 +83,7 @@
 </span>
 
 <span ng-if="icon === 'refresh'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -95,7 +95,7 @@
 </span>
 
 <span ng-if="icon === 'star'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -107,7 +107,7 @@
 </span>
 
 <span ng-if="icon === 'expand'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -119,7 +119,7 @@
 </span>
 
 <span ng-if="icon === 'chart'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--ghost euiIcon--app" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -133,7 +133,7 @@
 </span>
 
 <span ng-if="icon === 'cloud'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--ghost euiIcon--app" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -150,7 +150,7 @@
 </span>
 
 <span ng-if="icon === 'compass'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--ghost euiIcon--app" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -164,7 +164,7 @@
 </span>
 
 <span ng-if="icon === 'console'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -179,7 +179,7 @@
 </span>
 
 <span ng-if="icon === 'list'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg"
@@ -194,7 +194,7 @@
 </span>
 
 <span ng-if="icon === 'circles'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -206,7 +206,7 @@
 </span>
 
 <span ng-if="icon === 'wrench'" class="cursor-pointer" style="color: {{color}}">
-  <md-tooltip md-direction="left" class="wz-tooltip" ng-if="svgTooltip">
+  <md-tooltip md-direction="bottom" class="wz-tooltip" ng-if="svgTooltip">
     {{svgTooltip}}
   </md-tooltip>
   <svg class="euiIcon euiIcon--medium euiIcon--primary" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16"
@@ -226,7 +226,7 @@
   </svg>
 </span>
 
-<span ng-if="icon === 'hex'" class="cursor-pointer" style="color: {{color}}">
+<span ng-if="icon === 'hex'" style="color: {{color}}">
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
     viewBox="0 0 16 16">
     <path
@@ -236,7 +236,7 @@
 </span>
 
 
-<span ng-if="icon === 'burble'" class="cursor-pointer" style="color: {{color}}">
+<span ng-if="icon === 'burble'" style="color: {{color}}">
   <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
     viewBox="0 0 16 16">
     <path

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
@@ -16,7 +16,7 @@
       </div>
     </div>
     <div ng-class="{'showing-checks':showingChecks, 'not-showing-checks':!showingChecks}">
-      <md-tooltip md-direction="left" class="wz-tooltip">
+      <md-tooltip md-direction="bottom" class="wz-tooltip">
         Show or hide columns
       </md-tooltip>
       <span class="action-btn-td cursor-pointer" ng-click="showCheckbox()">

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-tag-filter/wz-tag-filter.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-tag-filter/wz-tag-filter.html
@@ -27,7 +27,7 @@
       ng-focus='showAutocomplete(true)' ng-blur='showAutocomplete(false)' placeholder='Add filter or search' ng-keyup='!autocompleteEnter && $event.keyCode == 13 ? addTag(true) : addSearchKey($event)' />
     <span ng-show="groupedTagList.length" class='wz-tag-remove-button wz-padding-top-5 remove-filters cursor-pointer' ng-click='removeAll()'><i class="fa fa-times"
         aria-hidden="true"></i>
-      <md-tooltip md-direction="left" class="wz-tooltip">
+      <md-tooltip md-direction="bottom" class="wz-tooltip">
         Remove all filters
       </md-tooltip>
     </span>


### PR DESCRIPTION
Hi team, this PR resolve these bugs:
- Move tooltips to bottom position to avoid blinking due to overlapping tooltip with the button
- Remove cursor pointer for title icons where there are no options at onClick