### PR TITLE
Fixed Agents table status filter doesn't work

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
@@ -95,7 +95,7 @@ define([
 
         this.scope.searchBarModel = {
           name: [],
-          status: ['Active', 'Disconnected', 'Never connected'],
+          status: ['active', 'disconnect', 'never_connected'],
           group: groups
             ? groups.sort((a, b) => {
                 return a.toString().localeCompare(b.toString())


### PR DESCRIPTION
Hi Team.
This PR resolve the status filter in Agents overview table.

Closes #1011 