### PR TITLE
fix message when add api fails

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -360,7 +360,7 @@ class manager(controllers.BaseController):
                 self.check_wazuh_version(kwargs)
             except Exception as ex:
                 self.logger.error("%s" % (ex))
-                error = {"status": 400, "error": str(ex), "message": "Cannot connect to the API"}
+                error = {"status": 400, "error": "Cannot connect to the API"}
                 return jsonbak.dumps(error)
             daemons_ready = self.check_daemons(url, auth, verify, opt_cluster, kwargs)
             # Pass the cluster status instead of always False

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -358,8 +358,9 @@ class manager(controllers.BaseController):
             verify = False
             try:
                 self.check_wazuh_version(kwargs)
-            except Exception as e:
-                error = {"status": 400, "error": str(e), "message": "Cannot connect to the API"}
+            except Exception as ex:
+                self.logger.error("%s" % (ex))
+                error = {"status": 400, "error": str(ex), "message": "Cannot connect to the API"}
                 return jsonbak.dumps(error)
             daemons_ready = self.check_daemons(url, auth, verify, opt_cluster, kwargs)
             # Pass the cluster status instead of always False
@@ -474,9 +475,9 @@ class manager(controllers.BaseController):
             app_version = str(a_split[0]+"."+a_split[1])
             if wazuh_version != app_version:
                 raise Exception("Unexpected Wazuh version. App version: %s, Wazuh version: %s" % (app_version, wazuh_version))
-        except Exception as e:
-            self.logger.error("Error when checking Wazuh version: %s" % (e))
-            raise e
+        except Exception as ex:
+            self.logger.error("Error when checking Wazuh version: %s" % (ex))
+            raise ex
             
     def check_daemons(self, url, auth, verify, check_cluster,kwargs):
         """ Request to check the status of this daemons: execd, modulesd, wazuhdb and clusterd

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -359,7 +359,7 @@ class manager(controllers.BaseController):
             try:
                 self.check_wazuh_version(kwargs)
             except Exception as e:
-                error = {"status": 400, "error": str(e)}
+                error = {"status": 400, "error": str(e), "message": "Cannot connect to the API"}
                 return jsonbak.dumps(error)
             daemons_ready = self.check_daemons(url, auth, verify, opt_cluster, kwargs)
             # Pass the cluster status instead of always False

--- a/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
@@ -229,7 +229,7 @@ define(['../module'], function(module) {
             if (result.data.error === 3099) {
               throw 'ERROR3099 - Wazuh not ready yet.'
             } else {
-              throw result.data.message || 'Unreachable API.'
+              throw result.data.error || 'Unreachable API.'
             }
           }
           return result

--- a/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/api-manager/apiMgrService.js
@@ -229,7 +229,7 @@ define(['../module'], function(module) {
             if (result.data.error === 3099) {
               throw 'ERROR3099 - Wazuh not ready yet.'
             } else {
-              throw result.data.error || 'Unreachable API.'
+              throw result.data.message || 'Unreachable API.'
             }
           }
           return result

--- a/SplunkAppForWazuh/bin/wazuhtoken.py
+++ b/SplunkAppForWazuh/bin/wazuhtoken.py
@@ -49,4 +49,6 @@ class wazuhtoken():
                 return self.cache.get('token')
         except Exception as e:
             self.logger.error("Error when get auth Wazuh token: %s" % (e))
+            error = {"status": 500, "error": "Error when get auth Wazuh token: "+str(e)}
+            return jsonbak.dumps(error)
         raise e


### PR DESCRIPTION
Hi team, this resolves:

- Uncontrolled message when api connection fails.

Before: 

![image](https://user-images.githubusercontent.com/36004787/114734203-64c0ce80-9d1a-11eb-9345-9b3b89a7fb6c.png)

Now:

![Captura de pantalla de 2021-04-14 12-02-58](https://user-images.githubusercontent.com/36004787/114733592-dd735b00-9d19-11eb-8267-805b1435c4eb.png)
