### PR TITLE
Fix the view of regex field in Decoder detail

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders-id.html
@@ -93,7 +93,7 @@
               ng-if="!isArray(value)">
               <span flex="20">{{key}}</span>
               <span class="wz-text-right color-grey" ng-if="key !== 'regex' && key !== 'order'">{{value}}</span>
-              <span class="wz-text-right color-grey" ng-if="key == 'regex'" ng-bind-html="colorRegex(value)"></span>
+              <span class="wz-text-right color-grey" ng-if="key == 'regex'" ng-bind-html="colorRegex(value.pattern || value)"></span>
               <span class="wz-text-right color-grey" ng-if="key == 'order'" ng-bind-html="colorOrder(value)"></span>
 
             </div>


### PR DESCRIPTION
### Description

Hi team, this PR, resolves:
- Enhance how the `regex` field of a Decoder is rendered due to API response change

### Screenshot
![image](https://user-images.githubusercontent.com/34042064/112957331-9eea7780-9141-11eb-8d27-5216290e52da.png)

### Checks
- Go to Decoder detail and see the `regex` field is rendered as a colored regex and not as an stringified object `{pattern, offset}`