### PR TITLE
Allow partial string search in main search

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-tag-filter/wz-tag-filter.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-tag-filter/wz-tag-filter.js
@@ -120,7 +120,7 @@ define(['../module'], function(app) {
                   .filter(x => x.type === 'filter')
                   .forEach((tag, idx2) => {
                     const value = tag.value.value === 'unknown' ? 'null' : tag.value.value;
-                    queryObj.query += tag.key + '=' + value;
+                    queryObj.query += tag.key + '~' + value;
                     if (idx2 != group.length - 1) {
                       queryObj.query +=
                         $scope.connectors[idx].subgroup[idx2].value


### PR DESCRIPTION
Hi team,

this changes the equal operator to _like_ operator, which allows partial string search when filtering by tag.

Closes #1012 