### PR TITLE
escaped back slash in File parameter request

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table-directive.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table-directive.js
@@ -671,7 +671,7 @@ define([
                 <wazuh-table
                   flex
                   path="'/syscheck/${$scope.agentId}'"
-                  implicit-filter="[{name:'type',value:'registry_value'},{name:'file',value:'${item.file}'}]"
+                  implicit-filter="[{name:'type',value:'registry_value'},{name:'file',value:'${item.file.replaceAll('\\','\\\\')}'}]"
                   row-sizes="[6,6,6]"
                   extra-limit="true"
                   keys="['date','value.name','value.type','sha1']"


### PR DESCRIPTION
Hi team,

this fixes the `file` filter value sent in the agent `registry_values` table request