### PR TITLE
Add script to generate the API info and update to API 4.1.3

### DIFF
--- a/SplunkAppForWazuh/bin/api_info/endpoints.json
+++ b/SplunkAppForWazuh/bin/api_info/endpoints.json
@@ -1,10093 +1,10735 @@
 [
-    {
-      "method": "GET",
-      "endpoints": [
-        {
-          "name": "/",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.default_controller.default_info",
-          "description": "Return basic information about the API",
-          "summary": "Get API info",
-          "tags": [
-            "API Info"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+  {
+    "method": "GET",
+    "endpoints": [
+      {
+        "name": "/",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.default_controller.default_info",
+        "description": "Return basic information about the API",
+        "summary": "Get API info",
+        "tags": [
+          "API Info"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/agents",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agents",
-          "description": "Return information about all available agents or a list of them",
-          "summary": "List agents",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "group",
-              "description": "Filter by group of agents",
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            },
-            {
-              "name": "ip",
-              "description": "Filter by the IP used by the agent to communicate with the manager. If it's not available, it will have the same value as registerIP",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "manager",
-              "description": "Filter by manager hostname where agents are connected to",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by agent name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "node_name",
-              "description": "Filter by node name",
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "older_than",
-              "description": "Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used",
-              "schema": {
-                "type": "string",
-                "format": "timeframe"
-              }
-            },
-            {
-              "name": "os.name",
-              "description": "Filter by OS name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "os.platform",
-              "description": "Filter by OS platform",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "os.version",
-              "description": "Filter by OS version",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "registerIP",
-              "description": "Filter by the IP used when registering the agent",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by agent status (use commas to enter multiple statuses)",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "pending",
-                    "never_connected",
-                    "disconnected"
-                  ]
-                },
-                "minItems": 1
-              }
-            },
-            {
-              "name": "version",
-              "description": "Filter by agents version",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/config/:component/:configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_config",
-          "description": "Return the active configuration the agent is currently using. This can be different from the configuration present in the configuration file, if it has been modified and the agent has not been restarted yet",
-          "summary": "Get active configuration",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": ":component",
-              "description": "Selected agent's component",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "agent",
-                  "agentless",
-                  "analysis",
-                  "auth",
-                  "com",
-                  "csyslog",
-                  "integrator",
-                  "logcollector",
-                  "mail",
-                  "monitor",
-                  "request",
-                  "syscheck",
-                  "wmodules"
-                ]
-              }
-            },
-            {
-              "name": ":configuration",
-              "description": "<p>Selected agent's configuration to read. The configuration to read depends on the selected component.\nThe following table shows all available combinations of component and configuration values:</p>\n<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>Component</th>\n<th>Configuration</th>\n<th>Tag</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>agent</td>\n<td>client</td>\n<td><code>&lt;client&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>buffer</td>\n<td><code>&lt;client_buffer&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>labels</td>\n<td><code>&lt;labels&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>internal</td>\n<td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>agentless</td>\n<td>agentless</td>\n<td><code>&lt;agentless&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>global</td>\n<td><code>&lt;global&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>active_response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>alerts</td>\n<td><code>&lt;alerts&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>command</td>\n<td><code>&lt;command&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>rules</td>\n<td><code>&lt;rule&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>decoders</td>\n<td><code>&lt;decoder&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>internal</td>\n<td><code>&lt;analysisd&gt;</code></td>\n</tr>\n<tr>\n<td>auth</td>\n<td>auth</td>\n<td><code>&lt;auth&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>active-response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>logging</td>\n<td><code>&lt;logging&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>internal</td>\n<td><code>&lt;execd&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>cluster</td>\n<td><code>&lt;cluster&gt;</code></td>\n</tr>\n<tr>\n<td>csyslog</td>\n<td>csyslog</td>\n<td><code>&lt;csyslog_output&gt;</code></td>\n</tr>\n<tr>\n<td>integrator</td>\n<td>integration</td>\n<td><code>&lt;integration&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>localfile</td>\n<td><code>&lt;localfile&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>socket</td>\n<td><code>&lt;socket&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>internal</td>\n<td><code>&lt;logcollector&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>global</td>\n<td><code>&lt;global&gt;&lt;email...&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>alerts</td>\n<td><code>&lt;email_alerts&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>internal</td>\n<td><code>&lt;maild&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;monitord&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;reports&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>remote</td>\n<td><code>&lt;remote&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>internal</td>\n<td><code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>syscheck</td>\n<td><code>&lt;syscheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>rootcheck</td>\n<td><code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>internal</td>\n<td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>wmodules</td>\n<td>wmodules</td>\n<td><code>&lt;wodle&gt;</code></td>\n</tr>\n</tbody>\n</table>\n",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "client",
-                  "buffer",
-                  "labels",
-                  "internal",
-                  "agentless",
-                  "global",
-                  "active_response",
-                  "alerts",
-                  "command",
-                  "rules",
-                  "decoders",
-                  "auth",
-                  "logging",
-                  "reports",
-                  "active-response",
-                  "cluster",
-                  "csyslog",
-                  "integration",
-                  "localfile",
-                  "socket",
-                  "remote",
-                  "syscheck",
-                  "rootcheck",
-                  "wmodules"
-                ]
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/group/is_sync",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_sync_agent",
-          "description": "Return whether the agent configuration has been synchronized with the agent or not. This can be useful to check after updating a group configuration",
-          "summary": "Get configuration sync status",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
+          }
+        ]
+      },
+      {
+        "name": "/agents",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agents",
+        "description": "Return information about all available agents or a list of them",
+        "summary": "List agents",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "minLength": 3,
                 "description": "Agent ID",
                 "format": "numbers"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "group",
+            "description": "Filter by group of agents",
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/key",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_key",
-          "description": "Return the key of an agent",
-          "summary": "Get key",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
+          },
+          {
+            "name": "ip",
+            "description": "Filter by the IP used by the agent to communicate with the manager. If it's not available, it will have the same value as registerIP",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/upgrade_result",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_upgrade",
-          "description": "Return the upgrade result after updating an agent",
-          "summary": "Get upgrade result",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
+          },
+          {
+            "name": "manager",
+            "description": "Filter by manager hostname where agents are connected to",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "name",
+            "description": "Filter by agent name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ]
-        },
-        {
-          "name": "/agents/no_group",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_no_group",
-          "description": "Return a list with all the available agents without an assigned group",
-          "summary": "List agents without group",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "node_name",
+            "description": "Filter by node name",
+            "schema": {
+              "type": "string",
+              "format": "names"
             }
-          ]
-        },
-        {
-          "name": "/agents/outdated",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_outdated",
-          "description": "Return the list of outdated agents",
-          "summary": "List outdated agents",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
             }
