### PR TITLE
Adapt files api endpoints

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -192,6 +192,11 @@ class api(controllers.BaseController):
                         json_load = json.loads(json_response)
                         request = json_load
                         return request
+                    if kwargs['origin'] == 'raw':
+                        response = self.session.get(
+                            url + opt_endpoint, headers = {'Authorization': f'Bearer {wazuh_token}'},
+                            verify=verify)
+                        return json.loads(json.dumps({'data': response.content.decode("utf-8") }))
                 else:
                     request = self.session.get(
                         url + opt_endpoint, params=kwargs, headers = {'Authorization': f'Bearer {wazuh_token}'},

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -529,7 +529,7 @@ class manager(controllers.BaseController):
             
             file_info = kwargs["file"].__dict__
             file_name = file_info['filename']
-            file_content = kwargs['file'].file.read(0)
+            file_content = kwargs['file'].file
             # Get path 
             dest_resource = kwargs["resource"]
 
@@ -558,7 +558,7 @@ class manager(controllers.BaseController):
                  
             if 'error' in result and result['error'] != 0:
                 self.logger.error("manager: Error trying to upload a file(s): %s" % (result))
-                return jsonbak.dumps({"status": "400", "text": "Error adding file: %s. Cause: %s" % (file_name,result["message"])})
+                return jsonbak.dumps({"status": "400", "text": "Error adding file: %s. Cause: %s" % (file_name,result["detail"])})
             return jsonbak.dumps({"status": "200", "text": "File %s was updated successfully. " % file_name})
         except Exception as e:
             self.logger.error("manager: Error trying to upload a file(s): %s" % (e))

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb-id.html
@@ -182,7 +182,7 @@
           <div layout="row" class="ruleset-csv-formater">
             <span flex></span>
             <a class="small formatted-color" id="btnDownload"
-              ng-click="downloadCsv('/lists?path=' + currentList.details.path + '/' + currentList.details.file, currentList.details.file + '.csv')">
+              ng-click="downloadCsv('/lists/files/' + currentList.details.file, currentList.details.file + '.csv')">
               <wz-svg icon="download"></wz-svg>&nbsp;Formatted
             </a>
           </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
@@ -23,7 +23,7 @@
 
             <div class="wz-popover-wrapper">
               <div ng-show="uploadingFiles" class="wz-popover-content">
-                  <wz-upload-files upload-title="Upload lists" path="etc/lists/"></wz-upload-files>
+                  <wz-upload-files upload-title="Upload lists" resource="lists"></wz-upload-files>
               </div>
             </div>
             <!-- Loading content -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/cdb/manager-cdb.html
@@ -23,7 +23,7 @@
 
             <div class="wz-popover-wrapper">
               <div ng-show="uploadingFiles" class="wz-popover-content">
-                  <wz-upload-files upload-title="Upload rules" path="etc/lists/"></wz-upload-files>
+                  <wz-upload-files upload-title="Upload lists" path="etc/lists/"></wz-upload-files>
               </div>
             </div>
             <!-- Loading content -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders-id.html
@@ -47,17 +47,17 @@
             Position:
             <span class="wz-text-bold">{{currentDecoder.position}}</span>
           </div>
-          <div flex="40" ng-if="currentDecoder.file" class="wz-text-truncatable">File:
+          <div flex="40" ng-if="currentDecoder.filename" class="wz-text-truncatable">File:
             <span class="wz-text-bold wz-text-link"
-              ng-click="editDecoder(currentDecoder.file)">{{currentDecoder.file}}
+              ng-click="editDecoder(currentDecoder.filename)">{{currentDecoder.filename}}
               <md-tooltip md-direction="bottom" class="wz-tooltip">
                 Filter by this file
               </md-tooltip>
             </span>
           </div>
-          <div flex="40" ng-if="currentDecoder.path" class="wz-text-truncatable">Path:
+          <div flex="40" ng-if="currentDecoder.relative_dirname" class="wz-text-truncatable">Path:
             <span class="wz-text-bold wz-text-link"
-              ng-click="addDetailFilter('path', currentDecoder.path)">{{currentDecoder.path}}
+              ng-click="addDetailFilter('path', currentDecoder.relative_dirname)">{{currentDecoder.relative_dirname}}
               <md-tooltip md-direction="bottom" class="wz-tooltip">
                 Filter by this path
               </md-tooltip>
@@ -70,10 +70,10 @@
 
     <!-- Edit button -->
     <div layout="row" ng-if="!editingFile">
-      <button ng-if="currentDecoder.file && isLocal && adminMode" ng-click="editDecoder(currentDecoder.file)"
+      <button ng-if="currentDecoder.filename && isLocal && adminMode" ng-click="editDecoder(currentDecoder.filename)"
         class="btn wz-button-empty btn-ruleset ng-scope">
         <wz-svg icon="pencil"></wz-svg>
-        Edit {{currentDecoder.file}}
+        Edit {{currentDecoder.filename}}
       </button>
     </div>
 
@@ -164,7 +164,7 @@
         </div>
         <div layout="row" class="md-padding">
           <wazuh-table custom-columns="true" flex path="'/decoders'"
-            implicit-filter="[{ name:'file',value: currentDecoder.file}]"
+            implicit-filter="[{ name:'filename',value: currentDecoder.filename}]"
             keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'filename',{value:'relative_dirname',nosortable:true}]"
             allow-click="true">
           </wazuh-table>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders.html
