### PR TITLE
Fix link to group in Agent overview and agent platform setted incorrectly

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/agentsOverviewCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/agentsOverviewCtrl.js
@@ -282,7 +282,7 @@ define(['../../module'], function(app) {
      */
     async goGroups(group) {
       try {
-        this.groupInfo = await this.requestService.apiReq(`/agents/groups/`)
+        this.groupInfo = await this.requestService.apiReq(`/groups`)
         if (
           typeof this.groupInfo.data === 'object' &&
           typeof this.groupInfo.data.data === 'object'
@@ -403,11 +403,12 @@ define(['../../module'], function(app) {
     setAgentPlatform() {
       try {
         this.scope.agentPlatform = 'other'
+        const agentInfo = ((((this.agent[0] || []).data || {}).data || {}).affected_items || [])[0] || {}
         let agentPlatformLinux = (
-          (((this.agent[0] || []).data || {}).data || {}).os || {}
+          (agentInfo || {}).os || {}
         ).uname
         let agentPlatformOther = (
-          (((this.agent[0] || []).data || {}).data || {}).os || {}
+          (agentInfo || {}).os || {}
         ).platform
         if (agentPlatformLinux && agentPlatformLinux.includes('Linux')) {
           this.scope.agentPlatform = 'linux'


### PR DESCRIPTION
Hi team, this PR resolves:
- Fix link to agent group in Agent overview
- Fix agent platform variable in Agent overview. It should show the `System auditing` panel when is enabled in the `AUDITING AND POLICY MONITORING` panel

Related Issue #953