-          ]
-        },
-        {
-          "name": "/agents/stats/distinct",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_fields",
-          "description": "Return all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination",
-          "summary": "List agents distinct",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "fields",
-              "description": "List of fields affecting the operation",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "older_than",
+            "description": "Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used",
+            "schema": {
+              "type": "string",
+              "format": "timeframe"
             }
-          ]
-        },
-        {
-          "name": "/agents/summary/os",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_summary_os",
-          "description": "Return a summary of the OS of available agents",
-          "summary": "Summarize agents OS",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "os.name",
+            "description": "Filter by OS name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ]
-        },
-        {
-          "name": "/agents/summary/status",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agent_summary_status",
-          "description": "Return a summary of the status of available agents",
-          "summary": "Summarize agents status",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "os.platform",
+            "description": "Filter by OS platform",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ]
-        },
-        {
-          "name": "/ciscat/:agent_id/results",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.ciscat_controller.get_agents_ciscat_results",
-          "description": "Return the agent's ciscat results info",
-          "summary": "Get results",
-          "tags": [
-            "Ciscat"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
+          },
+          {
+            "name": "os.version",
+            "description": "Filter by OS version",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ],
-          "query": [
-            {
-              "name": "benchmark",
-              "description": "Filter by benchmark type",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "error",
-              "description": "Filter by encountered errors",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "fail",
-              "description": "Filter by failed checks",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "notchecked",
-              "description": "Filter by not checked",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pass",
-              "description": "Filter by passed checks",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "profile",
-              "description": "Filter by evaluated profile",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "score",
-              "description": "Filter by final score",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "unknown",
-              "description": "Filter by unknown results",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_configuration_node",
-          "description": "Return wazuh configuration used in node {node_id}",
-          "summary": "Get node config",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "registerIP",
+            "description": "Filter by the IP used when registering the agent",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "field",
-              "description": "Indicate a section child. E.g, fields for *ruleset* section are: decoder_dir, rule_dir, etc",
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "section",
-              "description": "Indicates the wazuh configuration section",
-              "schema": {
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by agent status (use commas to enter multiple statuses)",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "enum": [
-                  "active-response",
-                  "agentless",
-                  "alerts",
-                  "auth",
-                  "client",
-                  "client_buffer",
-                  "cluster",
-                  "command",
-                  "database_output",
-                  "email_alerts",
-                  "global",
-                  "integration",
-                  "labels",
-                  "localfile",
-                  "logging",
-                  "remote",
-                  "reports",
-                  "rootcheck",
-                  "ruleset",
-                  "sca",
-                  "socket",
-                  "syscheck",
-                  "syslog_output",
-                  "agent-key-polling",
-                  "aws-s3",
-                  "azure-logs",
-                  "cis-cat",
-                  "docker-listener",
-                  "open-scap",
-                  "osquery",
-                  "syscollector",
-                  "vulnerability-detector"
+                  "active",
+                  "pending",
+                  "never_connected",
+                  "disconnected"
                 ]
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/configuration/:component/:configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_node_config",
-          "description": "Return the requested configuration in JSON format for the specified node",
-          "summary": "Get node active configuration",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":component",
-              "description": "Selected agent's component",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "agent",
-                  "agentless",
-                  "analysis",
-                  "auth",
-                  "com",
-                  "csyslog",
-                  "integrator",
-                  "logcollector",
-                  "mail",
-                  "monitor",
-                  "request",
-                  "syscheck",
-                  "wmodules"
-                ]
-              }
-            },
-            {
-              "name": ":configuration",
-              "description": "<p>Selected agent's configuration to read. The configuration to read depends on the selected component.\nThe following table shows all available combinations of component and configuration values:</p>\n<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>Component</th>\n<th>Configuration</th>\n<th>Tag</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>agent</td>\n<td>client</td>\n<td><code>&lt;client&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>buffer</td>\n<td><code>&lt;client_buffer&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>labels</td>\n<td><code>&lt;labels&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>internal</td>\n<td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>agentless</td>\n<td>agentless</td>\n<td><code>&lt;agentless&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>global</td>\n<td><code>&lt;global&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>active_response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>alerts</td>\n<td><code>&lt;alerts&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>command</td>\n<td><code>&lt;command&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>rules</td>\n<td><code>&lt;rule&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>decoders</td>\n<td><code>&lt;decoder&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>internal</td>\n<td><code>&lt;analysisd&gt;</code></td>\n</tr>\n<tr>\n<td>auth</td>\n<td>auth</td>\n<td><code>&lt;auth&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>active-response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>logging</td>\n<td><code>&lt;logging&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>internal</td>\n<td><code>&lt;execd&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>cluster</td>\n<td><code>&lt;cluster&gt;</code></td>\n</tr>\n<tr>\n<td>csyslog</td>\n<td>csyslog</td>\n<td><code>&lt;csyslog_output&gt;</code></td>\n</tr>\n<tr>\n<td>integrator</td>\n<td>integration</td>\n<td><code>&lt;integration&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>localfile</td>\n<td><code>&lt;localfile&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>socket</td>\n<td><code>&lt;socket&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>internal</td>\n<td><code>&lt;logcollector&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>global</td>\n<td><code>&lt;global&gt;&lt;email...&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>alerts</td>\n<td><code>&lt;email_alerts&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>internal</td>\n<td><code>&lt;maild&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;monitord&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;reports&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>remote</td>\n<td><code>&lt;remote&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>internal</td>\n<td><code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>syscheck</td>\n<td><code>&lt;syscheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>rootcheck</td>\n<td><code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>internal</td>\n<td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>wmodules</td>\n<td>wmodules</td>\n<td><code>&lt;wodle&gt;</code></td>\n</tr>\n</tbody>\n</table>\n",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "client",
-                  "buffer",
-                  "labels",
-                  "internal",
-                  "agentless",
-                  "global",
-                  "active_response",
-                  "alerts",
-                  "command",
-                  "rules",
-                  "decoders",
-                  "auth",
-                  "logging",
-                  "reports",
-                  "active-response",
-                  "cluster",
-                  "csyslog",
-                  "integration",
-                  "localfile",
-                  "socket",
-                  "remote",
-                  "syscheck",
-                  "rootcheck",
-                  "wmodules"
-                ]
-              }
-            },
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_files_node",
-          "description": "Return file contents from any file in the specified node",
-          "summary": "Get node file content",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "path",
-              "description": "Filepath to return file. (Relative to wazuh installation folder)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "get_files_path"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/info",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_info_node",
-          "description": "Return basic information about a specified node such as version, compilation date, installation path",
-          "summary": "Get node info",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/logs",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_node",
-          "description": "Return the last 2000 wazuh log entries in the specified node",
-          "summary": "Get node logs",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "level",
-              "description": "Filter by log level",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "critical",
-                  "debug",
-                  "debug2",
-                  "error",
-                  "info",
-                  "warning"
-                ]
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "tag",
-              "description": "Wazuh component that logged the event",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "ossec-agentlessd",
-                  "ossec-analysisd",
-                  "ossec-authd",
-                  "ossec-csyslogd",
-                  "ossec-dbd",
-                  "ossec-execd",
-                  "ossec-integratord",
-                  "ossec-maild",
-                  "ossec-monitord",
-                  "ossec-logcollector",
-                  "ossec-remoted",
-                  "ossec-reportd",
-                  "ossec-rootcheck",
-                  "ossec-syscheckd",
-                  "ossec-testrule",
-                  "sca",
-                  "wazuh-db",
-                  "wazuh-modulesd",
-                  "wazuh-modulesd:agent-key-polling",
-                  "wazuh-modulesd:aws-s3",
-                  "wazuh-modulesd:azure-logs",
-                  "wazuh-modulesd:ciscat",
-                  "wazuh-modulesd:control",
-                  "wazuh-modulesd:command",
-                  "wazuh-modulesd:database",
-                  "wazuh-modulesd:docker-listener",
-                  "wazuh-modulesd:download",
-                  "wazuh-modulesd:oscap",
-                  "wazuh-modulesd:osquery",
-                  "wazuh-modulesd:syscollector",
-                  "wazuh-modulesd:vulnerability-detector"
-                ]
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/logs/summary",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_summary_node",
-          "description": "Return a summary of the last 2000 wazuh log entries in the specified node",
-          "summary": "Get node logs summary",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/stats",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_node",
-          "description": "Return Wazuh statistical information in node {node_id} for the current or specified date",
-          "summary": "Get node stats",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "date",
-              "description": "Date to obtain statistical information from. Format YYYY-MM-DD",
-              "schema": {
-                "type": "string",
-                "format": "date"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/stats/analysisd",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_analysisd_node",
-          "description": "Return Wazuh analysisd statistical information in node {node_id}",
-          "summary": "Get node stats analysisd",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/stats/hourly",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_hourly_node",
-          "description": "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field represents the average of alerts per hour",
-          "summary": "Get node stats hour",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/stats/remoted",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_remoted_node",
-          "description": "Return Wazuh remoted statistical information in node {node_id}",
-          "summary": "Get node stats remoted",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/stats/weekly",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_weekly_node",
-          "description": "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field represents the average of alerts per hour for that specific day",
-          "summary": "Get node stats week",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/status",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status_node",
-          "description": "Return the status of all Wazuh daemons in node node_id",
-          "summary": "Get node status",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/api/config",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_api_config",
-          "description": "Return the API configuration of all nodes (or a list of them) in JSON format",
-          "summary": "Get nodes API config",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "nodes_list",
-              "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/configuration/validation",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_conf_validation",
-          "description": "Return whether the Wazuh configuration is correct or not in all cluster nodes or a list of them",
-          "summary": "Check nodes config",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "nodes_list",
-              "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/healthcheck",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_healthcheck",
-          "description": "Return cluster healthcheck information for all nodes or a list of them. Such information includes last keep alive, last synchronization time and number of agents reporting on each node",
-          "summary": "Get nodes healthcheck",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "nodes_list",
-              "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/local/config",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_config",
-          "description": "Return the current node cluster configuration",
-          "summary": "Get local node config",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/local/info",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_node",
-          "description": "Return basic information about the cluster node receiving the request",
-          "summary": "Get local node info",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/nodes",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_nodes",
-          "description": "Get information about all nodes in the cluster or a list of them",
-          "summary": "Get nodes info",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "nodes_list",
-              "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "type",
-              "description": "Filter by node type",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "worker",
-                  "master"
-                ]
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/status",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status",
-          "description": "Return information about the cluster status",
-          "summary": "Get cluster status",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/decoders",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoders_controller.get_decoders",
-          "description": "Return information about all decoders included in ossec.conf. This information include decoder's route, decoder's name, decoder's file among others",
-          "summary": "List decoders",
-          "tags": [
-            "Decoders"
-          ],
-          "query": [
-            {
-              "name": "decoder_names",
-              "description": "Decoder name",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "filename",
-              "description": "Filter by filename",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "alphanumeric"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "relative_dirname",
-              "description": "Filter by relative directory name",
-              "schema": {
-                "type": "string",
-                "format": "get_dirnames_path"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by list status. Use commas to enter multiple statuses",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled",
-                  "all"
-                ],
-                "minItems": 1
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/decoders/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoders_controller.get_decoders_files",
-          "description": "Return information about all decoders files used in Wazuh. This information include decoder's file, decoder's route and decoder's status among others",
-          "summary": "Get files",
-          "tags": [
-            "Decoders"
-          ],
-          "query": [
-            {
-              "name": "filename",
-              "description": "Filter by filename",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "alphanumeric"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "relative_dirname",
-              "description": "Filter by relative directory name",
-              "schema": {
-                "type": "string",
-                "format": "get_dirnames_path"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by list status. Use commas to enter multiple statuses",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled",
-                  "all"
-                ],
-                "minItems": 1
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/decoders/files/:filename/download",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoders_controller.get_download_file",
-          "description": "Download an specified decoder file",
-          "summary": "Download decoder",
-          "tags": [
-            "Decoders"
-          ],
-          "args": [
-            {
-              "name": ":filename",
-              "required": true,
-              "description": "Filename to download",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/decoders/parents",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoders_controller.get_decoders_parents",
-          "description": "Return information about all parent decoders. A parent decoder is a decoder used as base of other decoders",
-          "summary": "Get parent decoders",
-          "tags": [
-            "Decoders"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/ciscat/results",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_cis_cat_results",
-          "description": "Return CIS-CAT results for all agents or a list of them",
-          "summary": "Get agents CIS-CAT results",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "benchmark",
-              "description": "Filter by benchmark type",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "error",
-              "description": "Filter by encountered errors",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "fail",
-              "description": "Filter by failed checks",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "notchecked",
-              "description": "Filter by not checked",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pass",
-              "description": "Filter by passed checks",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "profile",
-              "description": "Filter by evaluated profile",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "score",
-              "description": "Filter by final score",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "unknown",
-              "description": "Filter by unknown results",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/hardware",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hardware_info",
-          "description": "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info among others of all agents",
-          "summary": "Get agents hardware",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "board_serial",
-              "description": "Filter by board_serial",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "cpu.cores",
-              "description": "Filter by cpu.cores",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 1
-              }
-            },
-            {
-              "name": "cpu.mhz",
-              "description": "Filter by cpu.mhz",
-              "schema": {
-                "type": "number",
-                "format": "float",
-                "minimum": 1
-              }
-            },
-            {
-              "name": "cpu.name",
-              "description": "Filter by cpu.name",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "ram.free",
-              "description": "Filter by ram.free",
-              "schema": {
-                "type": "integer",
-                "format": "int64",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "ram.total",
-              "description": "Filter by ram.total",
-              "schema": {
-                "type": "integer",
-                "format": "int64",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/hotfixes",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hotfixes_info",
-          "description": "Return all agents (or a list of them) hotfixes info",
-          "summary": "Get agents hotfixes",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "hotfix",
-              "description": "Filter by hotfix",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/netaddr",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_address_info",
-          "description": "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network interfaces. This information include used IP protocol, interface, and IP address among others",
-          "summary": "Get agents netaddr",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "address",
-              "description": "Filter by IP address",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "broadcast",
-              "description": "Filter by broadcast direction",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "netmask",
-              "description": "Filter by netmask",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "proto",
-              "description": "Filter by IP protocol",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/netiface",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_interface_info",
-          "description": "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx info and some network information among other",
-          "summary": "Get agents netiface",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "adapter",
-              "description": "Filter by adapter",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "mtu",
-              "description": "Filter by mtu",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by agent name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "rx.bytes",
-              "description": "Filter by rx.bytes",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "rx.dropped",
-              "description": "Filter by rx.dropped",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "rx.errors",
-              "description": "Filter by rx.errors",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "rx.packets",
-              "description": "Filter by rx.packets",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "state",
-              "description": "Filter by state",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "tx.bytes",
-              "description": "Filter by tx.bytes",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "tx.dropped",
-              "description": "Filter by tx.dropped",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "tx.errors",
-              "description": "Filter by tx.errors",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "tx.packets",
-              "description": "Filter by tx.packets",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "type",
-              "description": "Type of network",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/netproto",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_protocol_info",
-          "description": "Return all agents (or a list of them) routing configuration for each network interface. This information includes interface, type protocol information among other",
-          "summary": "Get agents netproto",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "dhcp",
-              "description": "Filter by network dhcp (enabled or disabled)",
-              "schema": {
-                "type": "string",
-                "description": "DHCP status",
-                "enum": [
-                  "enabled",
-                  "disabled",
-                  "unknown",
-                  "BOOTP"
-                ]
-              }
-            },
-            {
-              "name": "gateway",
-              "description": "Filter by network gateway",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "iface",
-              "description": "Filter by network interface",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "type",
-              "description": "Type of network",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/os",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_os_info",
-          "description": "Return all agents (or a list of them) OS info. This information includes os information, architecture information among other",
-          "summary": "Get agents OS",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "architecture",
-              "description": "Filter by architecture",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "os.name",
-              "description": "Filter by OS name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "os.version",
-              "description": "Filter by OS version",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "release",
-              "description": "Filter by release",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "version",
-              "description": "Filter by agents version",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/packages",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_packages_info",
-          "description": "Return all agents (or a list of them) packages info. This information includes name, section, size, and priority information of all packages among other",
-          "summary": "Get agents packages",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "architecture",
-              "description": "Filter by architecture",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "format",
-              "description": "Filter by file format. For example 'deb' will output deb files",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by agent name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "vendor",
-              "description": "Filter by vendor",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "version",
-              "description": "Filter by version name",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/ports",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_ports_info",
-          "description": "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP, protocol information among other",
-          "summary": "Get agents ports",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "local.ip",
-              "description": "Filter by Local IP",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "local.port",
-              "description": "Filter by Local Port",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pid",
-              "description": "Filter by pid",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "process",
-              "description": "Filter by process name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "protocol",
-              "description": "Filter by protocol",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "remote.ip",
-              "description": "Filter by Remote IP",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "state",
-              "description": "Filter by state",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "tx_queue",
-              "description": "Filter by tx_queue",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/experimental/syscollector/processes",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_processes_info",
-          "description": "Return all agents (or a list of them) processes info",
-          "summary": "Get agents processes",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "egroup",
-              "description": "Filter by process egroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "euser",
-              "description": "Filter by process euser",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "fgroup",
-              "description": "Filter by process fgroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by process name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "nlwp",
-              "description": "Filter by process nlwp",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pgrp",
-              "description": "Filter by process pgrp",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "pid",
-              "description": "Filter by process pid",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "ppid",
-              "description": "Filter by process parent pid",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "priority",
-              "description": "Filter by process priority",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "rgroup",
-              "description": "Filter by process rgroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "ruser",
-              "description": "Filter by process ruser",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sgroup",
-              "description": "Filter by process sgroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "state",
-              "description": "Filter by process state",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "suser",
-              "description": "Filter by process suser",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_list_group",
-          "description": "Get information about all groups or a list of them. Returns a list containing basic information about each group such as number of agents belonging to the group and the checksums of the configuration and shared files",
-          "summary": "Get groups",
-          "tags": [
-            "Groups"
-          ],
-          "query": [
-            {
-              "name": "groups_list",
-              "description": "List of group IDs (separated by comma), all groups selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Group name",
-                  "format": "group_names"
-                }
-              }
-            },
-            {
-              "name": "hash",
-              "description": "Select algorithm to generate the returned checksums",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "md5",
-                  "sha1",
-                  "sha224",
-                  "sha256",
-                  "sha384",
-                  "sha512",
-                  "blake2b",
-                  "blake2s",
-                  "sha3_224",
-                  "sha3_256",
-                  "sha3_384",
-                  "sha3_512"
-                ]
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups/:group_id/agents",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_agents_in_group",
-          "description": "Return the list of agents that belong to the specified group",
-          "summary": "Get agents in a group",
-          "tags": [
-            "Groups"
-          ],
-          "args": [
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by agent status (use commas to enter multiple statuses)",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "pending",
-                    "never_connected",
-                    "disconnected"
-                  ]
-                },
-                "minItems": 1
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups/:group_id/configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_group_config",
-          "description": "Return the group configuration defined in the `agent.conf` file",
-          "summary": "Get group configuration",
-          "tags": [
-            "Groups"
-          ],
-          "args": [
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups/:group_id/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_group_files",
-          "description": "Return the files placed under the group directory",
-          "summary": "Get group files",
-          "tags": [
-            "Groups"
-          ],
-          "args": [
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "hash",
-              "description": "Select algorithm to generate the returned checksums",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "md5",
-                  "sha1",
-                  "sha224",
-                  "sha256",
-                  "sha384",
-                  "sha512",
-                  "blake2b",
-                  "blake2s",
-                  "sha3_224",
-                  "sha3_256",
-                  "sha3_384",
-                  "sha3_512"
-                ]
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups/:group_id/files/:file_name/json",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_group_file_json",
-          "description": "Return the contents of the specified group file parsed to JSON",
-          "summary": "Get a file in group",
-          "tags": [
-            "Groups"
-          ],
-          "args": [
-            {
-              "name": ":file_name",
-              "description": "Filename",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "type",
-              "description": "Type of file",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "conf",
-                    "rootkit_files",
-                    "rootkit_trojans",
-                    "rcl"
-                  ]
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups/:group_id/files/:file_name/xml",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.get_group_file_xml",
-          "description": "Return the contents of the specified group file parsed to XML",
-          "summary": "Get a file in group",
-          "tags": [
-            "Groups"
-          ],
-          "args": [
-            {
-              "name": ":file_name",
-              "description": "Filename",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "type",
-              "description": "Type of file",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "conf",
-                    "rootkit_files",
-                    "rootkit_trojans",
-                    "rcl"
-                  ]
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/lists",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.lists_controller.get_lists",
-          "description": "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria. See available parameters for more details",
-          "summary": "Get CDB lists",
-          "tags": [
-            "Lists"
-          ],
-          "query": [
-            {
-              "name": "filename",
-              "description": "Filter by filename",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "alphanumeric"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "relative_dirname",
-              "description": "Filter by relative directory name",
-              "schema": {
-                "type": "string",
-                "format": "get_dirnames_path"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/lists/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.lists_controller.get_lists_files",
-          "description": "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder",
-          "summary": "Get CDB lists files",
-          "tags": [
-            "Lists"
-          ],
-          "query": [
-            {
-              "name": "filename",
-              "description": "Filter by filename",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "alphanumeric"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "relative_dirname",
-              "description": "Filter by relative directory name",
-              "schema": {
-                "type": "string",
-                "format": "get_dirnames_path"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/api/config",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_api_config",
-          "description": "Return the local API configuration in JSON format",
-          "summary": "Get API config",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_configuration",
-          "description": "Return wazuh configuration used",
-          "summary": "Get configuration",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "field",
-              "description": "Indicate a section child. E.g, fields for *ruleset* section are: decoder_dir, rule_dir, etc",
-              "schema": {
-                "type": "string",
-                "format": "names"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "section",
-              "description": "Indicates the wazuh configuration section",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "active-response",
-                  "agentless",
-                  "alerts",
-                  "auth",
-                  "client",
-                  "client_buffer",
-                  "cluster",
-                  "command",
-                  "database_output",
-                  "email_alerts",
-                  "global",
-                  "integration",
-                  "labels",
-                  "localfile",
-                  "logging",
-                  "remote",
-                  "reports",
-                  "rootcheck",
-                  "ruleset",
-                  "sca",
-                  "socket",
-                  "syscheck",
-                  "syslog_output",
-                  "agent-key-polling",
-                  "aws-s3",
-                  "azure-logs",
-                  "cis-cat",
-                  "docker-listener",
-                  "open-scap",
-                  "osquery",
-                  "syscollector",
-                  "vulnerability-detector"
-                ]
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/configuration/:component/:configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_manager_config_ondemand",
-          "description": "Return the requested active configuration in JSON format",
-          "summary": "Get active configuration",
-          "tags": [
-            "Manager"
-          ],
-          "args": [
-            {
-              "name": ":component",
-              "description": "Selected agent's component",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "agent",
-                  "agentless",
-                  "analysis",
-                  "auth",
-                  "com",
-                  "csyslog",
-                  "integrator",
-                  "logcollector",
-                  "mail",
-                  "monitor",
-                  "request",
-                  "syscheck",
-                  "wmodules"
-                ]
-              }
-            },
-            {
-              "name": ":configuration",
-              "description": "<p>Selected agent's configuration to read. The configuration to read depends on the selected component.\nThe following table shows all available combinations of component and configuration values:</p>\n<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>Component</th>\n<th>Configuration</th>\n<th>Tag</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>agent</td>\n<td>client</td>\n<td><code>&lt;client&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>buffer</td>\n<td><code>&lt;client_buffer&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>labels</td>\n<td><code>&lt;labels&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>internal</td>\n<td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>agentless</td>\n<td>agentless</td>\n<td><code>&lt;agentless&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>global</td>\n<td><code>&lt;global&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>active_response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>alerts</td>\n<td><code>&lt;alerts&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>command</td>\n<td><code>&lt;command&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>rules</td>\n<td><code>&lt;rule&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>decoders</td>\n<td><code>&lt;decoder&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>internal</td>\n<td><code>&lt;analysisd&gt;</code></td>\n</tr>\n<tr>\n<td>auth</td>\n<td>auth</td>\n<td><code>&lt;auth&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>active-response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>logging</td>\n<td><code>&lt;logging&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>internal</td>\n<td><code>&lt;execd&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>cluster</td>\n<td><code>&lt;cluster&gt;</code></td>\n</tr>\n<tr>\n<td>csyslog</td>\n<td>csyslog</td>\n<td><code>&lt;csyslog_output&gt;</code></td>\n</tr>\n<tr>\n<td>integrator</td>\n<td>integration</td>\n<td><code>&lt;integration&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>localfile</td>\n<td><code>&lt;localfile&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>socket</td>\n<td><code>&lt;socket&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>internal</td>\n<td><code>&lt;logcollector&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>global</td>\n<td><code>&lt;global&gt;&lt;email...&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>alerts</td>\n<td><code>&lt;email_alerts&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>internal</td>\n<td><code>&lt;maild&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;monitord&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;reports&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>remote</td>\n<td><code>&lt;remote&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>internal</td>\n<td><code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>syscheck</td>\n<td><code>&lt;syscheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>rootcheck</td>\n<td><code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>internal</td>\n<td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>wmodules</td>\n<td>wmodules</td>\n<td><code>&lt;wodle&gt;</code></td>\n</tr>\n</tbody>\n</table>\n",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "client",
-                  "buffer",
-                  "labels",
-                  "internal",
-                  "agentless",
-                  "global",
-                  "active_response",
-                  "alerts",
-                  "command",
-                  "rules",
-                  "decoders",
-                  "auth",
-                  "logging",
-                  "reports",
-                  "active-response",
-                  "cluster",
-                  "csyslog",
-                  "integration",
-                  "localfile",
-                  "socket",
-                  "remote",
-                  "syscheck",
-                  "rootcheck",
-                  "wmodules"
-                ]
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/configuration/validation",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_conf_validation",
-          "description": "Return whether the Wazuh configuration is correct",
-          "summary": "Check config",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_files",
-          "description": "Return file contents from any file",
-          "summary": "Get file content",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "path",
-              "description": "Filepath to return file. (Relative to wazuh installation folder)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "get_files_path"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/info",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_info",
-          "description": "Return basic information such as version, compilation date, installation path",
-          "summary": "Get information",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/logs",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log",
-          "description": "Return the last 2000 wazuh log entries",
-          "summary": "Get logs",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "level",
-              "description": "Filter by log level",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "critical",
-                  "debug",
-                  "debug2",
-                  "error",
-                  "info",
-                  "warning"
-                ]
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "tag",
-              "description": "Wazuh component that logged the event",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "ossec-agentlessd",
-                  "ossec-analysisd",
-                  "ossec-authd",
-                  "ossec-csyslogd",
-                  "ossec-dbd",
-                  "ossec-execd",
-                  "ossec-integratord",
-                  "ossec-maild",
-                  "ossec-monitord",
-                  "ossec-logcollector",
-                  "ossec-remoted",
-                  "ossec-reportd",
-                  "ossec-rootcheck",
-                  "ossec-syscheckd",
-                  "ossec-testrule",
-                  "sca",
-                  "wazuh-db",
-                  "wazuh-modulesd",
-                  "wazuh-modulesd:agent-key-polling",
-                  "wazuh-modulesd:aws-s3",
-                  "wazuh-modulesd:azure-logs",
-                  "wazuh-modulesd:ciscat",
-                  "wazuh-modulesd:control",
-                  "wazuh-modulesd:command",
-                  "wazuh-modulesd:database",
-                  "wazuh-modulesd:docker-listener",
-                  "wazuh-modulesd:download",
-                  "wazuh-modulesd:oscap",
-                  "wazuh-modulesd:osquery",
-                  "wazuh-modulesd:syscollector",
-                  "wazuh-modulesd:vulnerability-detector"
-                ]
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/logs/summary",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log_summary",
-          "description": "Return a summary of the last 2000 wazuh log entries",
-          "summary": "Get logs summary",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/stats",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats",
-          "description": "Return Wazuh statistical information for the current or specified date",
-          "summary": "Get stats",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "date",
-              "description": "Date to obtain statistical information from. Format YYYY-MM-DD",
-              "schema": {
-                "type": "string",
-                "format": "date"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/stats/analysisd",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_analysisd",
-          "description": "Return Wazuh analysisd statistical information",
-          "summary": "Get stats analysisd",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/stats/hourly",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_hourly",
-          "description": "Return Wazuh statistical information per hour. Each number in the averages field represents the average of alerts per hour",
-          "summary": "Get stats hour",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/stats/remoted",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_remoted",
-          "description": "Return Wazuh remoted statistical information",
-          "summary": "Get stats remoted",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/stats/weekly",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_weekly",
-          "description": "Return Wazuh statistical information per week. Each number in the averages field represents the average of alerts per hour for that specific day",
-          "summary": "Get stats week",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/manager/status",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_status",
-          "description": "Return the status of all Wazuh daemons",
-          "summary": "Get status",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/mitre",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_attack",
-          "description": "Return the requested attacks from MITRE database",
-          "summary": "Get MITRE attacks",
-          "tags": [
-            "Mitre"
-          ],
-          "query": [
-            {
-              "name": "id",
-              "description": "MITRE attack ID",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "phase_name",
-              "description": "Show results filtered by phase",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "platform_name",
-              "description": "Show results filtered by platform",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/overview/agents",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.overview_controller.get_overview_agents",
-          "description": "Return a dictionary with a full agents overview",
-          "summary": "Get agents overview",
-          "tags": [
-            "Overview"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/rules",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rules_controller.get_rules",
-          "description": "Return a list containing information about each rule such as file where it's defined, description, rule group, status, etc",
-          "summary": "List rules",
-          "tags": [
-            "Rules"
-          ],
-          "query": [
-            {
-              "name": "filename",
-              "description": "Filter by filename",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "alphanumeric"
-                }
-              }
-            },
-            {
-              "name": "gdpr",
-              "description": "Filter by GDPR requirement",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "gpg13",
-              "description": "Filter by GPG13 requirement",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "group",
-              "description": "Filter by rule group",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "hipaa",
-              "description": "Filter by HIPAA requirement",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "level",
-              "description": "Filter by rule level. Can be a single level (4) or an interval (2-4)",
-              "schema": {
-                "type": "string",
-                "format": "range"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "mitre",
-              "description": "Filters by MITRE attack ID",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "nist-800-53",
-              "description": "Filter by NIST-800-53 requirement",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pci_dss",
-              "description": "Filter by PCI_DSS requirement name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "relative_dirname",
-              "description": "Filter by relative directory name",
-              "schema": {
-                "type": "string",
-                "format": "get_dirnames_path"
-              }
-            },
-            {
-              "name": "rule_ids",
-              "description": "List of rule IDs",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32",
-                  "minimum": 1
-                }
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by list status. Use commas to enter multiple statuses",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled",
-                  "all"
-                ],
-                "minItems": 1
-              }
-            },
-            {
-              "name": "tsc",
-              "description": "Filters by TSC requirement",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/rules/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rules_controller.get_rules_files",
-          "description": "Return a list containing all files used to define rules and their status",
-          "summary": "Get files",
-          "tags": [
-            "Rules"
-          ],
-          "query": [
-            {
-              "name": "filename",
-              "description": "Filter by filename",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "alphanumeric"
-                }
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "relative_dirname",
-              "description": "Filter by relative directory name",
-              "schema": {
-                "type": "string",
-                "format": "get_dirnames_path"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by list status. Use commas to enter multiple statuses",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled",
-                  "all"
-                ],
-                "minItems": 1
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/rules/files/:filename/download",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rules_controller.get_download_file",
-          "description": "Download an specified rule file",
-          "summary": "Download rule",
-          "tags": [
-            "Rules"
-          ],
-          "args": [
-            {
-              "name": ":filename",
-              "required": true,
-              "description": "Filename to download",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/rules/groups",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rules_controller.get_rules_groups",
-          "description": "Return a list containing all rule groups names",
-          "summary": "Get groups",
-          "tags": [
-            "Rules"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/rules/requirement/:requirement",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rules_controller.get_rules_requirement",
-          "description": "Return all specified requirement names defined in the Wazuh ruleset",
-          "summary": "Get requirements",
-          "tags": [
-            "Rules"
-          ],
-          "args": [
-            {
-              "name": ":requirement",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "pci_dss",
-                  "gdpr",
-                  "hipaa",
-                  "nist-800-53",
-                  "gpg13",
-                  "tsc",
-                  "mitre"
-                ]
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/sca/:agent_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_agent",
-          "description": "Return the security SCA database of an agent",
-          "summary": "Get results",
-          "tags": [
-            "SCA"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "description",
-              "description": "Filter by policy description",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric_symbols"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by policy name",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "references",
-              "description": "Filter by references",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/sca/:agent_id/checks/:policy_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_checks",
-          "description": "Return the policy monitoring alerts for a given policy",
-          "summary": "Get policy checks",
-          "tags": [
-            "SCA"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": ":policy_id",
-              "description": "Filter by policy id",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "command",
-              "description": "Filter by command",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "condition",
-              "description": "Filter by condition",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "description",
-              "description": "Filter by policy description",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric_symbols"
-              }
-            },
-            {
-              "name": "directory",
-              "description": "Filter by directory",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "file",
-              "description": "Filter by full path",
-              "schema": {
-                "type": "string",
-                "format": "paths"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "process",
-              "description": "Filter by process name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "rationale",
-              "description": "Filter by rationale",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric_symbols"
-              }
-            },
-            {
-              "name": "reason",
-              "description": "Filter by reason",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric_symbols"
-              }
-            },
-            {
-              "name": "references",
-              "description": "Filter by references",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "registry",
-              "description": "Filter by registry",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "remediation",
-              "description": "Filter by remediation",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric_symbols"
-              }
-            },
-            {
-              "name": "result",
-              "description": "Filter by result",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by status",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "title",
-              "description": "Filter by title",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric_symbols"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/actions",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_actions",
-          "description": "Get all RBAC actions, including the potential related resources and endpoints.",
-          "summary": "List RBAC actions",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "endpoint",
-              "description": "Look for the RBAC actions which are related to the specified endpoint",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/config",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_security_config",
-          "description": "Return the security configuration in JSON format",
-          "summary": "Get security config",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/policies",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_policies",
-          "description": "Get all policies in the system, including the administrator policy",
-          "summary": "List policies",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "policy_ids",
-              "description": "List of policy IDs",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers",
-                  "description": "Policy ID"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/resources",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_resources",
-          "description": "This method should be called to get all current defined RBAC resources.",
-          "summary": "List RBAC resources",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "resource",
-              "description": "List of current RBAC's resources.",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "*:*",
-                  "agent:group",
-                  "agent:id",
-                  "group:id",
-                  "node:id",
-                  "file:path",
-                  "decoder:file",
-                  "list:path",
-                  "rule:file",
-                  "policy:id",
-                  "role:id",
-                  "user:id"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/roles",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_roles",
-          "description": "For a specific list, indicate the ids separated by commas. Example: ?role_ids=1,2,3",
-          "summary": "List roles",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "role_ids",
-              "description": "List of role IDs (separated by comma)",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers",
-                  "description": "Role ID"
-                }
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/rules",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rules",
-          "description": "Get a list of security rules from the system or all of them. These rules must be mapped with roles to obtain certain access privileges. For a specific list, indicate the ids separated by commas. Example: ?rule_ids=1,2,3",
-          "summary": "List security rules",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "rule_ids",
-              "description": "List of rule IDs (separated by comma)",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers",
-                  "description": "Security rule ID"
-                }
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/user/authenticate",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
-          "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
-          "summary": "Login",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "raw",
-              "description": "Format response in plain text",
-              "required": false,
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/users",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_users",
-          "description": "Get the information of a specified user",
-          "summary": "List users",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "user_ids",
-              "description": "List of user IDs (separated by comma)",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers",
-                  "description": "User ID"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/users/me",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me",
-          "description": "Get the information of the current user",
-          "summary": "Get current user info",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/users/me/policies",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me_policies",
-          "description": "Get the processed policies information for the current user",
-          "summary": "Get current user processed policies",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscheck/:agent_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_syscheck_agent",
-          "description": "Return FIM findings in the specified agent",
-          "summary": "Get results",
-          "tags": [
-            "Syscheck"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "distinct",
-              "description": "Look for distinct values.",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "file",
-              "description": "Filter by full path",
-              "schema": {
-                "type": "string",
-                "format": "paths"
-              }
-            },
-            {
-              "name": "hash",
-              "description": "Filter files with the specified hash (md5, sha256 or sha1)",
-              "schema": {
-                "type": "string",
-                "format": "hash"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "md5",
-              "description": "Filter files with the specified MD5 checksum",
-              "schema": {
-                "type": "string",
-                "format": "hash"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sha1",
-              "description": "Filter files with the specified SHA1 checksum",
-              "schema": {
-                "type": "string",
-                "format": "hash"
-              }
-            },
-            {
-              "name": "sha256",
-              "description": "Filter files with the specified SHA256 checksum",
-              "schema": {
-                "type": "string",
-                "format": "hash"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "summary",
-              "description": "Return a summary grouping by filename",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "type",
-              "description": "Filter by file type",
-              "schema": {
-                "type": "string",
-                "enum": [
-                  "file",
-                  "registry"
-                ]
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscheck/:agent_id/last_scan",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_last_scan_agent",
-          "description": "Return when the last syscheck scan started and ended. If the scan is still in progress the end date will be unknown",
-          "summary": "Get last scan datetime",
-          "tags": [
-            "Syscheck"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/hardware",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hardware_info",
-          "description": "Return the agent's hardware info. This information include cpu, ram, scan info among others",
-          "summary": "Get agent hardware",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/hotfixes",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hotfix_info",
-          "description": "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)",
-          "summary": "Get agent hotfixes",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "hotfix",
-              "description": "Filter by hotfix",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/netaddr",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_address_info",
-          "description": "Return the agent's network address info. This information include used IP protocol, interface, IP address  among others",
-          "summary": "Get agent netaddr",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "address",
-              "description": "Filter by IP address",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "broadcast",
-              "description": "Filter by broadcast direction",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "iface",
-              "description": "Filter by network interface",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "netmask",
-              "description": "Filter by netmask",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "proto",
-              "description": "Filter by IP protocol",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/netiface",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_interface_info",
-          "description": "Return the agent's network interface info. This information include rx, scan, tx info and some network information among others",
-          "summary": "Get agent netiface",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "adapter",
-              "description": "Filter by adapter",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "mtu",
-              "description": "Filter by mtu",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by agent name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "rx.bytes",
-              "description": "Filter by rx.bytes",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "rx.dropped",
-              "description": "Filter by rx.dropped",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "rx.errors",
-              "description": "Filter by rx.errors",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "rx.packets",
-              "description": "Filter by rx.packets",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "state",
-              "description": "Filter by state",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "tx.bytes",
-              "description": "Filter by tx.bytes",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "tx.dropped",
-              "description": "Filter by tx.dropped",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "tx.errors",
-              "description": "Filter by tx.errors",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "tx.packets",
-              "description": "Filter by tx.packets",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "type",
-              "description": "Type of file",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/netproto",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_protocol_info",
-          "description": "Return the agent's routing configuration for each network interface",
-          "summary": "Get agent netproto",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "dhcp",
-              "description": "Filter by network dhcp (enabled or disabled)",
-              "schema": {
-                "type": "string",
-                "description": "DHCP status",
-                "enum": [
-                  "enabled",
-                  "disabled",
-                  "unknown",
-                  "BOOTP"
-                ]
-              }
-            },
-            {
-              "name": "gateway",
-              "description": "Filter by network gateway",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "iface",
-              "description": "Filter by network interface",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "type",
-              "description": "Type of network",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/os",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_os_info",
-          "description": "Return the agent's OS info. This information include os information, architecture information among others of all agents",
-          "summary": "Get agent OS",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/packages",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_packages_info",
-          "description": "Return the agent's packages info. This information include name, section, size, priority information of all packages among others",
-          "summary": "Get agent packages",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "architecture",
-              "description": "Filter by architecture",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "format",
-              "description": "Filter by file format. For example 'deb' will output deb files",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by agent name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "vendor",
-              "description": "Filter by vendor",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "version",
-              "description": "Filter by version name",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/ports",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_ports_info",
-          "description": "Return the agent's ports info. This information include local IP, Remote IP, protocol information among others",
-          "summary": "Get agent ports",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "local.ip",
-              "description": "Filter by Local IP",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "local.port",
-              "description": "Filter by Local Port",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pid",
-              "description": "Filter by pid",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "process",
-              "description": "Filter by process name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "protocol",
-              "description": "Filter by protocol",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "remote.ip",
-              "description": "Filter by Remote IP",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "state",
-              "description": "Filter by state",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "tx_queue",
-              "description": "Filter by tx_queue",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/syscollector/:agent_id/processes",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_processes_info",
-          "description": "Return the agent's processes info",
-          "summary": "Get agent processes",
-          "tags": [
-            "Syscollector"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "egroup",
-              "description": "Filter by process egroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "euser",
-              "description": "Filter by process euser",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "fgroup",
-              "description": "Filter by process fgroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "limit",
-              "description": "Maximum number of elements to return",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 500,
-                "minimum": 1,
-                "maximum": 500
-              }
-            },
-            {
-              "name": "name",
-              "description": "Filter by process name",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "nlwp",
-              "description": "Filter by process nlwp",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "offset",
-              "description": "First element to return in the collection",
-              "schema": {
-                "type": "integer",
-                "format": "int32",
-                "default": 0,
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pgrp",
-              "description": "Filter by process pgrp",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "pid",
-              "description": "Filter by process pid",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "ppid",
-              "description": "Filter by process parent pid",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "priority",
-              "description": "Filter by process priority",
-              "schema": {
-                "type": "string",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": "q",
-              "description": "Query to filter results by. For example q=&quot;status=active&quot;",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "rgroup",
-              "description": "Filter by process rgroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "ruser",
-              "description": "Filter by process ruser",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "search",
-              "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
-              "schema": {
-                "type": "string",
-                "format": "search"
-              }
-            },
-            {
-              "name": "select",
-              "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "names"
-                }
-              }
-            },
-            {
-              "name": "sgroup",
-              "description": "Filter by process sgroup",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "sort",
-              "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
-              "schema": {
-                "type": "string",
-                "format": "sort"
-              }
-            },
-            {
-              "name": "state",
-              "description": "Filter by process state",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "suser",
-              "description": "Filter by process suser",
-              "schema": {
-                "type": "string",
-                "format": "alphanumeric"
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "method": "PUT",
-      "endpoints": [
-        {
-          "name": "/active-response",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.active_response_controller.run_command",
-          "description": "Run an Active Response command on all agents or a list of them",
-          "summary": "Run command",
-          "tags": [
-            "Active-response"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "properties": {
-                "arguments": {
-                  "description": "Command arguments",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "command": {
-                  "description": "Command running in the agent. If this value starts by `!`, then it refers to a script name instead of a command name",
-                  "type": "string"
-                },
-                "custom": {
-                  "description": "Whether the specified command is a custom command or not",
-                  "type": "boolean",
-                  "default": false
-                }
               },
-              "required": [
-                "command"
+              "minItems": 1
+            }
+          },
+          {
+            "name": "version",
+            "description": "Filter by agents version",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/config/:component/:configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_config",
+        "description": "Return the active configuration the agent is currently using. This can be different from the configuration present in the configuration file, if it has been modified and the agent has not been restarted yet",
+        "summary": "Get active configuration",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": ":component",
+            "description": "Selected agent's component",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "agent",
+                "agentless",
+                "analysis",
+                "auth",
+                "com",
+                "csyslog",
+                "integrator",
+                "logcollector",
+                "mail",
+                "monitor",
+                "request",
+                "syscheck",
+                "wmodules"
               ]
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/group/:group_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.put_agent_single_group",
-          "description": "Assign an agent to a specified group",
-          "summary": "Assign agent to group",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": ":configuration",
+            "description": "<p>Selected agent's configuration to read. The configuration to read depends on the selected component.\nThe following table shows all available combinations of component and configuration values:</p>\n<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>Component</th>\n<th>Configuration</th>\n<th>Tag</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>agent</td>\n<td>client</td>\n<td><code>&lt;client&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>buffer</td>\n<td><code>&lt;client_buffer&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>labels</td>\n<td><code>&lt;labels&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>internal</td>\n<td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>agentless</td>\n<td>agentless</td>\n<td><code>&lt;agentless&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>global</td>\n<td><code>&lt;global&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>active_response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>alerts</td>\n<td><code>&lt;alerts&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>command</td>\n<td><code>&lt;command&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>rules</td>\n<td><code>&lt;rule&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>decoders</td>\n<td><code>&lt;decoder&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>internal</td>\n<td><code>&lt;analysisd&gt;</code></td>\n</tr>\n<tr>\n<td>auth</td>\n<td>auth</td>\n<td><code>&lt;auth&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>active-response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>logging</td>\n<td><code>&lt;logging&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>internal</td>\n<td><code>&lt;execd&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>cluster</td>\n<td><code>&lt;cluster&gt;</code></td>\n</tr>\n<tr>\n<td>csyslog</td>\n<td>csyslog</td>\n<td><code>&lt;csyslog_output&gt;</code></td>\n</tr>\n<tr>\n<td>integrator</td>\n<td>integration</td>\n<td><code>&lt;integration&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>localfile</td>\n<td><code>&lt;localfile&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>socket</td>\n<td><code>&lt;socket&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>internal</td>\n<td><code>&lt;logcollector&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>global</td>\n<td><code>&lt;global&gt;&lt;email...&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>alerts</td>\n<td><code>&lt;email_alerts&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>internal</td>\n<td><code>&lt;maild&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;monitord&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;reports&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>remote</td>\n<td><code>&lt;remote&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>internal</td>\n<td><code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>syscheck</td>\n<td><code>&lt;syscheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>rootcheck</td>\n<td><code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>internal</td>\n<td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>wmodules</td>\n<td>wmodules</td>\n<td><code>&lt;wodle&gt;</code></td>\n</tr>\n</tbody>\n</table>\n",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "client",
+                "buffer",
+                "labels",
+                "internal",
+                "agentless",
+                "global",
+                "active_response",
+                "alerts",
+                "command",
+                "rules",
+                "decoders",
+                "auth",
+                "logging",
+                "reports",
+                "active-response",
+                "cluster",
+                "csyslog",
+                "integration",
+                "localfile",
+                "socket",
+                "remote",
+                "syscheck",
+                "rootcheck",
+                "wmodules"
+              ]
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/group/is_sync",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_sync_agent",
+        "description": "Return whether the agent configuration has been synchronized with the agent or not. This can be useful to check after updating a group configuration",
+        "summary": "Get configuration sync status",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/key",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_key",
+        "description": "Return the key of an agent",
+        "summary": "Get key",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/no_group",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_no_group",
+        "description": "Return a list with all the available agents without an assigned group",
+        "summary": "List agents without group",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/outdated",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_outdated",
+        "description": "Return the list of outdated agents",
+        "summary": "List outdated agents",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/stats/distinct",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_fields",
+        "description": "Return all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination",
+        "summary": "List agents distinct",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "fields",
+            "description": "List of fields affecting the operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/summary/os",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_summary_os",
+        "description": "Return a summary of the OS of available agents",
+        "summary": "Summarize agents OS",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/summary/status",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_summary_status",
+        "description": "Return a summary of the status of available agents",
+        "summary": "Summarize agents status",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/upgrade_result",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_upgrade",
+        "description": "Return the agents upgrade results",
+        "summary": "Get upgrade results",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "minLength": 3,
                 "description": "Agent ID",
                 "format": "numbers"
               }
-            },
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/ciscat/:agent_id/results",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.ciscat_controller.get_agents_ciscat_results",
+        "description": "Return the agent's ciscat results info",
+        "summary": "Get results",
+        "tags": [
+          "Ciscat"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "benchmark",
+            "description": "Filter by benchmark type",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "error",
+            "description": "Filter by encountered errors",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "fail",
+            "description": "Filter by failed checks",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "notchecked",
+            "description": "Filter by not checked",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pass",
+            "description": "Filter by passed checks",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "profile",
+            "description": "Filter by evaluated profile",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "score",
+            "description": "Filter by final score",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "description": "Group name",
-                "format": "group_names"
+                "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "force_single_group",
-              "description": "Whether to append the new group to current agent's multigroup or replace it",
-              "schema": {
-                "type": "boolean"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/restart",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.restart_agent",
-          "description": "Restart the specified agent",
-          "summary": "Restart agent",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
+          },
+          {
+            "name": "unknown",
+            "description": "Filter by unknown results",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/upgrade",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.put_upgrade_agent",
-          "description": "Upgrade the agent using a WPK file from online repository",
-          "summary": "Upgrade agent",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_configuration_node",
+        "description": "Return wazuh configuration used in node {node_id}. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided.",
+        "summary": "Get node config",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
             }
-          ],
-          "query": [
-            {
-              "name": "force",
-              "description": "Force upgrade",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "use_http",
-              "description": "Use http protocol. If it's false use https. By default the value is set to false",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "version",
-              "description": "Wazuh version to upgrade to",
-              "schema": {
+          }
+        ],
+        "query": [
+          {
+            "name": "field",
+            "description": "Indicate a section child. E.g, fields for *ruleset* section are: decoder_dir, rule_dir, etc",
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "section",
+            "description": "Indicates the wazuh configuration section",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active-response",
+                "agentless",
+                "alerts",
+                "auth",
+                "client",
+                "client_buffer",
+                "cluster",
+                "command",
+                "database_output",
+                "email_alerts",
+                "global",
+                "integration",
+                "labels",
+                "localfile",
+                "logging",
+                "remote",
+                "reports",
+                "rootcheck",
+                "ruleset",
+                "sca",
+                "socket",
+                "syscheck",
+                "syslog_output",
+                "agent-key-polling",
+                "aws-s3",
+                "azure-logs",
+                "cis-cat",
+                "docker-listener",
+                "open-scap",
+                "osquery",
+                "syscollector",
+                "vulnerability-detector"
+              ]
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/configuration/:component/:configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_node_config",
+        "description": "Return the requested configuration in JSON format for the specified node",
+        "summary": "Get node active configuration",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":component",
+            "description": "Selected agent's component",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "agent",
+                "agentless",
+                "analysis",
+                "auth",
+                "com",
+                "csyslog",
+                "integrator",
+                "logcollector",
+                "mail",
+                "monitor",
+                "request",
+                "syscheck",
+                "wmodules"
+              ]
+            }
+          },
+          {
+            "name": ":configuration",
+            "description": "<p>Selected agent's configuration to read. The configuration to read depends on the selected component.\nThe following table shows all available combinations of component and configuration values:</p>\n<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>Component</th>\n<th>Configuration</th>\n<th>Tag</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>agent</td>\n<td>client</td>\n<td><code>&lt;client&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>buffer</td>\n<td><code>&lt;client_buffer&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>labels</td>\n<td><code>&lt;labels&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>internal</td>\n<td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>agentless</td>\n<td>agentless</td>\n<td><code>&lt;agentless&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>global</td>\n<td><code>&lt;global&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>active_response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>alerts</td>\n<td><code>&lt;alerts&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>command</td>\n<td><code>&lt;command&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>rules</td>\n<td><code>&lt;rule&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>decoders</td>\n<td><code>&lt;decoder&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>internal</td>\n<td><code>&lt;analysisd&gt;</code></td>\n</tr>\n<tr>\n<td>auth</td>\n<td>auth</td>\n<td><code>&lt;auth&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>active-response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>logging</td>\n<td><code>&lt;logging&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>internal</td>\n<td><code>&lt;execd&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>cluster</td>\n<td><code>&lt;cluster&gt;</code></td>\n</tr>\n<tr>\n<td>csyslog</td>\n<td>csyslog</td>\n<td><code>&lt;csyslog_output&gt;</code></td>\n</tr>\n<tr>\n<td>integrator</td>\n<td>integration</td>\n<td><code>&lt;integration&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>localfile</td>\n<td><code>&lt;localfile&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>socket</td>\n<td><code>&lt;socket&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>internal</td>\n<td><code>&lt;logcollector&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>global</td>\n<td><code>&lt;global&gt;&lt;email...&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>alerts</td>\n<td><code>&lt;email_alerts&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>internal</td>\n<td><code>&lt;maild&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;monitord&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;reports&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>remote</td>\n<td><code>&lt;remote&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>internal</td>\n<td><code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>syscheck</td>\n<td><code>&lt;syscheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>rootcheck</td>\n<td><code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>internal</td>\n<td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>wmodules</td>\n<td>wmodules</td>\n<td><code>&lt;wodle&gt;</code></td>\n</tr>\n</tbody>\n</table>\n",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "client",
+                "buffer",
+                "labels",
+                "internal",
+                "agentless",
+                "global",
+                "active_response",
+                "alerts",
+                "command",
+                "rules",
+                "decoders",
+                "auth",
+                "logging",
+                "reports",
+                "active-response",
+                "cluster",
+                "csyslog",
+                "integration",
+                "localfile",
+                "socket",
+                "remote",
+                "syscheck",
+                "rootcheck",
+                "wmodules"
+              ]
+            }
+          },
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/info",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_info_node",
+        "description": "Return basic information about a specified node such as version, compilation date, installation path",
+        "summary": "Get node info",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/logs",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_node",
+        "description": "Return the last 2000 wazuh log entries in the specified node",
+        "summary": "Get node logs",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "level",
+            "description": "Filter by log level",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "critical",
+                "debug",
+                "debug2",
+                "error",
+                "info",
+                "warning"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "tag",
+            "description": "Wazuh component that logged the event",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ossec-agentlessd",
+                "ossec-analysisd",
+                "ossec-authd",
+                "ossec-csyslogd",
+                "ossec-dbd",
+                "ossec-execd",
+                "ossec-integratord",
+                "ossec-maild",
+                "ossec-monitord",
+                "ossec-logcollector",
+                "ossec-remoted",
+                "ossec-reportd",
+                "ossec-rootcheck",
+                "ossec-syscheckd",
+                "ossec-testrule",
+                "sca",
+                "wazuh-db",
+                "wazuh-modulesd",
+                "wazuh-modulesd:agent-key-polling",
+                "wazuh-modulesd:aws-s3",
+                "wazuh-modulesd:azure-logs",
+                "wazuh-modulesd:ciscat",
+                "wazuh-modulesd:control",
+                "wazuh-modulesd:command",
+                "wazuh-modulesd:database",
+                "wazuh-modulesd:docker-listener",
+                "wazuh-modulesd:download",
+                "wazuh-modulesd:oscap",
+                "wazuh-modulesd:osquery",
+                "wazuh-modulesd:syscollector",
+                "wazuh-modulesd:vulnerability-detector"
+              ]
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/logs/summary",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_summary_node",
+        "description": "Return a summary of the last 2000 wazuh log entries in the specified node",
+        "summary": "Get node logs summary",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/stats",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_node",
+        "description": "Return Wazuh statistical information in node {node_id} for the current or specified date",
+        "summary": "Get node stats",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "date",
+            "description": "Date to obtain statistical information from. Format YYYY-MM-DD",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/stats/analysisd",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_analysisd_node",
+        "description": "Return Wazuh analysisd statistical information in node {node_id}",
+        "summary": "Get node stats analysisd",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/stats/hourly",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_hourly_node",
+        "description": "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field represents the average of alerts per hour",
+        "summary": "Get node stats hour",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/stats/remoted",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_remoted_node",
+        "description": "Return Wazuh remoted statistical information in node {node_id}",
+        "summary": "Get node stats remoted",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/stats/weekly",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_weekly_node",
+        "description": "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field represents the average of alerts per hour for that specific day",
+        "summary": "Get node stats week",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/status",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status_node",
+        "description": "Return the status of all Wazuh daemons in node node_id",
+        "summary": "Get node status",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/api/config",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_api_config",
+        "description": "Return the API configuration of all nodes (or a list of them) in JSON format",
+        "summary": "Get nodes API config",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "nodes_list",
+            "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string"
               }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wpk_repo",
-              "description": "WPK repository",
-              "schema": {
-                "type": "string",
-                "format": "path"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/configuration/validation",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_conf_validation",
+        "description": "Return whether the Wazuh configuration is correct or not in all cluster nodes or a list of them",
+        "summary": "Check nodes config",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "nodes_list",
+            "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/upgrade_custom",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.put_upgrade_custom_agent",
-          "description": "Upgrade the agent using a local WPK file",
-          "summary": "Upgrade agent custom",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/healthcheck",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_healthcheck",
+        "description": "Return cluster healthcheck information for all nodes or a list of them. Such information includes last keep alive, last synchronization time and number of agents reporting on each node",
+        "summary": "Get nodes healthcheck",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "nodes_list",
+            "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "file_path",
-              "description": "Full path to the WPK file. The file must be on a folder on the Wazuh's installation directory (by default, <code>/var/ossec</code>)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "wazuh_path"
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/local/config",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_config",
+        "description": "Return the current node cluster configuration",
+        "summary": "Get local node config",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/local/info",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_node",
+        "description": "Return basic information about the cluster node receiving the request",
+        "summary": "Get local node info",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/nodes",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_nodes",
+        "description": "Get information about all nodes in the cluster or a list of them",
+        "summary": "Get nodes info",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "nodes_list",
+            "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
-            },
-            {
-              "name": "installer",
-              "description": "Installation script. Default is <code>upgrade.sh</code> or <code>upgrade.bat</code> for windows agents",
-              "schema": {
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "type",
+            "description": "Filter by node type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "worker",
+                "master"
+              ]
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/status",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status",
+        "description": "Return information about the cluster status",
+        "summary": "Get cluster status",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/decoders",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders",
+        "description": "Return information about all decoders included in ossec.conf. This information include decoder's route, decoder's name, decoder's file among others",
+        "summary": "List decoders",
+        "tags": [
+          "Decoders"
+        ],
+        "query": [
+          {
+            "name": "decoder_names",
+            "description": "Decoder name",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "filename",
+            "description": "Filter by filename",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "alphanumeric"
               }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
             }
-          ]
-        },
-        {
-          "name": "/agents/group",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.put_multiple_agent_single_group",
-          "description": "Assign all agents or a list of them to the specified group",
-          "summary": "Assign agents to group",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "force_single_group",
-              "description": "Whether to append the new group to current agent's multigroup or replace it",
-              "schema": {
-                "type": "boolean"
-              }
-            },
-            {
-              "name": "group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
             }
-          ]
-        },
-        {
-          "name": "/agents/group/:group_id/restart",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.restart_agents_by_group",
-          "description": "Restart all agents which belong to a given group",
-          "summary": "Restart agents in group",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/agents/node/:node_id/restart",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.restart_agents_by_node",
-          "description": "Restart all agents which belong to a specific given node",
-          "summary": "Restart agents in node",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "relative_dirname",
+            "description": "Filter by relative directory name",
+            "schema": {
+              "type": "string",
+              "format": "get_dirnames_path"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by list status. Use commas to enter multiple statuses",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "minItems": 1
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/decoders/files",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders_files",
+        "description": "Return information about all decoders files used in Wazuh. This information include decoder's file, decoder's route and decoder's status among others",
+        "summary": "Get files",
+        "tags": [
+          "Decoders"
+        ],
+        "query": [
+          {
+            "name": "filename",
+            "description": "Filter by filename",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "alphanumeric"
               }
             }
-          ]
-        },
-        {
-          "name": "/agents/restart",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.restart_agents",
-          "description": "Restart all agents or a list of them",
-          "summary": "Restart agents",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
             }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_files_node",
-          "description": "Replace file contents with the data contained in the API request for the specified node",
-          "summary": "Update node file content",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "relative_dirname",
+            "description": "Filter by relative directory name",
+            "schema": {
+              "type": "string",
+              "format": "get_dirnames_path"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by list status. Use commas to enter multiple statuses",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "minItems": 1
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/decoders/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_file",
+        "description": "Get the content of a specified decoder file",
+        "summary": "Get decoders file content",
+        "tags": [
+          "Decoders"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (rule or decoder) to download/upload/edit file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\w\\-]+\\.xml$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/decoders/parents",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders_parents",
+        "description": "Return information about all parent decoders. A parent decoder is a decoder used as base of other decoders",
+        "summary": "Get parent decoders",
+        "tags": [
+          "Decoders"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "overwrite",
-              "description": "If set to false, an exception will be raised when updating contents of an already existing filename",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "path",
-              "description": "Filepath to upload/edit file. (Relative to wazuh installation folder)",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/ciscat/results",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_cis_cat_results",
+        "description": "Return CIS-CAT results for all agents or a list of them",
+        "summary": "Get agents CIS-CAT results",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "edit_files_path"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
               }
             }
-          ]
-        },
-        {
-          "name": "/cluster/restart",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_restart",
-          "description": "Restart all nodes in the cluster or a list of them",
-          "summary": "Restart nodes",
-          "tags": [
-            "Cluster"
-          ],
-          "query": [
-            {
-              "name": "nodes_list",
-              "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+          },
+          {
+            "name": "benchmark",
+            "description": "Filter by benchmark type",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "error",
+            "description": "Filter by encountered errors",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "fail",
+            "description": "Filter by failed checks",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "notchecked",
+            "description": "Filter by not checked",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pass",
+            "description": "Filter by passed checks",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "profile",
+            "description": "Filter by evaluated profile",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "score",
+            "description": "Filter by final score",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
               }
             }
-          ]
-        },
-        {
-          "name": "/groups/:group_id/configuration",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.put_group_config",
-          "description": "Update an specified group's configuration. This API call expects a full valid XML file with the shared configuration tags/syntax",
-          "summary": "Update group configuration",
-          "tags": [
-            "Groups"
-          ],
-          "args": [
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "unknown",
+            "description": "Filter by unknown results",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/hardware",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hardware_info",
+        "description": "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info among others of all agents",
+        "summary": "Get agents hardware",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "board_serial",
+            "description": "Filter by board_serial",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "cpu.cores",
+            "description": "Filter by cpu.cores",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cpu.mhz",
+            "description": "Filter by cpu.mhz",
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cpu.name",
+            "description": "Filter by cpu.name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "ram.free",
+            "description": "Filter by ram.free",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "ram.total",
+            "description": "Filter by ram.total",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/hotfixes",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hotfixes_info",
+        "description": "Return all agents (or a list of them) hotfixes info",
+        "summary": "Get agents hotfixes",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "hotfix",
+            "description": "Filter by hotfix",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/netaddr",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_address_info",
+        "description": "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network interfaces. This information include used IP protocol, interface, and IP address among others",
+        "summary": "Get agents netaddr",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "address",
+            "description": "Filter by IP address",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "broadcast",
+            "description": "Filter by broadcast direction",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "netmask",
+            "description": "Filter by netmask",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "proto",
+            "description": "Filter by IP protocol",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/netiface",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_interface_info",
+        "description": "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx info and some network information among other",
+        "summary": "Get agents netiface",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "adapter",
+            "description": "Filter by adapter",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "mtu",
+            "description": "Filter by mtu",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by agent name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "rx.bytes",
+            "description": "Filter by rx.bytes",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "rx.dropped",
+            "description": "Filter by rx.dropped",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "rx.errors",
+            "description": "Filter by rx.errors",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "rx.packets",
+            "description": "Filter by rx.packets",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "state",
+            "description": "Filter by state",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "tx.bytes",
+            "description": "Filter by tx.bytes",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "tx.dropped",
+            "description": "Filter by tx.dropped",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "tx.errors",
+            "description": "Filter by tx.errors",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "tx.packets",
+            "description": "Filter by tx.packets",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "type",
+            "description": "Type of network",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/netproto",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_protocol_info",
+        "description": "Return all agents (or a list of them) routing configuration for each network interface. This information includes interface, type protocol information among other",
+        "summary": "Get agents netproto",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "dhcp",
+            "description": "Filter by network dhcp (enabled or disabled)",
+            "schema": {
+              "type": "string",
+              "description": "DHCP status",
+              "enum": [
+                "enabled",
+                "disabled",
+                "unknown",
+                "BOOTP"
+              ]
+            }
+          },
+          {
+            "name": "gateway",
+            "description": "Filter by network gateway",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "iface",
+            "description": "Filter by network interface",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "type",
+            "description": "Type of network",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/os",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_os_info",
+        "description": "Return all agents (or a list of them) OS info. This information includes os information, architecture information among other",
+        "summary": "Get agents OS",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "architecture",
+            "description": "Filter by architecture",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "os.name",
+            "description": "Filter by OS name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "os.version",
+            "description": "Filter by OS version",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "release",
+            "description": "Filter by release",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "version",
+            "description": "Filter by agents version",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/packages",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_packages_info",
+        "description": "Return all agents (or a list of them) packages info. This information includes name, section, size, and priority information of all packages among other",
+        "summary": "Get agents packages",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "architecture",
+            "description": "Filter by architecture",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "format",
+            "description": "Filter by file format. For example 'deb' will output deb files",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by agent name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "vendor",
+            "description": "Filter by vendor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "description": "Filter by version name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/ports",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_ports_info",
+        "description": "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP, protocol information among other",
+        "summary": "Get agents ports",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "local.ip",
+            "description": "Filter by Local IP",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "local.port",
+            "description": "Filter by Local Port",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pid",
+            "description": "Filter by pid",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "process",
+            "description": "Filter by process name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "protocol",
+            "description": "Filter by protocol",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "remote.ip",
+            "description": "Filter by Remote IP",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "state",
+            "description": "Filter by state",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "tx_queue",
+            "description": "Filter by tx_queue",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscollector/processes",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_processes_info",
+        "description": "Return all agents (or a list of them) processes info",
+        "summary": "Get agents processes",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "egroup",
+            "description": "Filter by process egroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "euser",
+            "description": "Filter by process euser",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "fgroup",
+            "description": "Filter by process fgroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by process name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "nlwp",
+            "description": "Filter by process nlwp",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pgrp",
+            "description": "Filter by process pgrp",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "pid",
+            "description": "Filter by process pid",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "ppid",
+            "description": "Filter by process parent pid",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "priority",
+            "description": "Filter by process priority",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "rgroup",
+            "description": "Filter by process rgroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "ruser",
+            "description": "Filter by process ruser",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sgroup",
+            "description": "Filter by process sgroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "state",
+            "description": "Filter by process state",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "suser",
+            "description": "Filter by process suser",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_list_group",
+        "description": "Get information about all groups or a list of them. Returns a list containing basic information about each group such as number of agents belonging to the group and the checksums of the configuration and shared files",
+        "summary": "Get groups",
+        "tags": [
+          "Groups"
+        ],
+        "query": [
+          {
+            "name": "groups_list",
+            "description": "List of group IDs (separated by comma), all groups selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "description": "Group name",
                 "format": "group_names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "hash",
+            "description": "Select algorithm to generate the returned checksums",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "md5",
+                "sha1",
+                "sha224",
+                "sha256",
+                "sha384",
+                "sha512",
+                "blake2b",
+                "blake2s",
+                "sha3_224",
+                "sha3_256",
+                "sha3_384",
+                "sha3_512"
+              ]
             }
-          ]
-        },
-        {
-          "name": "/manager/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_files",
-          "description": "Replace file contents with the data contained in the API request",
-          "summary": "Update file content",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "overwrite",
-              "description": "If set to false, an exception will be raised when updating contents of an already existing filename",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "path",
-              "description": "Filepath to upload/edit file. (Relative to wazuh installation folder)",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups/:group_id/agents",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agents_in_group",
+        "description": "Return the list of agents that belong to the specified group",
+        "summary": "Get agents in a group",
+        "tags": [
+          "Groups"
+        ],
+        "args": [
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "edit_files_path"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+                "format": "names"
               }
             }
-          ]
-        },
-        {
-          "name": "/manager/restart",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_restart",
-          "description": "Restart the wazuh manager",
-          "summary": "Restart manager",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by agent status (use commas to enter multiple statuses)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "pending",
+                  "never_connected",
+                  "disconnected"
+                ]
+              },
+              "minItems": 1
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups/:group_id/configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_config",
+        "description": "Return the group configuration defined in the `agent.conf` file",
+        "summary": "Get group configuration",
+        "tags": [
+          "Groups"
+        ],
+        "args": [
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups/:group_id/files",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_files",
+        "description": "Return the files placed under the group directory",
+        "summary": "Get group files",
+        "tags": [
+          "Groups"
+        ],
+        "args": [
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "hash",
+            "description": "Select algorithm to generate the returned checksums",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "md5",
+                "sha1",
+                "sha224",
+                "sha256",
+                "sha384",
+                "sha512",
+                "blake2b",
+                "blake2s",
+                "sha3_224",
+                "sha3_256",
+                "sha3_384",
+                "sha3_512"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups/:group_id/files/:file_name/json",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_file_json",
+        "description": "Return the contents of the specified group file parsed to JSON",
+        "summary": "Get a file in group",
+        "tags": [
+          "Groups"
+        ],
+        "args": [
+          {
+            "name": ":file_name",
+            "description": "Filename",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "type",
+            "description": "Type of file",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "conf",
+                  "rootkit_files",
+                  "rootkit_trojans",
+                  "rcl"
+                ]
               }
             }
-          ]
-        },
-        {
-          "name": "/security/config",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.put_security_config",
-          "description": "Update the security configuration with the data contained in the API request",
-          "summary": "Update security config",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups/:group_id/files/:file_name/xml",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_file_xml",
+        "description": "Return the contents of the specified group file parsed to XML",
+        "summary": "Get a file in group",
+        "tags": [
+          "Groups"
+        ],
+        "args": [
+          {
+            "name": ":file_name",
+            "description": "Filename",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "type",
+            "description": "Type of file",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "conf",
+                  "rootkit_files",
+                  "rootkit_trojans",
+                  "rcl"
+                ]
               }
             }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "minProperties": 1,
-              "properties": {
-                "auth_token_exp_timeout": {
-                  "description": "Time in seconds until the token expires",
-                  "type": "integer",
-                  "format": "int32",
-                  "minimum": 30,
-                  "example": 900
-                },
-                "rbac_mode": {
-                  "description": "RBAC mode (white/black)",
-                  "type": "string",
-                  "enum": [
-                    "white",
-                    "black"
-                  ],
-                  "example": "white"
-                }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/lists",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_lists",
+        "description": "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria. See available parameters for more details",
+        "summary": "Get CDB lists info",
+        "tags": [
+          "Lists"
+        ],
+        "query": [
+          {
+            "name": "filename",
+            "description": "Filter by filename",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "alphanumeric"
               }
             }
-          ]
-        },
-        {
-          "name": "/security/policies/:policy_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_policy",
-          "description": "Modify a policy, at least one property must be indicated",
-          "summary": "Update policy",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":policy_id",
-              "description": "Specify a policy id",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "relative_dirname",
+            "description": "Filter by relative directory name",
+            "schema": {
+              "type": "string",
+              "format": "get_dirnames_path"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/lists/files",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_lists_files",
+        "description": "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder",
+        "summary": "Get CDB lists files",
+        "tags": [
+          "Lists"
+        ],
+        "query": [
+          {
+            "name": "filename",
+            "description": "Filter by filename",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "alphanumeric"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "relative_dirname",
+            "description": "Filter by relative directory name",
+            "schema": {
+              "type": "string",
+              "format": "get_dirnames_path"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/lists/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_file",
+        "description": "Return the content of a CDB list file. Only the filename can be specified. It will be searched recursively if not found",
+        "summary": "Get CDB list file content",
+        "tags": [
+          "Lists"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (CDB list) to get/edit/delete.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\-\\w]+$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/api/config",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_api_config",
+        "description": "Return the local API configuration in JSON format",
+        "summary": "Get API config",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_configuration",
+        "description": "Return wazuh configuration used. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided.",
+        "summary": "Get configuration",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "field",
+            "description": "Indicate a section child. E.g, fields for *ruleset* section are: decoder_dir, rule_dir, etc",
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "section",
+            "description": "Indicates the wazuh configuration section",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active-response",
+                "agentless",
+                "alerts",
+                "auth",
+                "client",
+                "client_buffer",
+                "cluster",
+                "command",
+                "database_output",
+                "email_alerts",
+                "global",
+                "integration",
+                "labels",
+                "localfile",
+                "logging",
+                "remote",
+                "reports",
+                "rootcheck",
+                "ruleset",
+                "sca",
+                "socket",
+                "syscheck",
+                "syslog_output",
+                "agent-key-polling",
+                "aws-s3",
+                "azure-logs",
+                "cis-cat",
+                "docker-listener",
+                "open-scap",
+                "osquery",
+                "syscollector",
+                "vulnerability-detector"
+              ]
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/configuration/:component/:configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_manager_config_ondemand",
+        "description": "Return the requested active configuration in JSON format",
+        "summary": "Get active configuration",
+        "tags": [
+          "Manager"
+        ],
+        "args": [
+          {
+            "name": ":component",
+            "description": "Selected agent's component",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "agent",
+                "agentless",
+                "analysis",
+                "auth",
+                "com",
+                "csyslog",
+                "integrator",
+                "logcollector",
+                "mail",
+                "monitor",
+                "request",
+                "syscheck",
+                "wmodules"
+              ]
+            }
+          },
+          {
+            "name": ":configuration",
+            "description": "<p>Selected agent's configuration to read. The configuration to read depends on the selected component.\nThe following table shows all available combinations of component and configuration values:</p>\n<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>Component</th>\n<th>Configuration</th>\n<th>Tag</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>agent</td>\n<td>client</td>\n<td><code>&lt;client&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>buffer</td>\n<td><code>&lt;client_buffer&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>labels</td>\n<td><code>&lt;labels&gt;</code></td>\n</tr>\n<tr>\n<td>agent</td>\n<td>internal</td>\n<td><code>&lt;agent&gt;</code>, <code>&lt;monitord&gt;</code>, <code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>agentless</td>\n<td>agentless</td>\n<td><code>&lt;agentless&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>global</td>\n<td><code>&lt;global&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>active_response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>alerts</td>\n<td><code>&lt;alerts&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>command</td>\n<td><code>&lt;command&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>rules</td>\n<td><code>&lt;rule&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>decoders</td>\n<td><code>&lt;decoder&gt;</code></td>\n</tr>\n<tr>\n<td>analysis</td>\n<td>internal</td>\n<td><code>&lt;analysisd&gt;</code></td>\n</tr>\n<tr>\n<td>auth</td>\n<td>auth</td>\n<td><code>&lt;auth&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>active-response</td>\n<td><code>&lt;active-response&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>logging</td>\n<td><code>&lt;logging&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>internal</td>\n<td><code>&lt;execd&gt;</code></td>\n</tr>\n<tr>\n<td>com</td>\n<td>cluster</td>\n<td><code>&lt;cluster&gt;</code></td>\n</tr>\n<tr>\n<td>csyslog</td>\n<td>csyslog</td>\n<td><code>&lt;csyslog_output&gt;</code></td>\n</tr>\n<tr>\n<td>integrator</td>\n<td>integration</td>\n<td><code>&lt;integration&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>localfile</td>\n<td><code>&lt;localfile&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>socket</td>\n<td><code>&lt;socket&gt;</code></td>\n</tr>\n<tr>\n<td>logcollector</td>\n<td>internal</td>\n<td><code>&lt;logcollector&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>global</td>\n<td><code>&lt;global&gt;&lt;email...&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>alerts</td>\n<td><code>&lt;email_alerts&gt;</code></td>\n</tr>\n<tr>\n<td>mail</td>\n<td>internal</td>\n<td><code>&lt;maild&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;monitord&gt;</code></td>\n</tr>\n<tr>\n<td>monitor</td>\n<td>internal</td>\n<td><code>&lt;reports&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>remote</td>\n<td><code>&lt;remote&gt;</code></td>\n</tr>\n<tr>\n<td>request</td>\n<td>internal</td>\n<td><code>&lt;remoted&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>syscheck</td>\n<td><code>&lt;syscheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>rootcheck</td>\n<td><code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>syscheck</td>\n<td>internal</td>\n<td><code>&lt;syscheck&gt;</code>, <code>&lt;rootcheck&gt;</code></td>\n</tr>\n<tr>\n<td>wmodules</td>\n<td>wmodules</td>\n<td><code>&lt;wodle&gt;</code></td>\n</tr>\n</tbody>\n</table>\n",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "client",
+                "buffer",
+                "labels",
+                "internal",
+                "agentless",
+                "global",
+                "active_response",
+                "alerts",
+                "command",
+                "rules",
+                "decoders",
+                "auth",
+                "logging",
+                "reports",
+                "active-response",
+                "cluster",
+                "csyslog",
+                "integration",
+                "localfile",
+                "socket",
+                "remote",
+                "syscheck",
+                "rootcheck",
+                "wmodules"
+              ]
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/configuration/validation",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_conf_validation",
+        "description": "Return whether the Wazuh configuration is correct",
+        "summary": "Check config",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/info",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_info",
+        "description": "Return basic information such as version, compilation date, installation path",
+        "summary": "Get information",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/logs",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log",
+        "description": "Return the last 2000 wazuh log entries",
+        "summary": "Get logs",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "level",
+            "description": "Filter by log level",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "critical",
+                "debug",
+                "debug2",
+                "error",
+                "info",
+                "warning"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "tag",
+            "description": "Wazuh component that logged the event",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ossec-agentlessd",
+                "ossec-analysisd",
+                "ossec-authd",
+                "ossec-csyslogd",
+                "ossec-dbd",
+                "ossec-execd",
+                "ossec-integratord",
+                "ossec-maild",
+                "ossec-monitord",
+                "ossec-logcollector",
+                "ossec-remoted",
+                "ossec-reportd",
+                "ossec-rootcheck",
+                "ossec-syscheckd",
+                "ossec-testrule",
+                "sca",
+                "wazuh-db",
+                "wazuh-modulesd",
+                "wazuh-modulesd:agent-key-polling",
+                "wazuh-modulesd:aws-s3",
+                "wazuh-modulesd:azure-logs",
+                "wazuh-modulesd:ciscat",
+                "wazuh-modulesd:control",
+                "wazuh-modulesd:command",
+                "wazuh-modulesd:database",
+                "wazuh-modulesd:docker-listener",
+                "wazuh-modulesd:download",
+                "wazuh-modulesd:oscap",
+                "wazuh-modulesd:osquery",
+                "wazuh-modulesd:syscollector",
+                "wazuh-modulesd:vulnerability-detector"
+              ]
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/logs/summary",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log_summary",
+        "description": "Return a summary of the last 2000 wazuh log entries",
+        "summary": "Get logs summary",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/stats",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats",
+        "description": "Return Wazuh statistical information for the current or specified date",
+        "summary": "Get stats",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "date",
+            "description": "Date to obtain statistical information from. Format YYYY-MM-DD",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/stats/analysisd",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_analysisd",
+        "description": "Return Wazuh analysisd statistical information",
+        "summary": "Get stats analysisd",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/stats/hourly",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_hourly",
+        "description": "Return Wazuh statistical information per hour. Each number in the averages field represents the average of alerts per hour",
+        "summary": "Get stats hour",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/stats/remoted",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_remoted",
+        "description": "Return Wazuh remoted statistical information",
+        "summary": "Get stats remoted",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/stats/weekly",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_weekly",
+        "description": "Return Wazuh statistical information per week. Each number in the averages field represents the average of alerts per hour for that specific day",
+        "summary": "Get stats week",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/status",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_status",
+        "description": "Return the status of all Wazuh daemons",
+        "summary": "Get status",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/mitre",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_attack",
+        "description": "Return the requested attacks from MITRE database",
+        "summary": "Get MITRE attacks",
+        "tags": [
+          "Mitre"
+        ],
+        "query": [
+          {
+            "name": "id",
+            "description": "MITRE attack ID",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "phase_name",
+            "description": "Show results filtered by phase",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "platform_name",
+            "description": "Show results filtered by platform",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/overview/agents",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.overview_controller.get_overview_agents",
+        "description": "Return a dictionary with a full agents overview",
+        "summary": "Get agents overview",
+        "tags": [
+          "Overview"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rootcheck/:agent_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.get_rootcheck_agent",
+        "description": "Return the rootcheck database of an agent",
+        "summary": "Get results",
+        "tags": [
+          "Rootcheck"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "cis",
+            "description": "Filter by CIS requirement",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "distinct",
+            "description": "Look for distinct values.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pci_dss",
+            "description": "Filter by PCI_DSS requirement name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by status",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rootcheck/:agent_id/last_scan",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.get_last_scan_agent",
+        "description": "Return the timestamp of the last rootcheck scan of an agent",
+        "summary": "Get last scan datetime",
+        "tags": [
+          "Rootcheck"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules",
+        "description": "Return a list containing information about each rule such as file where it's defined, description, rule group, status, etc",
+        "summary": "List rules",
+        "tags": [
+          "Rules"
+        ],
+        "query": [
+          {
+            "name": "filename",
+            "description": "Filter by filename",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "alphanumeric"
+              }
+            }
+          },
+          {
+            "name": "gdpr",
+            "description": "Filter by GDPR requirement",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "gpg13",
+            "description": "Filter by GPG13 requirement",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "group",
+            "description": "Filter by rule group",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "hipaa",
+            "description": "Filter by HIPAA requirement",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "level",
+            "description": "Filter by rule level. Can be a single level (4) or an interval (2-4)",
+            "schema": {
+              "type": "string",
+              "format": "range"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "mitre",
+            "description": "Filters by MITRE attack ID",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "nist-800-53",
+            "description": "Filter by NIST-800-53 requirement",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pci_dss",
+            "description": "Filter by PCI_DSS requirement name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "relative_dirname",
+            "description": "Filter by relative directory name",
+            "schema": {
+              "type": "string",
+              "format": "get_dirnames_path"
+            }
+          },
+          {
+            "name": "rule_ids",
+            "description": "List of rule IDs",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1
+              }
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by list status. Use commas to enter multiple statuses",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "minItems": 1
+            }
+          },
+          {
+            "name": "tsc",
+            "description": "Filters by TSC requirement",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules/files",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_files",
+        "description": "Return a list containing all files used to define rules and their status",
+        "summary": "Get files",
+        "tags": [
+          "Rules"
+        ],
+        "query": [
+          {
+            "name": "filename",
+            "description": "Filter by filename of one or more rule or decoder files.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[\\w\\-]+\\.xml(,[\\w\\-]+\\.xml)*$"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "relative_dirname",
+            "description": "Filter by relative directory name",
+            "schema": {
+              "type": "string",
+              "format": "get_dirnames_path"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by list status. Use commas to enter multiple statuses",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "minItems": 1
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_file",
+        "description": "Get the content of a specified rule in the ruleset",
+        "summary": "Get rules file content",
+        "tags": [
+          "Rules"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (rule or decoder) to download/upload/edit file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\w\\-]+\\.xml$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules/groups",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_groups",
+        "description": "Return a list containing all rule groups names",
+        "summary": "Get groups",
+        "tags": [
+          "Rules"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules/requirement/:requirement",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_requirement",
+        "description": "Return all specified requirement names defined in the Wazuh ruleset",
+        "summary": "Get requirements",
+        "tags": [
+          "Rules"
+        ],
+        "args": [
+          {
+            "name": ":requirement",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pci_dss",
+                "gdpr",
+                "hipaa",
+                "nist-800-53",
+                "gpg13",
+                "tsc",
+                "mitre"
+              ]
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/sca/:agent_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_agent",
+        "description": "Return the security SCA database of an agent",
+        "summary": "Get results",
+        "tags": [
+          "SCA"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "description",
+            "description": "Filter by policy description",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by policy name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "references",
+            "description": "Filter by references",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/sca/:agent_id/checks/:policy_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_checks",
+        "description": "Return the policy monitoring alerts for a given policy",
+        "summary": "Get policy checks",
+        "tags": [
+          "SCA"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": ":policy_id",
+            "description": "Filter by policy id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "command",
+            "description": "Filter by command",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "condition",
+            "description": "Filter by condition",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "description",
+            "description": "Filter by policy description",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "directory",
+            "description": "Filter by directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file",
+            "description": "Filter by full path",
+            "schema": {
+              "type": "string",
+              "format": "paths"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "process",
+            "description": "Filter by process name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rationale",
+            "description": "Filter by rationale",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "reason",
+            "description": "Filter by reason",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "references",
+            "description": "Filter by references",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "registry",
+            "description": "Filter by registry",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "remediation",
+            "description": "Filter by remediation",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "result",
+            "description": "Filter by result",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by status",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "title",
+            "description": "Filter by title",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/actions",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_actions",
+        "description": "Get all RBAC actions, including the potential related resources and endpoints.",
+        "summary": "List RBAC actions",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "endpoint",
+            "description": "Look for the RBAC actions which are related to the specified endpoint",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/config",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_security_config",
+        "description": "Return the security configuration in JSON format",
+        "summary": "Get security config",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/policies",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_policies",
+        "description": "Get all policies in the system, including the administrator policy",
+        "summary": "List policies",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "policy_ids",
+            "description": "List of policy IDs",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "numbers",
                 "description": "Policy ID"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "description": "Policy name",
-                  "type": "string",
-                  "maxLength": 64,
-                  "format": "names"
-                },
-                "policy": {
-                  "description": "New policy definition",
-                  "type": "object",
-                  "properties": {
-                    "actions": {
-                      "type": "array",
-                      "description": "Actions to perform",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "resources": {
-                      "type": "array",
-                      "description": "Resources to apply the actions on",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "effect": {
-                      "type": "string",
-                      "description": "Effect of the policy"
-                    }
-                  },
-                  "required": [
-                    "actions",
-                    "resources",
-                    "effect"
-                  ]
-                }
-              }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
             }
-          ]
-        },
-        {
-          "name": "/security/roles/:role_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_role",
-          "description": "Modify a role, cannot modify associated policies in this endpoint, at least one property must be indicated",
-          "summary": "Update role",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":role_id",
-              "description": "Specify a role ID",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/resources",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_resources",
+        "description": "This method should be called to get all current defined RBAC resources.",
+        "summary": "List RBAC resources",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "resource",
+            "description": "List of current RBAC's resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "*:*",
+                "agent:group",
+                "agent:id",
+                "group:id",
+                "node:id",
+                "decoder:file",
+                "list:file",
+                "rule:file",
+                "policy:id",
+                "role:id",
+                "user:id"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_roles",
+        "description": "For a specific list, indicate the ids separated by commas. Example: ?role_ids=1,2,3",
+        "summary": "List roles",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "role_ids",
+            "description": "List of role IDs (separated by comma)",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "numbers",
                 "description": "Role ID"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
             }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Role name",
-                  "maxLength": 64,
-                  "format": "names"
-                }
-              }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
             }
-          ]
-        },
-        {
-          "name": "/security/rules/:rule_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_rule",
-          "description": "Modify a security rule by specifying its ID",
-          "summary": "Update security rule",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":rule_id",
-              "description": "Specify a rule ID",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/rules",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rules",
+        "description": "Get a list of security rules from the system or all of them. These rules must be mapped with roles to obtain certain access privileges. For a specific list, indicate the ids separated by commas. Example: ?rule_ids=1,2,3",
+        "summary": "List security rules",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "rule_ids",
+            "description": "List of rule IDs (separated by comma)",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "numbers",
                 "description": "Security rule ID"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
             }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Rule name",
-                  "maxLength": 64,
-                  "format": "names"
-                },
-                "rule": {
-                  "type": "object",
-                  "description": "Rule body"
-                }
-              }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
             }
-          ]
-        },
-        {
-          "name": "/security/user/revoke",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.revoke_all_tokens",
-          "description": "This method should be called to revoke all active JWT tokens",
-          "summary": "Revoke JWT tokens",
-          "tags": [
-            "Security"
-          ]
-        },
-        {
-          "name": "/security/users/:user_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_user",
-          "description": "Modify a user's password by specifying their ID",
-          "summary": "Update users",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":user_id",
-              "description": "User ID",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/user/authenticate",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
+        "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
+        "summary": "Login",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/users",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_users",
+        "description": "Get the information of a specified user",
+        "summary": "List users",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "user_ids",
+            "description": "List of user IDs (separated by comma)",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "numbers",
                 "description": "User ID"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "name": "allow_run_as",
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
               "type": "boolean",
               "default": false
-            },
-            {
-              "name": "password",
-              "type": "string",
-              "format": "password"
             }
-          ]
-        },
-        {
-          "name": "/syscheck",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.put_syscheck",
-          "description": "Run FIM scan in all agents",
-          "summary": "Run scan",
-          "tags": [
-            "Syscheck"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID",
-                  "format": "numbers"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          }
+        ]
+      },
+      {
+        "name": "/security/users/me",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me",
+        "description": "Get the information of the current user",
+        "summary": "Get current user info",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        }
-      ]
-    },
-    {
-      "method": "POST",
-      "endpoints": [
-        {
-          "name": "/agents",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.add_agent",
-          "description": "Add a new agent",
-          "summary": "Add agent",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ],
-          "body": [
-            {
-              "name": "force_time",
-              "description": "Remove the old agent with the same IP if disconnected since <force_time> seconds",
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
-            },
-            {
-              "name": "ip",
-              "description": "If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY",
-              "type": "string",
-              "format": "alphanumeric"
-            },
-            {
-              "name": "name",
-              "description": "Agent name",
-              "type": "string",
-              "format": "names"
+          }
+        ]
+      },
+      {
+        "name": "/security/users/me/policies",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me_policies",
+        "description": "Get the processed policies information for the current user",
+        "summary": "Get current user processed policies",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/agents/insert",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.insert_agent",
-          "description": "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace it using `force` parameter",
-          "summary": "Add agent full",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "name": "force_time",
-              "description": "Remove the old agent with the same IP if disconnected for <force_time> seconds",
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
-            },
-            {
-              "name": "id",
+          }
+        ]
+      },
+      {
+        "name": "/syscheck/:agent_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_syscheck_agent",
+        "description": "Return FIM findings in the specified agent",
+        "summary": "Get results",
+        "tags": [
+          "Syscheck"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
               "type": "string",
               "minLength": 3,
               "description": "Agent ID",
               "format": "numbers"
-            },
-            {
-              "name": "ip",
-              "description": "If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY",
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "arch",
+            "description": "Filter by architecture",
+            "schema": {
               "type": "string",
-              "format": "alphanumeric"
-            },
-            {
-              "name": "key",
-              "type": "string",
-              "maxLength": 64,
-              "minLength": 64,
-              "format": "wazuh_key",
-              "description": "Key to use when communicating with the manager. The agent must have the same key on its `client.keys` file"
-            },
-            {
-              "name": "name",
-              "description": "Agent name",
-              "type": "string",
-              "format": "names"
+              "enum": [
+                "[x32]",
+                "[x64]"
+              ]
             }
-          ]
-        },
-        {
-          "name": "/agents/insert/quick",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.post_new_agent",
-          "description": "Add a new agent with name `agent_name`. This agent will use `any` as IP",
-          "summary": "Add agent quick",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "agent_name",
-              "description": "Agent name",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "names",
-                "maxLength": 128
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/groups",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.post_group",
-          "description": "Create a new group",
-          "summary": "Create a group",
-          "tags": [
-            "Groups"
-          ],
-          "query": [
-            {
-              "name": "group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/policies",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.add_policy",
-          "description": "Add a new policy, all fields need to be specified",
-          "summary": "Add policy",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "required": [
-                "name",
-                "policy"
-              ],
-              "properties": {
-                "name": {
-                  "description": "Policy name",
-                  "type": "string",
-                  "maxLength": 64,
-                  "format": "names"
-                },
-                "policy": {
-                  "description": "New policy definition",
-                  "type": "object",
-                  "properties": {
-                    "actions": {
-                      "type": "array",
-                      "description": "Actions to perform",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "resources": {
-                      "type": "array",
-                      "description": "Resources to apply the actions on",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "effect": {
-                      "type": "string",
-                      "description": "Effect of the policy"
-                    }
-                  },
-                  "required": [
-                    "actions",
-                    "resources",
-                    "effect"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/roles",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.add_role",
-          "description": "Add a new role, all fields need to be specified",
-          "summary": "Add role",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "required": [
-                "name"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Role name",
-                  "maxLength": 64,
-                  "format": "names"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/roles/:role_id/policies",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_policy",
-          "description": "Create a specified relation role-policy, one role may have multiples policies",
-          "summary": "Add policies to role",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":role_id",
-              "description": "Specify a role ID",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "numbers",
-                "description": "Role ID"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "policy_ids",
-              "description": "List of policy IDs",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers",
-                  "description": "Policy ID"
-                }
-              }
-            },
-            {
-              "name": "position",
-              "description": "Security position for roles/policies",
-              "required": false,
-              "schema": {
-                "type": "integer",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/roles/:role_id/rules",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_rule",
-          "description": "Create a specific role-rule relation. One role may have multiple security rules",
-          "summary": "Add security rules to role",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":role_id",
-              "description": "Specify a role ID",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "numbers",
-                "description": "Role ID"
-              }
-            }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "rule_ids",
-              "description": "List of rule IDs (separated by comma)",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers",
-                  "description": "Security rule ID"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/rules",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.add_rule",
-          "description": "Add a new security rule",
-          "summary": "Add security rule",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "type": "object",
-              "required": [
-                "name",
-                "rule"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Rule name",
-                  "maxLength": 64,
-                  "format": "names"
-                },
-                "rule": {
-                  "type": "object",
-                  "description": "Rule body"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "name": "/security/user/authenticate/run_as",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
-          "description": "This method should be called to get an API token using an authorization context body. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
-          "summary": "Login auth_context",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "raw",
-              "description": "Format response in plain text",
-              "required": false,
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "body": [
-            {
-              "name": "type",
-              "type": "object"
-            }
-          ]
-        },
-        {
-          "name": "/security/users",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.create_user",
-          "description": "Add a new API user to the system",
-          "summary": "Add user",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ],
-          "body": [
-            {
-              "name": "allow_run_as",
+          },
+          {
+            "name": "distinct",
+            "description": "Look for distinct values.",
+            "schema": {
               "type": "boolean",
               "default": false
-            },
-            {
-              "name": "password",
+            }
+          },
+          {
+            "name": "file",
+            "description": "Filter by full path",
+            "schema": {
               "type": "string",
-              "format": "password"
-            },
-            {
-              "name": "username",
+              "format": "paths"
+            }
+          },
+          {
+            "name": "hash",
+            "description": "Filter files with the specified hash (md5, sha256 or sha1)",
+            "schema": {
               "type": "string",
-              "minLength": 4,
-              "maxLength": 64,
-              "format": "names"
+              "format": "hash"
             }
-          ]
-        },
-        {
-          "name": "/security/users/:user_id/roles",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.set_user_role",
-          "description": "Create a specified relation role-policy, one user may have multiples roles",
-          "summary": "Add roles to user",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":user_id",
-              "description": "User ID",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "numbers",
-                "description": "User ID"
-              }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
             }
-          ],
-          "query": [
-            {
-              "name": "position",
-              "description": "Security position for roles/policies",
-              "required": false,
-              "schema": {
-                "type": "integer",
-                "minimum": 0
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "role_ids",
-              "description": "List of role IDs (separated by comma)",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Role ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "md5",
+            "description": "Filter files with the specified MD5 checksum",
+            "schema": {
+              "type": "string",
+              "format": "hash"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "method": "DELETE",
-      "endpoints": [
-        {
-          "name": "/agents",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.delete_agents",
-          "description": "Delete agents with optional criteria based on the status or time of the last connection",
-          "summary": "Delete agents",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), use the keyword `all` to select all agents",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "older_than",
-              "description": "Consider only agents whose last keep alive is older than the specified time frame. For never_connected agents, register date is considered instead of last keep alive. For example, `7d`, `10s` and `10` are valid values. When no time unit is specified, seconds are assumed. Use 0s to select all agents",
-              "schema": {
-                "type": "string",
-                "format": "timeframe",
-                "default": "7d"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "purge",
-              "description": "Permanently delete an agent from the key store",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "status",
-              "description": "Filter by agent status (use commas to enter multiple statuses)",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "pending",
-                    "never_connected",
-                    "disconnected"
-                  ]
-                },
-                "minItems": 1
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/group",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.delete_single_agent_multiple_groups",
-          "description": "Remove the agent from all groups or a list of them. The agent will automatically revert to the default group if it is removed from all its assigned groups",
-          "summary": "Remove agent from groups",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ],
-          "query": [
-            {
-              "name": "groups_list",
-              "description": "List of group IDs (separated by comma), all groups selected by default if not specified",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Group name",
-                  "format": "group_names"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
             }
-          ]
-        },
-        {
-          "name": "/agents/:agent_id/group/:group_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.delete_single_agent_single_group",
-          "description": "Remove an agent from an specified group. If the agent has multigroups, it will preserve all previous groups except the last one",
-          "summary": "Remove agent from group",
-          "tags": [
-            "Agents"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "minLength": 3,
-                "description": "Agent ID",
-                "format": "numbers"
-              }
-            },
-            {
-              "name": ":group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/agents/group",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.delete_multiple_agent_single_group",
-          "description": "Remove all agents assignment or a list of them from the specified group",
-          "summary": "Remove agents from group",
-          "tags": [
-            "Agents"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), use the keyword `all` to select all agents",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "group_id",
-              "description": "Group ID. (Name of the group)",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "description": "Group name",
-                "format": "group_names"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            }
-          ]
-        },
-        {
-          "name": "/cluster/:node_id/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.delete_files_node",
-          "description": "Delete a file in the specified node",
-          "summary": "Delete node file",
-          "tags": [
-            "Cluster"
-          ],
-          "args": [
-            {
-              "name": ":node_id",
-              "description": "Cluster node name",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "path",
-              "description": "Filepath to delete file. (Relative to wazuh installation folder)",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "sha1",
+            "description": "Filter files with the specified SHA1 checksum",
+            "schema": {
+              "type": "string",
+              "format": "hash"
+            }
+          },
+          {
+            "name": "sha256",
+            "description": "Filter files with the specified SHA256 checksum",
+            "schema": {
+              "type": "string",
+              "format": "hash"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "summary",
+            "description": "Return a summary grouping by filename",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "type",
+            "description": "Filter by file type. Registry_key and registry_value types are only available in Windows agents",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "file",
+                "registry_key",
+                "registry_value"
+              ]
+            }
+          },
+          {
+            "name": "value.name",
+            "description": "Filter by value name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "value.type",
+            "description": "Filter by value type",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscheck/:agent_id/last_scan",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_last_scan_agent",
+        "description": "Return when the last syscheck scan started and ended. If the scan is still in progress the end date will be unknown",
+        "summary": "Get last scan datetime",
+        "tags": [
+          "Syscheck"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/hardware",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hardware_info",
+        "description": "Return the agent's hardware info. This information include cpu, ram, scan info among others",
+        "summary": "Get agent hardware",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "delete_files_path"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+                "format": "names"
               }
             }
-          ]
-        },
-        {
-          "name": "/experimental/syscheck",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.clear_syscheck_database",
-          "description": "Clear the syscheck database for all agents or a list of them",
-          "summary": "Clear agents FIM results",
-          "tags": [
-            "Experimental"
-          ],
-          "query": [
-            {
-              "name": "agents_list",
-              "description": "List of agent IDs (separated by comma), use the keyword `all` to select all agents",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 3,
-                  "description": "Agent ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/groups",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agents_controller.delete_groups",
-          "description": "Delete all groups or a list of them",
-          "summary": "Delete groups",
-          "tags": [
-            "Groups"
-          ],
-          "query": [
-            {
-              "name": "groups_list",
-              "description": "List of group IDs (separated by comma), use the keyword 'all' to select all groups",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "Group name|all",
-                  "format": "group_names_delete"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/hotfixes",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hotfix_info",
+        "description": "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)",
+        "summary": "Get agent hotfixes",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
             }
-          ]
-        },
-        {
-          "name": "/manager/files",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.delete_files",
-          "description": "Delete a specified file",
-          "summary": "Delete file",
-          "tags": [
-            "Manager"
-          ],
-          "query": [
-            {
-              "name": "path",
-              "description": "Filepath to delete file. (Relative to wazuh installation folder)",
-              "required": true,
-              "schema": {
+          }
+        ],
+        "query": [
+          {
+            "name": "hotfix",
+            "description": "Filter by hotfix",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "delete_files_path"
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+                "format": "names"
               }
             }
-          ]
-        },
-        {
-          "name": "/security/config",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_security_config",
-          "description": "Replaces the security configuration with the original one",
-          "summary": "Restore default security config",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
             }
-          ]
-        },
-        {
-          "name": "/security/policies",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_policies",
-          "description": "Delete a list of policies or all policies in the system, roles linked to policies are not going to be removed",
-          "summary": "Delete policies",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "policy_ids",
-              "description": "List of policy IDs (separated by comma), use the keyword 'all' to select all policies",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Policy ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
-          ]
-        },
-        {
-          "name": "/security/roles",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_roles",
-          "description": "Policies linked to roles are not going to be removed",
-          "summary": "Delete roles",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "role_ids",
-              "description": "List of role IDs (separated by comma), use the keyword 'all' to select all roles",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Role ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/netaddr",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_address_info",
+        "description": "Return the agent's network address info. This information include used IP protocol, interface, IP address  among others",
+        "summary": "Get agent netaddr",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
             }
-          ]
-        },
-        {
-          "name": "/security/roles/:role_id/policies",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_policy",
-          "description": "Delete a specified relation role-policy",
-          "summary": "Remove policies from role",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":role_id",
-              "description": "Specify a role ID",
-              "required": true,
-              "schema": {
+          }
+        ],
+        "query": [
+          {
+            "name": "address",
+            "description": "Filter by IP address",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "broadcast",
+            "description": "Filter by broadcast direction",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "iface",
+            "description": "Filter by network interface",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "netmask",
+            "description": "Filter by netmask",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "proto",
+            "description": "Filter by IP protocol",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "numbers",
-                "description": "Role ID"
+                "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "policy_ids",
-              "description": "List of policy IDs (separated by comma), use the keyword 'all' to select all policies",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Policy ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
             }
-          ]
-        },
-        {
-          "name": "/security/roles/:role_id/rules",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_rule",
-          "description": "Delete a specific role-rule relation",
-          "summary": "Remove security rules from role",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":role_id",
-              "description": "Specify a role ID",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/netiface",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_interface_info",
+        "description": "Return the agent's network interface info. This information include rx, scan, tx info and some network information among others",
+        "summary": "Get agent netiface",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "adapter",
+            "description": "Filter by adapter",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "mtu",
+            "description": "Filter by mtu",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by agent name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rx.bytes",
+            "description": "Filter by rx.bytes",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "rx.dropped",
+            "description": "Filter by rx.dropped",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "rx.errors",
+            "description": "Filter by rx.errors",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "rx.packets",
+            "description": "Filter by rx.packets",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "numbers",
-                "description": "Role ID"
+                "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "rule_ids",
-              "description": "List of rule IDs (separated by comma), use the keyword 'all' to select all rules",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers_delete",
-                  "description": "Security rule ID|all"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
             }
-          ]
-        },
-        {
-          "name": "/security/rules",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_rules",
-          "description": "Delete a list of security rules or all security rules in the system, roles linked to rules are not going to be deleted",
-          "summary": "Delete security rules",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "rule_ids",
-              "description": "List of rule IDs (separated by comma), use the keyword 'all' to select all rules",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers_delete",
-                  "description": "Security rule ID|all"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "state",
+            "description": "Filter by state",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
             }