@@ -28,7 +28,7 @@
             
             <div class="wz-popover-wrapper">
               <div ng-show="uploadingFiles" class="wz-popover-content">
-                  <wz-upload-files upload-title="Upload decoders" path="etc/decoders/" allowed-extensions="'.xml'"></wz-upload-files>
+                  <wz-upload-files upload-title="Upload decoders" resource="decoders" allowed-extensions="'.xml'"></wz-upload-files>
               </div>
             </div>
             <!-- Loading content -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders.html
@@ -179,7 +179,7 @@
               <div ng-if="editingRulesetFile">
                   <div layout="row" class="md-padding wz-padding-top-0">
                     <button ng-click='closeEditingFile()' class='btn wz-button-cancel'>Cancel</button>
-                    <button ng-if="adminMode" ng-disabled='xmlHasErrors || overwrite || saveIncomplete' ng-click='saveFile(editingRulesetFile.path)'
+                    <button ng-if="adminMode" ng-disabled='xmlHasErrors || overwrite || saveIncomplete' ng-click='saveFile(editingRulesetFile.file, editingRulesetFile.dir)'
                       class='btn wz-button-empty pull-right wz-margin-left-10'>
                       <span ng-show='!xmlHasErrors && adminMode'><i
                           ng-class="{'fa fa-fw fa-spin fa-spinner': saveIncomplete, 'fa fa-fw fa-save': !saveIncomplete}"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/managerDecodersIdCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/managerDecodersIdCtrl.js
@@ -61,7 +61,7 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
         this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
         this.scope.addDetailFilter = (name, value) =>
           this.addDetailFilter(name, value)
-        this.scope.isLocal = this.scope.currentDecoder.path === 'etc/decoders'
+        this.scope.isLocal = this.scope.currentDecoder.relative_dirname === 'etc/decoders'
         this.scope.saveDecoderConfig = fileName =>
           this.saveDecoderConfig(fileName)
         this.scope.closeEditingFile = () => this.closeEditingFile()
@@ -119,8 +119,8 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
 
     async editDecoder(fileName) {
       try {
-        const readOnly = !(this.scope.currentDecoder.path === 'etc/decoders')
-        const result = await this.fetchFileContent(fileName, readOnly)
+        const readOnly = !(this.scope.currentDecoder.relative_dirname === 'etc/decoders')
+        const result = await this.fetchFileContent(fileName, this.scope.currentDecoder.relative_dirname, readOnly)
       } catch (error) {}
       return
     }
@@ -129,17 +129,16 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
      * Fetches file content
      * @param {String} file
      */
