### PR TITLE
Fix no panel in Configuration > Alerts > Email alerts when emails are not configurated

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
@@ -377,7 +377,7 @@
 
     <!-- No configuration section -->
     <wz-no-config flex error="currentConfig['csyslog-csyslog']" ng-if="currentConfig['csyslog-csyslog'] && isString(currentConfig['csyslog-csyslog'])"></wz-no-config>
-    <wz-no-config flex error="'not-present'" ng-if="currentConfig['csyslog-csyslog'] && !isString(currentConfig['csyslog-csyslog']) || (!currentConfig['csyslog-csyslog'].syslog_output || !currentConfig['csyslog-csyslog'].syslog_output.length)"></wz-no-config>
+    <wz-no-config flex error="'not-present'" ng-if="(currentConfig['csyslog-csyslog'] && !isString(currentConfig['csyslog-csyslog'])) && (!currentConfig['csyslog-csyslog'].syslog_output || !currentConfig['csyslog-csyslog'].syslog_output.length)"></wz-no-config>
     <!-- End no configuration section -->
 
     <!-- This section is the main content -->

--- a/SplunkAppForWazuh/appserver/static/js/utils/query-config.js
+++ b/SplunkAppForWazuh/appserver/static/js/utils/query-config.js
@@ -61,7 +61,7 @@ define([], function() {
           : partialResult.data.data;
         } 
         else if (partialResult.data.error) {
-          result[`${component}-${configuration}`] = partialResult.data.message
+          result[`${component}-${configuration}`] = partialResult.data.detail || partialResult.data.message
         }
       }
       return result


### PR DESCRIPTION
Hi team, this PR resolves:
- Configuration > Alerts > Email alerts section didn't display anything when emails are not configurated

Related Issue #953