-          ]
-        },
-        {
-          "name": "/security/user/authenticate",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.logout_user",
-          "description": "This method should be called to invalidate all the current user's tokens",
-          "summary": "Logout current user",
-          "tags": [
-            "Security"
-          ]
-        },
-        {
-          "name": "/security/users",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_users",
-          "description": "Delete a list of users by specifying their IDs",
-          "summary": "Delete users",
-          "tags": [
-            "Security"
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "user_ids",
-              "description": "List of user IDs (separated by comma), use the keyword 'all' to select all users",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "numbers_delete",
-                  "description": "User ID|all"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
+          },
+          {
+            "name": "tx.bytes",
+            "description": "Filter by tx.bytes",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
             }
-          ]
-        },
-        {
-          "name": "/security/users/:user_id/roles",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_user_role",
-          "description": "Delete a specified relation user-roles",
-          "summary": "Remove roles from user",
-          "tags": [
-            "Security"
-          ],
-          "args": [
-            {
-              "name": ":user_id",
-              "description": "User ID",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "tx.dropped",
+            "description": "Filter by tx.dropped",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "tx.errors",
+            "description": "Filter by tx.errors",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "tx.packets",
+            "description": "Filter by tx.packets",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "type",
+            "description": "Type of file",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/netproto",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_protocol_info",
+        "description": "Return the agent's routing configuration for each network interface",
+        "summary": "Get agent netproto",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "dhcp",
+            "description": "Filter by network dhcp (enabled or disabled)",
+            "schema": {
+              "type": "string",
+              "description": "DHCP status",
+              "enum": [
+                "enabled",
+                "disabled",
+                "unknown",
+                "BOOTP"
+              ]
+            }
+          },
+          {
+            "name": "gateway",
+            "description": "Filter by network gateway",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "iface",
+            "description": "Filter by network interface",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
-                "format": "numbers",
-                "description": "User ID"
+                "format": "names"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
-                "type": "boolean",
-                "default": false
-              }
-            },
-            {
-              "name": "role_ids",
-              "description": "List of role IDs (separated by comma), use the keyword 'all' to select all roles",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Role ID|all",
-                  "format": "numbers_delete"
-                }
-              }
-            },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "type",
+            "description": "Type of network",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/os",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_os_info",
+        "description": "Return the agent's OS info. This information include os information, architecture information among others of all agents",
+        "summary": "Get agent OS",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
               }
             }