-    async fetchFileContent(file, readOnly = false) {
+    async fetchFileContent(file, path, readOnly = false) {
       try {
         this.scope.editingFile = true
         this.scope.readOnly = readOnly
         if (readOnly) {
           if (!file.startsWith('ruleset/decoders')) {
             this.scope.fileName = file
-            file = this.scope.currentDecoder.path + '/' + file
             this.scope.XMLContent = await this.fileEditor.getConfiguration(
               file,
-              null,
+              path,
               null,
               readOnly
             )
@@ -149,7 +148,7 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
           } else {
             this.scope.XMLContent = await this.fileEditor.getConfiguration(
               file,
-              null,
+              path,
               null,
               readOnly
             )
@@ -159,7 +158,7 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
           if (file.startsWith('etc/decoders/')) {
             this.scope.fetchedXML = await this.fileEditor.getConfiguration(
               file,
-              null,
+              path,
               null,
               readOnly
             )
@@ -167,7 +166,7 @@ define(['../../module', '../rules/ruleset'], function(controllers, Ruleset) {
           } else {
             this.scope.fetchedXML = await this.fileEditor.getConfiguration(
               file,
-              'decoders',
+              path,
               null,
               readOnly
             )

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset.html
@@ -30,7 +30,7 @@
           
             <div class="wz-popover-wrapper">
                 <div ng-show="uploadingFiles" class="wz-popover-content">
-                    <wz-upload-files upload-title="Upload rules" path="etc/rules/" allowed-extensions="'.xml'"></wz-upload-files>
+                    <wz-upload-files upload-title="Upload rules" resource="rules" allowed-extensions="'.xml'"></wz-upload-files>
                 </div>
               </div>
           <!-- Loading content -->

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/managerRulesetIdCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/managerRulesetIdCtrl.js
@@ -136,22 +136,21 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
     async editRule(fileName) {
       try {
         const readOnly = !(this.scope.ruleInfo.relative_dirname === 'etc/rules')
-        await this.fetchFileContent(fileName, readOnly)
+        await this.fetchFileContent(fileName, this.scope.ruleInfo.relative_dirname, readOnly)
       } catch (error) {}
       return
     }
 
-    async fetchFileContent(file, readOnly = false) {
+    async fetchFileContent(file, path, readOnly = false) {
       try {
         this.scope.editingFile = true
         this.scope.readOnly = readOnly
         if (readOnly) {
           if (!file.startsWith('ruleset/rules')) {
             this.scope.fileName = file
-            file = this.scope.ruleInfo.relative_dirname + '/' + file
             this.scope.XMLContent = await this.fileEditor.getConfiguration(
               file,
-              null,
+              path,
               null,
               readOnly
             )
@@ -161,7 +160,7 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
           } else {
             this.scope.XMLContent = await this.fileEditor.getConfiguration(
               file,
-              null,
+              path,
               null,
               readOnly
             )
@@ -171,7 +170,7 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
           if (file.startsWith('etc/rules/')) {
             this.scope.fetchedXML = await this.fileEditor.getConfiguration(
               file,
-              null,
+              path,
               null,
               readOnly
             )
@@ -179,7 +178,7 @@ define(['../../module', './ruleset'], function(controllers, Ruleset) {
           } else {
             this.scope.fetchedXML = await this.fileEditor.getConfiguration(
               file,
-              'rules',
+              path,
               null,
               readOnly
             )

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/ruleset.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/ruleset.js
@@ -561,8 +561,10 @@ define(['../../module', 'FileSaver'], function(app) {
     async editFile(file, path, readOnly = false) {
       try {
         if (readOnly) {
-          this.scope.XMLContent = await this.fetchFileContent(
-            `${path}/${file}`,
+          this.scope.XMLContent = await this.fileEditor.getConfiguration(
+            file,
+            path,
+            null,
             readOnly
           )
           this.scope.$broadcast('XMLContentReady', {
@@ -573,9 +575,15 @@ define(['../../module', 'FileSaver'], function(app) {
           this.scope.editingRulesetFile = {
             file,
             dir: path,
+            // typeFile,
             path: `${path}/${file}`
           }
-          this.scope.fetchedXML = await this.fetchFileContent(`${path}/${file}`)
+          this.scope.fetchedXML = await this.fileEditor.getConfiguration(
+            file,
+            path,
+            null,
+            readOnly
+            )
           this.scope.$broadcast('fetchedFile', { data: this.scope.fetchedXML })
         }
       } catch (error) {
@@ -597,24 +605,6 @@ define(['../../module', 'FileSaver'], function(app) {
         dir,
         overwrite: true
       })
-    }
-
-    /**
-     * Fetchs file content
-     * @param {String} file
-     */
-    async fetchFileContent(file, readOnly = false) {
-      try {
-        const result = await this.fileEditor.getConfiguration(
-          file,
-          null,
-          null,
-          readOnly
-        )
-        return result
-      } catch (error) {
-        return Promise.reject(error)
-      }
     }
 
     /**

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/ruleset.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/ruleset.js
@@ -575,7 +575,6 @@ define(['../../module', 'FileSaver'], function(app) {
           this.scope.editingRulesetFile = {
             file,
             dir: path,
-            // typeFile,
             path: `${path}/${file}`
           }
           this.scope.fetchedXML = await this.fileEditor.getConfiguration(

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-upload-files/wz-upload-files.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-upload-files/wz-upload-files.html
@@ -44,7 +44,10 @@
                     <span class="dz-upload" data-dz-uploadprogress=""></span>
                 </div>  
                 <div class="dz-error-message">
-                    <span data-dz-errormessage="">
+                    <span ng-if="errorMessage">
+                        {errorMessage}
+                    </span>
+                    <span  ng-if="!errorMessage" data-dz-errormessage="">
 
                     </span>
                 </div>  

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-upload-files/wz-upload-files.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-upload-files/wz-upload-files.js
@@ -19,7 +19,7 @@ define(['../module','Dropzone'], function(app,Dropzone) {
         uploadTitle: '@uploadTitle',
         allowedExtensions: '=allowedExtensions',
         refreshList: '&',
-        path: '@path'
+        resource: '@resource'
       },
       controller($scope,$currentDataService) {
         $scope.noFilesAdded = true
@@ -34,13 +34,14 @@ define(['../module','Dropzone'], function(app,Dropzone) {
         const currentApi = apiId['_key']
 
         $scope.myDropzone = new Dropzone("#myDropzone",{
-          url: `en-us/custom/SplunkAppForWazuh//manager/upload_file?apiId=${currentApi}&path=${$scope.path}`, 
+          url: `en-us/custom/SplunkAppForWazuh/manager/upload_file?apiId=${currentApi}&resource=${$scope.resource}`, 
           autoProcessQueue: false,
           parallelUploads: 5,
           maxFiles: 5,
           previewTemplate: previewTemplate,
           previewsContainer: "#previews",
-          acceptedFiles: $scope.allowedExtensions
+          acceptedFiles: $scope.allowedExtensions,
+          method: 'POST'
         })
         
 
@@ -55,6 +56,7 @@ define(['../module','Dropzone'], function(app,Dropzone) {
               $scope.noFilesAdded = false
             }            
           }
+
           $scope.myDropzone.on("success", function (file, message) {
             message = JSON.parse(message)
             if (file.previewElement) {
@@ -87,10 +89,11 @@ define(['../module','Dropzone'], function(app,Dropzone) {
           $scope.myDropzone.on("error", function (file, jsonResponse) {
             var errorMessage = "Could not upload document: ";
             if (jsonResponse["ValidationMessage"] != null) {
-                errorMessage += jsonResponse["ValidationMessage"];
+                $scope.errorMessage += jsonResponse["ValidationMessage"];
             } else {
-                errorMessage += "unknown error";
+                $scope.errorMessage += "unknown error";
             }
+            
         });
 
         $scope.myDropzone.on("removedfile", function (file) {

--- a/SplunkAppForWazuh/appserver/static/js/services/cdb-editor/cdb-editor.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/cdb-editor/cdb-editor.js
@@ -21,9 +21,7 @@ define(['../module'], function(module) {
 
     async sendConfiguration(file, path, content, overwrite = false) {
       try {
-        const url = overwrite
-          ? `/manager/files?path=${path}/${file}&overwrite=true`
-          : `/manager/files?path=${path}/${file}`
+        const url = `/lists/files/${file}?overwrite=${overwrite}`
         const result = await this.apiReq(
           `${url}`,
           { content, origin: 'raw' },
@@ -49,16 +47,18 @@ define(['../module'], function(module) {
 
     async getConfiguration(file, path) {
       try {
-        const url = `/manager/files?path=${path}/${file}`
-        const result = await this.getConfig(url)
+        const url = `/lists/files/${file}?raw=true`
+        const result = await this.apiReq(
+          url,
+          { origin:"raw" }
+        )
         if (
           !result ||
-          !result.data ||
-          result.data.error != 0
+          !result.data
         ) {
           throw new Error('Error fetching cdb list content')
         }
-        return result.data.contents
+        return result.data.data
       } catch (error) {
         return Promise.reject(error)
       }

--- a/SplunkAppForWazuh/default/app.conf
+++ b/SplunkAppForWazuh/default/app.conf
@@ -3,7 +3,7 @@ is_visible = 1
 label = Wazuh
 
 [launcher]
-version = 4.0.4
+version = 4.1.3
 author = info@wazuh.com
 description = Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level.
 

--- a/SplunkAppForWazuh/default/package.conf
+++ b/SplunkAppForWazuh/default/package.conf
@@ -1,9 +1,9 @@
 [app]
-version = 4.0.4
+version = 4.1.3
 revision = 68
 
 [wazuh]
-version = 4.0.4
+version = 4.1.3
 
 [splunk]
 version = 8.1.1


### PR DESCRIPTION
### Description

Hi team, this PR resolves:

- Adapt the calls to endpoints about rules/decoders/files content, saving and editing
- Fixed export of CDB list keys and values

Closes #1025

### Checks
Use Wazuh API 4.1.3

- Rules
  - See file content
  - Edit and save content
  - Delete file
  - Import file
  - See file content from the rule detail
- Decoders
  - See file content
  - Edit and save content
  - Delete file
  - Import file
  - See file content from the decoder detail  
- CDB List
  - See file content
  - Edit and save content
  - Delete file
  - Import file
  - Export keys and values as `.csv` file
  
  