### PR TITLE
Fix blocked app when there isn't connection with the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v4.2.0 - Splunk Enterprise v8.1.2 - Revision 4201
+
+### Fixed
+
+- Fixed blocked app when there isn't connection with the API [#1045](https://github.com/wazuh/wazuh-splunk/pull/1045)
+
 ## Wazuh v4.1.4 - Splunk Enterprise v8.1.2 - Revision 68
 
 ### Added

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -406,7 +406,7 @@ class manager(controllers.BaseController):
             result = jsonbak.dumps(output)             
         except Exception as e:
             self.logger.error("Error when checking API connection: %s" % (e))
-            raise e
+            return jsonbak.dumps({"status": "500", "error": "Error when checking API connection: %s" % (e)})
         return result
     
     def get_cluster_info(self, opt_username, opt_password, opt_base_url, opt_base_port, opt_cluster):

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/main/settingsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/main/settingsCtrl.js
@@ -37,6 +37,11 @@ define(['../../module'], function(controllers) {
         this.scope.loadingContent = data.status
         event.preventDefault()
       })
+
+      this.scope.$on('changeSettingsTab', (event, data) => {
+        this.scope.tabName = data.tabName
+        event.preventDefault()
+      })
     }
   }
   controllers.controller('settingsCtrl', Main)

--- a/SplunkAppForWazuh/appserver/static/js/run/run.js
+++ b/SplunkAppForWazuh/appserver/static/js/run/run.js
@@ -68,6 +68,7 @@ define(['./module'], function(module) {
               $notificationService.showErrorToast(err)
             }
             $state.go('settings.api')
+            $rootScope.$broadcast('changeSettingsTab', { tabName: 'api' })
           }
         }
       }
@@ -142,9 +143,15 @@ define(['./module'], function(module) {
         } else if (to.startsWith('settings')) {
           $rootScope.$broadcast('stateChanged', 'settings')
         }
+        // This selects "api" tab when there some state transition error.
+        // It solves that another setting tab could appear as selected when show the view of "api" tab.
+        if (to === 'settings.api') {
+          $rootScope.$broadcast('changeSettingsTab', { tabName: 'api' })
+        }
       })
 
       $transitions.onError({}, async trans => {
+        $rootScope.$broadcast('loadingMain', { status: false })
         const err = trans.error()
         if (
           trans.to().name != 'settings.api' &&


### PR DESCRIPTION
### Description

Hi team, this PR resolves:
- Fix blocked app when there is not a connection with the Wazuh API. Finish the loading status.

Closes #1002

### Checks

- Down the Wazuh API and try to go to sections as `Overview`, `Management`, `Agents`, `Dev Tools`. It should redirect to `Settings > API`
- From some `Settings > API` try to go to another `Settings` section like:
  - `Index`: it should display it
  - `Configuration`: it should not display it and redirect to `Settings > API`
  - `Logs`: it should display it
  - `About`: it should display it