-          ]
-        },
-        {
-          "name": "/syscheck/:agent_id",
-          "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.delete_syscheck_agent",
-          "description": "Clear file integrity monitoring scan results for a specified agent",
-          "summary": "Clear results",
-          "tags": [
-            "Syscheck"
-          ],
-          "args": [
-            {
-              "name": ":agent_id",
-              "description": "Agent ID. All possible values from 000 onwards",
-              "required": true,
-              "schema": {
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/packages",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_packages_info",
+        "description": "Return the agent's packages info. This information include name, section, size, priority information of all packages among others",
+        "summary": "Get agent packages",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "architecture",
+            "description": "Filter by architecture",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "format",
+            "description": "Filter by file format. For example 'deb' will output deb files",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by agent name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "vendor",
+            "description": "Filter by vendor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "description": "Filter by version name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/ports",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_ports_info",
+        "description": "Return the agent's ports info. This information include local IP, Remote IP, protocol information among others",
+        "summary": "Get agent ports",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "local.ip",
+            "description": "Filter by Local IP",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "local.port",
+            "description": "Filter by Local Port",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pid",
+            "description": "Filter by pid",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "process",
+            "description": "Filter by process name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "protocol",
+            "description": "Filter by protocol",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "remote.ip",
+            "description": "Filter by Remote IP",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "state",
+            "description": "Filter by state",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "tx_queue",
+            "description": "Filter by tx_queue",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscollector/:agent_id/processes",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_processes_info",
+        "description": "Return the agent's processes info",
+        "summary": "Get agent processes",
+        "tags": [
+          "Syscollector"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "egroup",
+            "description": "Filter by process egroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "euser",
+            "description": "Filter by process euser",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "fgroup",
+            "description": "Filter by process fgroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "name",
+            "description": "Filter by process name",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "nlwp",
+            "description": "Filter by process nlwp",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pgrp",
+            "description": "Filter by process pgrp",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "pid",
+            "description": "Filter by process pid",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "ppid",
+            "description": "Filter by process parent pid",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "priority",
+            "description": "Filter by process priority",
+            "schema": {
+              "type": "string",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rgroup",
+            "description": "Filter by process rgroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "ruser",
+            "description": "Filter by process ruser",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sgroup",
+            "description": "Filter by process sgroup",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "state",
+            "description": "Filter by process state",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "suser",
+            "description": "Filter by process suser",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/tasks/status",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.task_controller.get_tasks_status",
+        "description": "Returns all available information about the specified tasks",
+        "summary": "List tasks",
+        "tags": [
+          "tasks"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string",
                 "minLength": 3,
                 "description": "Agent ID",
                 "format": "numbers"
               }
             }
-          ],
-          "query": [
-            {
-              "name": "pretty",
-              "description": "Show results in human-readable format",
-              "schema": {
+          },
+          {
+            "name": "command",
+            "description": "Filter by command",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "module",
+            "description": "Show results filtered by module",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "node",
+            "description": "Show results filtered by node",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "offset",
+            "description": "First element to return in the collection",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "q",
+            "description": "Query to filter results by. For example q=&quot;status=active&quot;",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Look for elements containing the specified string. To obtain a complementary search, use '-' at the beggining",
+            "schema": {
+              "type": "string",
+              "format": "search"
+            }
+          },
+          {
+            "name": "select",
+            "description": "Select which fields to return (separated by comma). Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "names"
+              }
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
+            "schema": {
+              "type": "string",
+              "format": "sort"
+            }
+          },
+          {
+            "name": "status",
+            "description": "Filter by status",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "tasks_list",
+            "description": "List of task IDs (separated by comma)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "numbers",
+                "description": "Task ID"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "method": "PUT",
+    "endpoints": [
+      {
+        "name": "/active-response",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.active_response_controller.run_command",
+        "description": "Run an Active Response command on all agents or a list of them",
+        "summary": "Run command",
+        "tags": [
+          "Active-response"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "properties": {
+              "arguments": {
+                "description": "Command arguments",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "description": "Command running in the agent. If this value starts by `!`, then it refers to a script name instead of a command name",
+                "type": "string"
+              },
+              "custom": {
+                "description": "Whether the specified command is a custom command or not",
                 "type": "boolean",
                 "default": false
               }
             },
-            {
-              "name": "wait_for_complete",
-              "description": "Disable timeout response",
-              "schema": {
-                "type": "boolean",
-                "default": false
+            "required": [
+              "command"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/group/:group_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_agent_single_group",
+        "description": "Assign an agent to a specified group",
+        "summary": "Assign agent to group",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "force_single_group",
+            "description": "Whether to append the new group to current agent's multigroup or replace it",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/restart",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agent",
+        "description": "Restart the specified agent",
+        "summary": "Restart agent",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/group",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_multiple_agent_single_group",
+        "description": "Assign all agents or a list of them to the specified group",
+        "summary": "Assign agents to group",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
               }
             }
-          ]
-        }
-      ]
-    }
+          },
+          {
+            "name": "force_single_group",
+            "description": "Whether to append the new group to current agent's multigroup or replace it",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/group/:group_id/restart",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents_by_group",
+        "description": "Restart all agents which belong to a given group",
+        "summary": "Restart agents in group",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/node/:node_id/restart",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents_by_node",
+        "description": "Restart all agents which belong to a specific given node",
+        "summary": "Restart agents in node",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/restart",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents",
+        "description": "Restart all agents or a list of them",
+        "summary": "Restart agents",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/upgrade",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_upgrade_agents",
+        "description": "Upgrade agents using a WPK file from online repository",
+        "summary": "Upgrade agents",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), select a list of agents with size less or equal than 100",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              },
+              "maxItems": 100
+            }
+          },
+          {
+            "name": "force",
+            "description": "Force upgrade",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "use_http",
+            "description": "Use http protocol. If it's false use https. By default the value is set to false",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "version",
+            "description": "Wazuh version to upgrade to",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wpk_repo",
+            "description": "WPK repository",
+            "schema": {
+              "type": "string",
+              "format": "path"
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/upgrade_custom",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_upgrade_custom_agents",
+        "description": "Upgrade the agents using a local WPK file",
+        "summary": "Upgrade agents custom",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), select a list of agents with size less or equal than 100",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              },
+              "maxItems": 100
+            }
+          },
+          {
+            "name": "file_path",
+            "description": "Full path to the WPK file. The file must be on a folder on the Wazuh's installation directory (by default, <code>/var/ossec</code>)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "wazuh_path"
+            }
+          },
+          {
+            "name": "installer",
+            "description": "Installation script. Default is <code>upgrade.sh</code> or <code>upgrade.bat</code> for windows agents",
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/:node_id/configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.update_configuration",
+        "description": "Replace wazuh configuration for the given node with the data contained in the API request",
+        "summary": "Update node configuration",
+        "tags": [
+          "Cluster"
+        ],
+        "args": [
+          {
+            "name": ":node_id",
+            "description": "Cluster node name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/cluster/restart",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_restart",
+        "description": "Restart all nodes in the cluster or a list of them",
+        "summary": "Restart nodes",
+        "tags": [
+          "Cluster"
+        ],
+        "query": [
+          {
+            "name": "nodes_list",
+            "description": "List of node IDs (separated by comma), all nodes selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/decoders/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoder_controller.put_file",
+        "description": "Upload or replace a user decoder file content",
+        "summary": "Update decoders file",
+        "tags": [
+          "Decoders"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (rule or decoder) to download/upload/edit file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\w\\-]+\\.xml$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "overwrite",
+            "description": "If set to false, an exception will be raised when updating contents of an already existing filename",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups/:group_id/configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_group_config",
+        "description": "Update an specified group's configuration. This API call expects a full valid XML file with the shared configuration tags/syntax",
+        "summary": "Update group configuration",
+        "tags": [
+          "Groups"
+        ],
+        "args": [
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/lists/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.put_file",
+        "description": "Replace or upload a CDB list file with the data contained in the API request",
+        "summary": "Update CDB list file",
+        "tags": [
+          "Lists"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (CDB list) to get/edit/delete.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\-\\w]+$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "overwrite",
+            "description": "If set to false, an exception will be raised when updating contents of an already existing filename",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/logtest",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.logtest_controller.run_logtest_tool",
+        "description": "Run logtest tool to check if a specified log raises any alert among other information",
+        "summary": "Run logtest",
+        "tags": [
+          "Logtest"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "required": [
+              "event",
+              "log_format",
+              "location"
+            ],
+            "properties": {
+              "token": {
+                "type": "string",
+                "description": "Token for the logtest session"
+              },
+              "log_format": {
+                "type": "string",
+                "description": "Allowed values: syslog, json, snort-full, squid, eventlog, eventchannel, audit, mysql_log, postgresql_log, nmapg, iis, command, full_command, djb-multilog, multi-line"
+              },
+              "location": {
+                "type": "string",
+                "description": "Path string"
+              },
+              "event": {
+                "type": "string",
+                "description": "Event to look for"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/configuration",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.update_configuration",
+        "description": "Replace Wazuh configuration with the data contained in the API request",
+        "summary": "Update Wazuh configuration",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/manager/restart",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_restart",
+        "description": "Restart the wazuh manager",
+        "summary": "Restart manager",
+        "tags": [
+          "Manager"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rootcheck",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.put_rootcheck",
+        "description": "Run rootcheck scan in all agents or a list of them",
+        "summary": "Run scan",
+        "tags": [
+          "Rootcheck"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.put_file",
+        "description": "Upload or replace a user ruleset file content",
+        "summary": "Update rules file",
+        "tags": [
+          "Rules"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (rule or decoder) to download/upload/edit file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\w\\-]+\\.xml$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "overwrite",
+            "description": "If set to false, an exception will be raised when updating contents of an already existing filename",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/config",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.put_security_config",
+        "description": "Update the security configuration with the data contained in the API request",
+        "summary": "Update security config",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "minProperties": 1,
+            "properties": {
+              "auth_token_exp_timeout": {
+                "description": "Time in seconds until the token expires",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 30,
+                "example": 900
+              },
+              "rbac_mode": {
+                "description": "RBAC mode (white/black)",
+                "type": "string",
+                "enum": [
+                  "white",
+                  "black"
+                ],
+                "example": "white"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/policies/:policy_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_policy",
+        "description": "Modify a policy, at least one property must be indicated",
+        "summary": "Update policy",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":policy_id",
+            "description": "Specify a policy id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Policy ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Policy name",
+                "type": "string",
+                "maxLength": 64,
+                "format": "names"
+              },
+              "policy": {
+                "description": "New policy definition",
+                "type": "object",
+                "properties": {
+                  "actions": {
+                    "type": "array",
+                    "description": "Actions to perform",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": {
+                    "type": "array",
+                    "description": "Resources to apply the actions on",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "effect": {
+                    "type": "string",
+                    "description": "Effect of the policy"
+                  }
+                },
+                "required": [
+                  "actions",
+                  "resources",
+                  "effect"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles/:role_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_role",
+        "description": "Modify a role, cannot modify associated policies in this endpoint, at least one property must be indicated",
+        "summary": "Update role",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":role_id",
+            "description": "Specify a role ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Role ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Role name",
+                "maxLength": 64,
+                "format": "names"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/rules/:rule_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_rule",
+        "description": "Modify a security rule by specifying its ID",
+        "summary": "Update security rule",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":rule_id",
+            "description": "Specify a rule ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Security rule ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Rule name",
+                "maxLength": 64,
+                "format": "names"
+              },
+              "rule": {
+                "type": "object",
+                "description": "Rule body"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/user/revoke",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.revoke_all_tokens",
+        "description": "This method should be called to revoke all active JWT tokens",
+        "summary": "Revoke JWT tokens",
+        "tags": [
+          "Security"
+        ]
+      },
+      {
+        "name": "/security/users/:user_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.update_user",
+        "description": "Modify a user's password by specifying their ID",
+        "summary": "Update users",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":user_id",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "User ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "name": "allow_run_as",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "password",
+            "type": "string",
+            "format": "password"
+          }
+        ]
+      },
+      {
+        "name": "/syscheck",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.put_syscheck",
+        "description": "Run FIM scan in all agents",
+        "summary": "Run scan",
+        "tags": [
+          "Syscheck"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "method": "POST",
+    "endpoints": [
+      {
+        "name": "/agents",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.add_agent",
+        "description": "Add a new agent",
+        "summary": "Add agent",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "name": "force_time",
+            "description": "Remove the old agent with the same IP if disconnected since <force_time> seconds",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          {
+            "name": "ip",
+            "description": "If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY",
+            "type": "string",
+            "format": "alphanumeric"
+          },
+          {
+            "name": "name",
+            "description": "Agent name",
+            "type": "string",
+            "format": "names"
+          }
+        ]
+      },
+      {
+        "name": "/agents/insert",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.insert_agent",
+        "description": "Add an agent specifying its name, ID and IP. If an agent with the same ID already exists, replace it using `force` parameter",
+        "summary": "Add agent full",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "name": "force_time",
+            "description": "Remove the old agent with the same IP if disconnected for <force_time> seconds",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "minLength": 3,
+            "description": "Agent ID",
+            "format": "numbers"
+          },
+          {
+            "name": "ip",
+            "description": "If this is not included, the API will get the IP automatically. If you are behind a proxy, you must set the option behind_proxy_server to yes at api.yaml and make sure the proxy is setting HTTP header 'X-Forwarded-For' with origin IP address. Allowed values: IP, IP/NET, ANY",
+            "type": "string",
+            "format": "alphanumeric"
+          },
+          {
+            "name": "key",
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 64,
+            "format": "wazuh_key",
+            "description": "Key to use when communicating with the manager. The agent must have the same key on its `client.keys` file"
+          },
+          {
+            "name": "name",
+            "description": "Agent name",
+            "type": "string",
+            "format": "names"
+          }
+        ]
+      },
+      {
+        "name": "/agents/insert/quick",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.post_new_agent",
+        "description": "Add a new agent with name `agent_name`. This agent will use `any` as IP",
+        "summary": "Add agent quick",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agent_name",
+            "description": "Agent name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "names",
+              "maxLength": 128
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.post_group",
+        "description": "Create a new group",
+        "summary": "Create a group",
+        "tags": [
+          "Groups"
+        ],
+        "query": [
+          {
+            "name": "group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/policies",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.add_policy",
+        "description": "Add a new policy, all fields need to be specified",
+        "summary": "Add policy",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "policy"
+            ],
+            "properties": {
+              "name": {
+                "description": "Policy name",
+                "type": "string",
+                "maxLength": 64,
+                "format": "names"
+              },
+              "policy": {
+                "description": "New policy definition",
+                "type": "object",
+                "properties": {
+                  "actions": {
+                    "type": "array",
+                    "description": "Actions to perform",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": {
+                    "type": "array",
+                    "description": "Resources to apply the actions on",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "effect": {
+                    "type": "string",
+                    "description": "Effect of the policy"
+                  }
+                },
+                "required": [
+                  "actions",
+                  "resources",
+                  "effect"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.add_role",
+        "description": "Add a new role, all fields need to be specified",
+        "summary": "Add role",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Role name",
+                "maxLength": 64,
+                "format": "names"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles/:role_id/policies",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_policy",
+        "description": "Create a specified relation role-policy, one role may have multiples policies",
+        "summary": "Add policies to role",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":role_id",
+            "description": "Specify a role ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Role ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "policy_ids",
+            "description": "List of policy IDs",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "numbers",
+                "description": "Policy ID"
+              }
+            }
+          },
+          {
+            "name": "position",
+            "description": "Security position for roles/policies",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles/:role_id/rules",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_rule",
+        "description": "Create a specific role-rule relation. One role may have multiple security rules",
+        "summary": "Add security rules to role",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":role_id",
+            "description": "Specify a role ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Role ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "rule_ids",
+            "description": "List of rule IDs (separated by comma)",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "numbers",
+                "description": "Security rule ID"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/rules",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.add_rule",
+        "description": "Add a new security rule",
+        "summary": "Add security rule",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "rule"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Rule name",
+                "maxLength": 64,
+                "format": "names"
+              },
+              "rule": {
+                "type": "object",
+                "description": "Rule body"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/user/authenticate/run_as",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
+        "description": "This method should be called to get an API token using an authorization context body. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
+        "summary": "Login auth_context",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "body": [
+          {
+            "name": "type",
+            "type": "object"
+          }
+        ]
+      },
+      {
+        "name": "/security/users",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.create_user",
+        "description": "Add a new API user to the system",
+        "summary": "Add user",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "body": [
+          {
+            "name": "allow_run_as",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "name": "password",
+            "type": "string",
+            "format": "password"
+          },
+          {
+            "name": "username",
+            "type": "string",
+            "minLength": 4,
+            "maxLength": 64,
+            "format": "names"
+          }
+        ]
+      },
+      {
+        "name": "/security/users/:user_id/roles",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.set_user_role",
+        "description": "Create a specified relation role-policy, one user may have multiples roles",
+        "summary": "Add roles to user",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":user_id",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "User ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "position",
+            "description": "Security position for roles/policies",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "role_ids",
+            "description": "List of role IDs (separated by comma)",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Role ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "method": "DELETE",
+    "endpoints": [
+      {
+        "name": "/agents",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_agents",
+        "description": "Delete agents with optional criteria based on the status or time of the last connection",
+        "summary": "Delete agents",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), use the keyword `all` to select all agents",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "older_than",
+            "description": "Consider only agents whose last keep alive is older than the specified time frame. For never_connected agents, register date is considered instead of last keep alive. For example, `7d`, `10s` and `10` are valid values. When no time unit is specified, seconds are assumed. Use 0s to select all agents",
+            "schema": {
+              "type": "string",
+              "format": "timeframe",
+              "default": "7d"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "purge",
+            "description": "Permanently delete an agent from the key store",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "status",
+            "required": true,
+            "description": "Filter by agent status (use commas to enter multiple statuses)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "active",
+                  "pending",
+                  "never_connected",
+                  "disconnected"
+                ]
+              },
+              "minItems": 1
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/group",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_single_agent_multiple_groups",
+        "description": "Remove the agent from all groups or a list of them. The agent will automatically revert to the default group if it is removed from all its assigned groups",
+        "summary": "Remove agent from groups",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "groups_list",
+            "description": "List of group IDs (separated by comma), all groups selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Group name",
+                "format": "group_names"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/:agent_id/group/:group_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_single_agent_single_group",
+        "description": "Remove an agent from an specified group. If the agent has multigroups, it will preserve all previous groups except the last one",
+        "summary": "Remove agent from group",
+        "tags": [
+          "Agents"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": ":group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/agents/group",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_multiple_agent_single_group",
+        "description": "Remove all agents assignment or a list of them from the specified group",
+        "summary": "Remove agents from group",
+        "tags": [
+          "Agents"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), use the keyword `all` to select all agents",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "group_id",
+            "description": "Group ID. (Name of the group)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Group name",
+              "format": "group_names"
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/decoders/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.decoder_controller.delete_file",
+        "description": "Delete a specified decoder file",
+        "summary": "Delete decoders file",
+        "tags": [
+          "Decoders"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (rule or decoder) to download/upload/edit file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\w\\-]+\\.xml$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/experimental/syscheck",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.experimental_controller.clear_syscheck_database",
+        "description": "Clear the syscheck database for all agents or a list of them",
+        "summary": "Clear agents FIM results",
+        "tags": [
+          "Experimental"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), use the keyword `all` to select all agents",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/groups",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_groups",
+        "description": "Delete all groups or a list of them",
+        "summary": "Delete groups",
+        "tags": [
+          "Groups"
+        ],
+        "query": [
+          {
+            "name": "groups_list",
+            "description": "List of group IDs (separated by comma), use the keyword 'all' to select all groups",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Group name|all",
+                "format": "group_names_delete"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/lists/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.delete_file",
+        "description": "Delete a specified CDB list file. Only the filename can be specified. It will be searched recursively if not found",
+        "summary": "Delete CDB list file",
+        "tags": [
+          "Lists"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (CDB list) to get/edit/delete.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\-\\w]+$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/logtest/sessions/:token",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.logtest_controller.end_logtest_session",
+        "description": "Delete the saved logtest session corresponding to {token}",
+        "summary": "End session",
+        "tags": [
+          "Logtest"
+        ],
+        "args": [
+          {
+            "name": ":token",
+            "description": "Token of the logtest saved session",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "alphanumeric"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rootcheck",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.delete_rootcheck",
+        "description": "Clear rootcheck database for all agents or a list of them",
+        "summary": "Clear results",
+        "tags": [
+          "Rootcheck"
+        ],
+        "query": [
+          {
+            "name": "agents_list",
+            "description": "List of agent IDs (separated by comma), all agents selected by default if not specified",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Agent ID",
+                "format": "numbers"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/rules/files/:filename",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.rule_controller.delete_file",
+        "description": "Delete a specified rule file",
+        "summary": "Delete rules file",
+        "tags": [
+          "Rules"
+        ],
+        "args": [
+          {
+            "name": ":filename",
+            "description": "Filename (rule or decoder) to download/upload/edit file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[\\w\\-]+\\.xml$"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/config",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_security_config",
+        "description": "Replaces the security configuration with the original one",
+        "summary": "Restore default security config",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/policies",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_policies",
+        "description": "Delete a list of policies or all policies in the system, roles linked to policies are not going to be removed",
+        "summary": "Delete policies",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "policy_ids",
+            "description": "List of policy IDs (separated by comma), use the keyword 'all' to select all policies",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Policy ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_roles",
+        "description": "Policies linked to roles are not going to be removed",
+        "summary": "Delete roles",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "role_ids",
+            "description": "List of role IDs (separated by comma), use the keyword 'all' to select all roles",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Role ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles/:role_id/policies",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_policy",
+        "description": "Delete a specified relation role-policy",
+        "summary": "Remove policies from role",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":role_id",
+            "description": "Specify a role ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Role ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "policy_ids",
+            "description": "List of policy IDs (separated by comma), use the keyword 'all' to select all policies",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Policy ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/roles/:role_id/rules",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_rule",
+        "description": "Delete a specific role-rule relation",
+        "summary": "Remove security rules from role",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":role_id",
+            "description": "Specify a role ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "Role ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "rule_ids",
+            "description": "List of rule IDs (separated by comma), use the keyword 'all' to select all rules",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "numbers_delete",
+                "description": "Security rule ID|all"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/rules",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_rules",
+        "description": "Delete a list of security rules or all security rules in the system, roles linked to rules are not going to be deleted",
+        "summary": "Delete security rules",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "rule_ids",
+            "description": "List of rule IDs (separated by comma), use the keyword 'all' to select all rules",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "numbers_delete",
+                "description": "Security rule ID|all"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/user/authenticate",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.logout_user",
+        "description": "This method should be called to invalidate all the current user's tokens",
+        "summary": "Logout current user",
+        "tags": [
+          "Security"
+        ]
+      },
+      {
+        "name": "/security/users",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_users",
+        "description": "Delete a list of users by specifying their IDs",
+        "summary": "Delete users",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "user_ids",
+            "description": "List of user IDs (separated by comma), use the keyword 'all' to select all users",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "numbers_delete",
+                "description": "User ID|all"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/users/:user_id/roles",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_user_role",
+        "description": "Delete a specified relation user-roles",
+        "summary": "Remove roles from user",
+        "tags": [
+          "Security"
+        ],
+        "args": [
+          {
+            "name": ":user_id",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "numbers",
+              "description": "User ID"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "role_ids",
+            "description": "List of role IDs (separated by comma), use the keyword 'all' to select all roles",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Role ID|all",
+                "format": "numbers_delete"
+              }
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/syscheck/:agent_id",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.delete_syscheck_agent",
+        "description": "Clear file integrity monitoring scan results for a specified agent",
+        "summary": "Clear results",
+        "tags": [
+          "Syscheck"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/SplunkAppForWazuh/bin/api_info/security-actions.json
+++ b/SplunkAppForWazuh/bin/api_info/security-actions.json
@@ -1,0 +1,1042 @@
+{
+  "active-response:command": {
+    "description": "Execute active response commands in the agents",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "active-response:command"
+      ],
+      "resources": [
+        "agent:id:001",
+        "agent:group:atlantic"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /active-response"
+    ]
+  },
+  "agent:delete": {
+    "description": "Delete agents",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "agent:delete"
+      ],
+      "resources": [
+        "agent:id:010",
+        "agent:group:pacific"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "DELETE /agents"
+    ]
+  },
+  "agent:read": {
+    "description": "Access agents information (id, name, group, last keep alive, etc)",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "agent:read"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /agents",
+      "GET /agents/{agent_id}/config/{component}/{configuration}",
+      "GET /agents/{agent_id}/group/is_sync",
+      "GET /agents/{agent_id}/key",
+      "GET /groups/{group_id}/agents",
+      "GET /agents/no_group",
+      "GET /agents/outdated",
+      "GET /agents/stats/distinct",
+      "GET /agents/summary/os",
+      "GET /agents/summary/status",
+      "GET /overview/agents"
+    ]
+  },
+  "agent:create": {
+    "description": "Create new agents",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "agent:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "POST /agents",
+      "POST /agents/insert",
+      "POST /agents/insert/quick"
+    ]
+  },
+  "agent:modify_group": {
+    "description": "Change the group of agents",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "agent:modify_group"
+      ],
+      "resources": [
+        "agent:id:004",
+        "agent:group:us-east"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "DELETE /agents/{agent_id}/group",
+      "DELETE /agents/{agent_id}/group/{group_id}",
+      "PUT /agents/{agent_id}/group/{group_id}",
+      "DELETE /agents/group",
+      "PUT /agents/group",
+      "DELETE /groups"
+    ]
+  },
+  "group:modify_assignments": {
+    "description": "Change the agents assigned to the group",
+    "resources": [
+      "group:id"
+    ],
+    "example": {
+      "actions": [
+        "group:modify_assignments"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "DELETE /agents/{agent_id}/group",
+      "DELETE /agents/{agent_id}/group/{group_id}",
+      "PUT /agents/{agent_id}/group/{group_id}",
+      "DELETE /agents/group",
+      "PUT /agents/group",
+      "DELETE /groups"
+    ]
+  },
+  "agent:restart": {
+    "description": "Restart agents",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "agent:restart"
+      ],
+      "resources": [
+        "agent:id:050",
+        "agent:id:049"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "PUT /agents/{agent_id}/restart",
+      "PUT /agents/group/{group_id}/restart",
+      "PUT /agents/node/{node_id}/restart",
+      "PUT /agents/restart"
+    ]
+  },
+  "agent:upgrade": {
+    "description": "Upgrade the version of the agents",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "agent:upgrade"
+      ],
+      "resources": [
+        "agent:id:001",
+        "agent:group:mediterranean"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /agents/upgrade",
+      "PUT /agents/upgrade_custom",
+      "GET /agents/upgrade_result"
+    ]
+  },
+  "group:delete": {
+    "description": "Delete agent groups",
+    "resources": [
+      "group:id"
+    ],
+    "example": {
+      "actions": [
+        "group:delete"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "DELETE /groups"
+    ]
+  },
+  "group:read": {
+    "description": "Access agent groups information (id, name, agents, etc)",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "group:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /groups",
+      "GET /groups/{group_id}/agents",
+      "GET /groups/{group_id}/configuration",
+      "GET /groups/{group_id}/files",
+      "GET /groups/{group_id}/files/{file_name}/json",
+      "GET /groups/{group_id}/files/{file_name}/xml",
+      "GET /overview/agents"
+    ]
+  },
+  "group:create": {
+    "description": "Create new agent groups",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "group:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "POST /groups"
+    ]
+  },
+  "group:update_config": {
+    "description": "Change the configuration of agent groups",
+    "resources": [
+      "group:id"
+    ],
+    "example": {
+      "actions": [
+        "group:update_config"
+      ],
+      "resources": [
+        "group:id:*"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "PUT /groups/{group_id}/configuration"
+    ]
+  },
+  "cluster:read": {
+    "description": "Read Wazuh's cluster nodes configuration",
+    "resources": [
+      "node:id"
+    ],
+    "example": {
+      "actions": [
+        "cluster:read"
+      ],
+      "resources": [
+        "node:id:worker1",
+        "node:id:worker3"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "PUT /agents/node/{node_id}/restart",
+      "GET /cluster/local/info",
+      "GET /cluster/nodes",
+      "GET /cluster/healthcheck",
+      "GET /cluster/local/config",
+      "GET /cluster/{node_id}/status",
+      "GET /cluster/{node_id}/info",
+      "GET /cluster/{node_id}/configuration",
+      "GET /cluster/{node_id}/stats",
+      "GET /cluster/{node_id}/stats/hourly",
+      "GET /cluster/{node_id}/stats/weekly",
+      "GET /cluster/{node_id}/stats/analysisd",
+      "GET /cluster/{node_id}/stats/remoted",
+      "GET /cluster/{node_id}/logs",
+      "GET /cluster/{node_id}/logs/summary",
+      "PUT /cluster/restart",
+      "GET /cluster/configuration/validation",
+      "GET /cluster/{node_id}/configuration/{component}/{configuration}"
+    ]
+  },
+  "ciscat:read": {
+    "description": "Access CIS-CAT results for agents",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "ciscat:read"
+      ],
+      "resources": [
+        "agent:id:001",
+        "agent:id:003",
+        "agent:group:default"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "GET /ciscat/{agent_id}/results",
+      "GET /experimental/ciscat/results"
+    ]
+  },
+  "cluster:status": {
+    "description": "Check Wazuh's cluster general status",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "cluster:status"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /cluster/status"
+    ]
+  },
+  "cluster:read_api_config": {
+    "description": "Check Wazuh's cluster nodes API configuration",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "cluster:read_api_config"
+      ],
+      "resources": [
+        "node:id:worker1",
+        "node:id:worker3"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /cluster/api/config"
+    ]
+  },
+  "cluster:update_config": {
+    "description": "Change the Wazuh's cluster node configuration",
+    "resources": [
+      "node:id"
+    ],
+    "example": {
+      "actions": [
+        "cluster:update_config"
+      ],
+      "resources": [
+        "node:id:worker1"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /cluster/{node_id}/configuration"
+    ]
+  },
+  "cluster:restart": {
+    "description": "Restart Wazuh's cluster nodes",
+    "resources": [
+      "node:id"
+    ],
+    "example": {
+      "actions": [
+        "cluster:restart"
+      ],
+      "resources": [
+        "node:id:worker1"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /cluster/restart"
+    ]
+  },
+  "lists:read": {
+    "description": "Read cdb lists files",
+    "resources": [
+      "list:file"
+    ],
+    "example": {
+      "actions": [
+        "lists:read"
+      ],
+      "resources": [
+        "list:file:audit-keys"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "GET /lists",
+      "GET /lists/files/{filename}",
+      "GET /lists/files"
+    ]
+  },
+  "lists:update": {
+    "description": "Update or upload cdb lists files",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "lists:update"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /lists/files/{filename}"
+    ]
+  },
+  "lists:delete": {
+    "description": "Delete cdb lists files",
+    "resources": [
+      "list:file"
+    ],
+    "example": {
+      "actions": [
+        "lists:delete"
+      ],
+      "resources": [
+        "list:file:audit-keys"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "PUT /lists/files/{filename}",
+      "DELETE /lists/files/{filename}"
+    ]
+  },
+  "logtest:run": {
+    "description": "Run logtest tool or end a logtest session",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "logtest:run"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /logtest",
+      "DELETE /logtest/sessions/{token}"
+    ]
+  },
+  "manager:read": {
+    "description": "Read Wazuh manager configuration",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "manager:read"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /manager/status",
+      "GET /manager/info",
+      "GET /manager/configuration",
+      "GET /manager/stats",
+      "GET /manager/stats/hourly",
+      "GET /manager/stats/weekly",
+      "GET /manager/stats/analysisd",
+      "GET /manager/stats/remoted",
+      "GET /manager/logs",
+      "GET /manager/logs/summary",
+      "PUT /manager/restart",
+      "GET /manager/configuration/validation",
+      "GET /manager/configuration/{component}/{configuration}"
+    ]
+  },
+  "manager:update_config": {
+    "description": "Update current Wazuh manager configuration",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "manager:update_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /manager/configuration"
+    ]
+  },
+  "manager:read_api_config": {
+    "description": "Read Wazuh manager API configuration",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "manager:read_api_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /manager/api/config"
+    ]
+  },
+  "manager:restart": {
+    "description": "Restart Wazuh managers",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "manager:restart"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "PUT /manager/restart"
+    ]
+  },
+  "mitre:read": {
+    "description": "Access attacks information from MITRE database",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "mitre:read"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /mitre"
+    ]
+  },
+  "rootcheck:clear": {
+    "description": "Clear the agents rootcheck database",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "rootcheck:clear"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "DELETE /rootcheck"
+    ]
+  },
+  "rootcheck:run": {
+    "description": "Run agents rootcheck scan",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "rootcheck:run"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /rootcheck"
+    ]
+  },
+  "rootcheck:read": {
+    "description": "Access information from agents rootcheck database",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "rootcheck:read"
+      ],
+      "resources": [
+        "agent:id:011"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /rootcheck/{agent_id}",
+      "GET /rootcheck/{agent_id}/last_scan"
+    ]
+  },
+  "rules:read": {
+    "description": "Read rules files",
+    "resources": [
+      "rule:file"
+    ],
+    "example": {
+      "actions": [
+        "rules:read"
+      ],
+      "resources": [
+        "rule:file:0610-win-ms_logs_rules.xml"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /rules",
+      "GET /rules/groups",
+      "GET /rules/requirement/{requirement}",
+      "GET /rules/files",
+      "GET /rules/files/{filename}"
+    ]
+  },
+  "rules:update": {
+    "description": "Update or upload custom rule files",
+    "resources": [
+      "rule:file"
+    ],
+    "example": {
+      "actions": [
+        "rules:update"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /rules/files/{filename}"
+    ]
+  },
+  "rules:delete": {
+    "description": "Delete custom rule files",
+    "resources": [
+      "rule:file"
+    ],
+    "example": {
+      "actions": [
+        "rules:delete"
+      ],
+      "resources": [
+        "rule:file:0610-win-ms_logs_rules.xml"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /rules/files/{filename}",
+      "DELETE /rules/files/{filename}"
+    ]
+  },
+  "sca:read": {
+    "description": "Access agents security configuration assessment",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "sca:read"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /sca/{agent_id}",
+      "GET /sca/{agent_id}/checks/{policy_id}"
+    ]
+  },
+  "syscheck:run": {
+    "description": "Run agents syscheck scan",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "syscheck:run"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /syscheck"
+    ]
+  },
+  "syscheck:read": {
+    "description": "Access information from agents syscheck database",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "syscheck:read"
+      ],
+      "resources": [
+        "agent:id:011",
+        "agent:group:us-west"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /syscheck/{agent_id}",
+      "GET /syscheck/{agent_id}/last_scan"
+    ]
+  },
+  "syscheck:clear": {
+    "description": "Clear the agents syscheck database",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "syscheck:clear"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "DELETE /syscheck/{agent_id}",
+      "DELETE /experimental/syscheck"
+    ]
+  },
+  "decoders:read": {
+    "description": "Read decoders files",
+    "resources": [
+      "decoder:file"
+    ],
+    "example": {
+      "actions": [
+        "decoders:read"
+      ],
+      "resources": [
+        "decoder:file:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /decoders",
+      "GET /decoders/files",
+      "GET /decoders/files/{filename}",
+      "GET /decoders/parents"
+    ]
+  },
+  "decoders:update": {
+    "description": "Update or upload custom decoder files",
+    "resources": [
+      "decoder:file"
+    ],
+    "example": {
+      "actions": [
+        "decoders:update"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /decoders/files/{filename}"
+    ]
+  },
+  "decoders:delete": {
+    "description": "Delete custom decoder files",
+    "resources": [
+      "decoder:file"
+    ],
+    "example": {
+      "actions": [
+        "decoders:delete"
+      ],
+      "resources": [
+        "decoder:file:local_decoder.xml"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /decoders/files/{filename}",
+      "DELETE /decoders/files/{filename}"
+    ]
+  },
+  "syscollector:read": {
+    "description": "Access agents syscollector information",
+    "resources": [
+      "agent:id",
+      "agent:group"
+    ],
+    "example": {
+      "actions": [
+        "syscollector:read"
+      ],
+      "resources": [
+        "agent:id:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /experimental/syscollector/hardware",
+      "GET /experimental/syscollector/netaddr",
+      "GET /experimental/syscollector/netiface",
+      "GET /experimental/syscollector/netproto",
+      "GET /experimental/syscollector/os",
+      "GET /experimental/syscollector/packages",
+      "GET /experimental/syscollector/ports",
+      "GET /experimental/syscollector/processes",
+      "GET /experimental/syscollector/hotfixes",
+      "GET /syscollector/{agent_id}/hardware",
+      "GET /syscollector/{agent_id}/hotfixes",
+      "GET /syscollector/{agent_id}/netaddr",
+      "GET /syscollector/{agent_id}/netiface",
+      "GET /syscollector/{agent_id}/netproto",
+      "GET /syscollector/{agent_id}/os",
+      "GET /syscollector/{agent_id}/packages",
+      "GET /syscollector/{agent_id}/ports",
+      "GET /syscollector/{agent_id}/processes"
+    ]
+  },
+  "security:read": {
+    "description": "Access information about system security resources",
+    "resources": [
+      "policy:id",
+      "role:id",
+      "user:id",
+      "rule:id"
+    ],
+    "example": {
+      "actions": [
+        "security:read"
+      ],
+      "resources": [
+        "policy:id:*",
+        "role:id:2",
+        "user:id:5",
+        "rule:id:3"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /security/users",
+      "GET /security/roles",
+      "GET /security/rules",
+      "GET /security/policies"
+    ]
+  },
+  "security:create_user": {
+    "description": "Create new system users",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "security:create_user"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "POST /security/users"
+    ]
+  },
+  "security:delete": {
+    "description": "Delete system security resources",
+    "resources": [
+      "policy:id",
+      "role:id",
+      "user:id",
+      "rule:id"
+    ],
+    "example": {
+      "actions": [
+        "security:update"
+      ],
+      "resources": [
+        "policy:id:*",
+        "role:id:3",
+        "user:id:4",
+        "rule:id:2"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "DELETE /security/users",
+      "DELETE /security/roles",
+      "DELETE /security/rules",
+      "DELETE /security/policies",
+      "DELETE /security/users/{user_id}/roles",
+      "DELETE /security/roles/{role_id}/policies",
+      "DELETE /security/roles/{role_id}/rules"
+    ]
+  },
+  "security:update": {
+    "description": "Update the information of system security resources",
+    "resources": [
+      "policy:id",
+      "role:id",
+      "user:id",
+      "rule:id"
+    ],
+    "example": {
+      "actions": [
+        "security:update"
+      ],
+      "resources": [
+        "policy:id:*",
+        "role:id:4",
+        "user:id:3",
+        "rule:id:4"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "PUT /security/users/{user_id}",
+      "PUT /security/roles/{role_id}",
+      "PUT /security/rules/{rule_id}",
+      "PUT /security/policies/{policy_id}",
+      "POST /security/users/{user_id}/roles",
+      "POST /security/roles/{role_id}/policies",
+      "POST /security/roles/{role_id}/rules"
+    ]
+  },
+  "security:create": {
+    "description": "Create new system security resources",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "security:create"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "POST /security/roles",
+      "POST /security/rules",
+      "POST /security/policies"
+    ]
+  },
+  "security:read_config": {
+    "description": "Read current system security configuration",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "security:read_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "GET /security/config"
+    ]
+  },
+  "security:update_config": {
+    "description": "Update current system security configuration",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "security:update_config"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "allow"
+    },
+    "related_endpoints": [
+      "PUT /security/config",
+      "DELETE /security/config"
+    ]
+  },
+  "task:status": {
+    "description": "Access task's status information",
+    "resources": [
+      "*:*"
+    ],
+    "example": {
+      "actions": [
+        "task:status"
+      ],
+      "resources": [
+        "*:*:*"
+      ],
+      "effect": "deny"
+    },
+    "related_endpoints": [
+      "GET /tasks/status"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "pretty": "prettier --single-quote --semi=false --write SplunkAppForWazuh/**/*.js !SplunkAppForWazuh/appserver/static/js/libs/** !SplunkAppForWazuh/appserver/static/js/utils/codemirror/**",
     "lint": "eslint . --ext .js -c .eslintrc.json",
-    "test": "mocha tests/manager.js"
+    "test": "mocha tests/manager.js",
+    "generate:api-info": "cd scripts/generate-api-info;./generate-api-info.sh;cd ../.."
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-api-info/generate-api-info.js
+++ b/scripts/generate-api-info/generate-api-info.js
@@ -1,0 +1,291 @@
+/*
+  Description: this script generates a file with the extrated data of Wazuh API 4.0, formatted to use in Wazuh app.
+
+  Requirements:
+    - Wazuh manager 4.0 up
+
+  Use: node generate-api-4.0-info.js WAZUH_API_URL [-f filename]
+
+  The generated files will be saved in OUTPUT_ENDPOINTS_PATH.
+
+  Note: if new endpoints are created or are not defined in documentation file, add them with their links.
+        The documentation file is a dependency of this script to get the documentation links.
+*/
+
+// Import required packages
+const fs = require('fs');
+const path = require('path');
+
+// Constants
+const WAZUH_API_URL = process.argv[2]; // Wazuh API url is a required argument
+// Get console input as string
+const consoleInput = [...process.argv].slice(2).join(' ');
+// Regular expressions
+const reFilename = /-f ([\S]+)/;
+const reEndpointPathArgs = /\{([^}]+)\}/g; // Regular expresion to get the endpoint path arguments
+const reFormatter = /--full/
+
+const OUTPUT_MODE_FULL = consoleInput.match(reFormatter) && true;
+const WAZUH_DOCUMENTATION_API_REFERENCE_URL = 'https://documentation.wazuh.com/current/user-manual/api/reference.html'
+const OUTPUT_ENDPOINTS_FILENAME = `${(consoleInput.match(reFilename) || [])[1] || 'endpoints'}.json`;
+const OUTPUT_SECURITY_ACTIONS_FILENAME = 'security-actions.json';
+const OUTPUT_DIRECTORY = path.join(__dirname, 'output');
+
+// Define console color codes
+const CONSOLE_COLORS_CODES = {
+  BLACK: 30,
+  RED: 31,
+  GREEN: 32,
+  YELLOW: 33,
+  BLUE: 34,
+  MAGENTA: 35,
+  CYAN: 36,
+  WHITE: 37
+};
+
+// Main method
+const main = () => {
+  // Check Wazuh API url argument is defined
+  if(!WAZUH_API_URL){
+    exitWithMessage('Wazuh API url is not defined.');
+  };
+  // Check Wazuh API url argument is valid
+  if(!WAZUH_API_URL.startsWith('http') ){
+    exitWithMessage(`Wazuh API url is not valid. It should start with "http". Example: https://172.16.1.2:55000`);
+  };
+  
+  // Log the configuration:
+  console.log('--------------- Configuration ---------------');
+  console.log(`Wazuh API url: ${WAZUH_API_URL}`);
+  console.log(`Output directory: ${OUTPUT_DIRECTORY}`);
+  console.log(`Output endpoints mode: ${OUTPUT_MODE_FULL ? 'Full': 'Simple'}`);
+  console.log('----------------------------------------------')
+
+  if (!fs.existsSync(OUTPUT_DIRECTORY)){
+    fs.mkdirSync(OUTPUT_DIRECTORY);
+    logger.info(`Created ${OUTPUT_DIRECTORY} directory`);
+  };
+
+  generateAPIEndpointsInformation();
+  generateAPISecurityActionsInformation();
+}
+
+// Genearate API endpoints information
+const generateAPIEndpointsInformation = async () => {
+  try{
+    // Request to API swagger.json file
+    const apiData = await request(`${WAZUH_API_URL}/openapi.json`);
+    // Parse response to JSON
+    const jsonData = JSON.parse(apiData);
+    // Extract the endpoints, mapped as { [httpMethod: ('GET' | 'PUT' | 'POST' | 'DELETE' | 'HEAD')]: endpoint[]}
+    const extractedEndpoints = Object.keys(jsonData.paths).reduce((accum, endpointPath) => {
+      const endpointData = jsonData.paths[endpointPath];
+      Object.keys(endpointData).forEach(httpMethod => {
+        const httpMethodUppercase = httpMethod.toUpperCase();
+        accum[httpMethodUppercase] = [...accum[httpMethodUppercase], formatEndpoint({...endpointData[httpMethod], path: endpointPath, method: httpMethodUppercase}, jsonData)]
+      });
+      return accum;
+    }, ['GET', 'PUT', 'POST', 'DELETE'].reduce((accum, httpMethod) => ({...accum, [httpMethod]: []}), {}));
+    // Map extracted endpoints to <{ method: ('GET' | 'PUT' | 'POST' | 'DELETE' | 'HEAD'), endpoints: endpoint[]}>[]
+    const resultEndpoints = Object.keys(extractedEndpoints).map(httpMethod => ({method: httpMethod, endpoints: extractedEndpoints[httpMethod].sort(sortAlphabeticalByNameProp)}));
+
+    // Save the formatted endpoints data to a file
+    saveFileToOutputDir(OUTPUT_ENDPOINTS_FILENAME, JSON.stringify(resultEndpoints, null, 2));
+  }catch(error){
+    logger.error('An error appeared:', error);
+  };
+
+}
+
+// Generates security actions information
+const generateAPISecurityActionsInformation = async () => {
+  // Check Wazuh API url argument is defined
+  if(!WAZUH_API_URL){
+    exitWithMessage('Wazuh API url is not defined.');
+  };
+  // Check Wazuh API url argument is valid
+  if(!WAZUH_API_URL.startsWith('http') ){
+    exitWithMessage(`Wazuh API url is not valid. It should start with "http". Example: https://172.16.1.2:55000`);
+  };
+  const username = 'wazuh';
+  const password = 'wazuh';
+  try{
+    const authenticationResponse = await request(`${WAZUH_API_URL}/security/user/authenticate`, {
+      headers: {
+        'Authorization': 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
+      }
+    });
+    // console.log(authenticationResponse, typeof authenticationResponse, JSON.parse(authenticationResponse), JSON.parse(authenticationResponse).data.token)
+    const { token } = JSON.parse(authenticationResponse).data;
+    const securityActionsResponse = await request(`${WAZUH_API_URL}/security/actions`, {
+      headers: {
+        'Authorization': `Bearer ${token}` 
+      }
+    });
+    const securityActions = JSON.parse(securityActionsResponse).data;
+    // Save the formatted endpoints data to a file
+    saveFileToOutputDir(OUTPUT_SECURITY_ACTIONS_FILENAME, JSON.stringify(securityActions, null, 2));
+  }catch(error){
+    logger.error('An error appeared:', error);
+  }
+}
+
+// Utilities
+const request = (apiEndpoint, options = {}) => {
+  let requestPackage;
+  if(apiEndpoint.startsWith('http:')){
+    requestPackage = require('http');
+  }else if(apiEndpoint.startsWith('https:')){
+    requestPackage = require('https');
+  }else{
+    exitWithMessage('Endpoint should start with "http" or "https"');
+  };
+  return new Promise((resolve, reject) => {
+    requestPackage.get(apiEndpoint, {rejectUnauthorized: false, ...options}, (response) => {
+      let data = '';
+
+      // A chunk of data has been recieved
+      response.on('data', chunk => {
+        data += chunk;
+      });
+
+      // The whole response has been received. Print out the result
+      response.on('end', () => {
+        resolve(data);
+      });
+
+      // Manage the error
+      response.on("error", (error) => {
+        reject(error);
+      });
+    })
+  })
+}
+// Formatters
+// Format the endpoint to use in the Wazuh app
+const formatEndpoint = (endpointData, jsonData) => {
+  const formattedParameters = endpointData.parameters && endpointData.parameters
+    .filter(parameter => parameter.$ref)
+    .map(parameter => getNestedObject(jsonData, parameter.$ref.split('/').splice(1)))
+    .map((parameter) => extendParamReference(parameter, jsonData))
+  || [];
+  const endpointPathParams = formattedParameters.filter(parameter => parameter.in === 'path');
+  const endpointQueryParams = formattedParameters.filter(parameter => parameter.in === 'query');
+  const endpointBodyParams = (
+    endpointData.requestBody
+      && endpointData.requestBody.content
+      && endpointData.requestBody.content['application/json']
+      && endpointData.requestBody.content['application/json'].schema
+      && ((endpointData.requestBody.content['application/json'].schema.properties
+          && Object.keys(endpointData.requestBody.content['application/json'].schema.properties)
+            .map(bodyParamKey => ({name: bodyParamKey, ...endpointData.requestBody.content['application/json'].schema.properties[bodyParamKey]}))
+            .map((parameter) => extendParamReference(parameter, jsonData))
+        ) || (endpointData.requestBody.content['application/json'].schema
+          && Object.keys(endpointData.requestBody.content['application/json'].schema)
+            .map(bodyParamKey => ({name: bodyParamKey, ...endpointData.requestBody.content['application/json'].schema}))
+            .map((parameter) => extendParamReference(parameter, jsonData))
+        )
+    )) || [];
+  const endpointPath = formatEndpointPath(endpointData.path);
+  const endpointDocumentation = generateEndpointDocumentationLink(endpointData);
+  const endpointSummary = endpointData.summary || '';
+  const endpointDescription = endpointData.description || '';
+  const endpointTags = endpointData.tags || [];
+  return {
+      name: endpointPath,
+      documentation: endpointDocumentation,
+      ...(OUTPUT_MODE_FULL ? {description: endpointDescription} : {}),
+      ...(OUTPUT_MODE_FULL ? {summary: endpointSummary} : {}),
+      ...(OUTPUT_MODE_FULL ? {tags: endpointTags} : {}),
+      ...(endpointPathParams.length ? {args: endpointPathParams.map(formatterEndpointParams).sort(sortAlphabeticalByNameProp).map(item => ({...item, name: `:${item.name}`}))} : {}),
+      ...(endpointQueryParams.length ? {query: endpointQueryParams.map(formatterEndpointParams).sort(sortAlphabeticalByNameProp)} : {}),
+      ...(endpointBodyParams.length ? {body: endpointBodyParams.map(formatterEndpointParams).sort(sortAlphabeticalByNameProp)} : {})
+  };
+};
+
+const formatEndpointSimpleParams = ({name}) => ({name});
+const formatEndpointFullParams = ({ in: typeParam, ...endpointData}) => endpointData;
+const formatterEndpointParams = OUTPUT_MODE_FULL ? formatEndpointFullParams : formatEndpointSimpleParams;
+const formatEndpointPath = endpointPath => endpointPath.replace(reEndpointPathArgs, (capture, group) => {
+  return `:${group}`
+});
+
+// Sort by alphabetical
+const sortAlphabetical = (a, b) => {
+  if(a > b){
+    return 1
+  }else if(a < b){
+    return -1
+  };
+  return 0
+};
+
+// Sort by alphabetical name property
+const sortAlphabeticalByNameProp = (a, b) => sortAlphabetical(a.name, b.name);
+
+// Get the endpoint arguments. Example: `/agents/{agent_id}` => args: agent_id
+const getEndpointPathArgs = endpointPath => {
+  let myArray;
+  let tokens = [];
+  while (capture = reEndpointPathArgs.exec(endpointPath)) {
+    tokens.push(capture[1]);
+  };
+  return tokens;
+};
+
+// Extend the parameter with the reference data
+const extendParamReference = (parameter, jsonData) => {
+  if (parameter.$ref){
+    return { ...(parameter.name && parameter.name !== '$ref'? {name: parameter.name} : {}),...getNestedObject(jsonData, parameter.$ref.split('/').splice(1)) }
+  }else if(parameter.schema && parameter.schema.$ref){
+    return { ...parameter, schema: {...getNestedObject(jsonData, parameter.schema.$ref.split('/').splice(1))}};
+  }else if(parameter.schema && parameter.schema.items && parameter.schema.items.$ref){
+    return { ...parameter, schema: {...parameter.schema, items: { ...getNestedObject(jsonData, parameter.schema.items.$ref.split('/').splice(1)) }}};
+  }else{
+    return parameter;
+  };
+};
+
+// Get the nested object defined with a ordered arrays of keys
+const getNestedObject = (obj, keys) => {
+    if(!keys.length){
+        return obj;
+    };
+    const key = keys.shift();
+    return getNestedObject(obj[key], keys);
+}
+
+// Create a function to log with a [TAG] ...messages
+const createLog = (tag, consoleColorCode) => (...args) => console.log(`\x1b[${consoleColorCode}m[${tag}]\x1b[0m`, ...args);
+
+// Create the script logger
+const logger = {
+  info: createLog('INFO', CONSOLE_COLORS_CODES.BLUE),
+  success: createLog('SUCCESS', CONSOLE_COLORS_CODES.GREEN),
+  warning: createLog('WARNING', CONSOLE_COLORS_CODES.YELLOW),
+  danger: createLog('DANGER', CONSOLE_COLORS_CODES.RED),
+  error: createLog('ERROR', CONSOLE_COLORS_CODES.RED),
+};
+
+// Log a message and end script
+const exitWithMessage = message => {
+  logger.error(message);
+  process.exit(1);
+};
+
+// Generate the endpoint documentation link
+const generateEndpointDocumentationLink = endpointData => `${WAZUH_DOCUMENTATION_API_REFERENCE_URL}#operation/${endpointData.operationId}`;
+
+// Save file
+const saveFileToOutputDir = (filename, content) => {
+  const filePath = path.join(OUTPUT_DIRECTORY, filename);
+  fs.writeFile(filePath, content, function (error, data) {
+    if (error) {
+      return logger.error(`An error appeared saving the output file "${filePath}":`, error);
+    }
+    logger.success(`File was created! Path: ${filePath}`);
+  });
+};
+
+// Run the method
+main();

--- a/scripts/generate-api-info/generate-api-info.sh
+++ b/scripts/generate-api-info/generate-api-info.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Define the main function
+main(){
+  if [ -z ${WAZUH_API_URL+x} ]; then
+cat <<EOF
+ERROR: WAZUH_API_URL variable is not defined.
+If you are using npm script to launch it, use:
+  WAZUH_API_URL="WAZUH_API_URL" npm run <script_name>
+  Example: WAZUH_API_URL="https://172.16.1.2:55000" npm run <script_name>
+EOF
+    exit 1
+  fi
+  echo "Generate Wazuh API 4.0 endpoints data and format to use in Wazuh app";
+  local API_TMP_OUTPUT_PATH="output";
+  local API_OUTPUT_PATH="../../SplunkAppForWazuh/bin/api_info";
+
+  node generate-api-info.js $WAZUH_API_URL --full || exit_with_message "ERROR: the script had an error";
+  echo "Moving files to $API_OUTPUT_PATH";
+  mv "$API_TMP_OUTPUT_PATH"/* "$API_OUTPUT_PATH" || exit_with_message "ERROR: moving the generated files";
+  echo "Removing temporal directory $API_TMP_OUTPUT_PATH";
+  rm -rf $API_TMP_OUTPUT_PATH || exit_with_message "ERROR: removing the temporal directory";
+  echo "Success generating Wazuh API 4.0 API info!";
+}
+
+# Function to exit with a message
+exit_with_message(){
+  echo $1
+  exit 1
+}
+
+# Run main function
+main


### PR DESCRIPTION
### Description
Hi team, this PR resolves:
- Add an npm script to generate the API information (endpoints, security-actions).
- Update endpoints information to Wazuh API 4.1.3.
- Add `security-actions.json` file.

How to use:

`WAZUH_API_URL="https://WAZUH_API_IP:WAZUH_API_PORT" npm run generate:api-info`

### Checks
- Check the script works, generates the `.json` files, and moves them to the correct location path.
- Check the suggestions in Dev Tools are working.