### PR TITLE
Cannot pin search filters on Edge - Chip style collapses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v4.2.0 - Splunk Enterprise v8.1.2 - Revision 4202
+
+### Fixed
+
+- Cannot pin search filters on Edge - Chip style collapses [#1070](https://github.com/wazuh/wazuh-splunk/pull/1070)
+
 ## Wazuh v4.2.0 - Splunk Enterprise v8.1.2 - Revision 4201
 
 ### Added

--- a/SplunkAppForWazuh/appserver/static/css/styles/component.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/component.css
@@ -120,6 +120,10 @@ md-chip {
   margin: 0 8px 0 0 !important;
 }
 
+md-chip-template.wz-chip[ng-mouseover="editChip($chip)"]{
+  display: block;
+}
+
 .euiFlexGroup {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-bar/wz-bar.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-bar/wz-bar.js
@@ -102,10 +102,11 @@ define(['../module'], function(directives) {
          * Change chip showing pin and trash icons
          * @param {Object | String} chip
          */
-        $scope.editChip = chip => {
+         $scope.editChip = chip => {
           const chipIsStatic = filterStatic(chip)
           if (!chipIsStatic) {
             $scope.editingChip = chip
+            if($scope.finishChipTimer) clearTimeout($scope.finishChipTimer);
           }
         }
 
@@ -114,7 +115,11 @@ define(['../module'], function(directives) {
          * @param {Object | String} chip
          */
         $scope.finishChipEdition = () => {
-          $scope.editingChip = false
+          $scope.finishChipTimer = setTimeout(function(){
+            $scope.editingChip = false;
+            clearTimeout($scope.finishChipTimer);
+            $scope.$applyAsync()
+          },500)
         }
 
         /**


### PR DESCRIPTION
Hi team,

this improves `mouseover` and `mouseleave` handlers to pin search filters chips.

Closes #1047 

![Peek 2021-04-14 16-53](https://user-images.githubusercontent.com/9343732/114733692-f54adf00-9d19-11eb-8f6b-b72b3f0f9faf.gif)
