### PR TITLE
Wazuh server side pagination table directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v4.2.0 - Splunk Enterprise v8.1.2 - Revision 4202
+
+### Fixed
+
+- Tables without server side pagination [#1074](https://github.com/wazuh/wazuh-splunk/pull/1074)
+
 ## Wazuh v4.2.0 - Splunk Enterprise v8.1.2 - Revision 4201
 
 ### Added

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
@@ -119,10 +119,10 @@
       <a class="cursor-pointer green-href" ng-click="addNewAgent()">Add new agent</a>
     </md-card-actions>
     <md-card-contents>
-      <wazuh-table flex path="'/agents'" custom-columns="true"
+      <wazuh-table-server-side flex path="'/agents'" custom-columns="true"
         keys="['id',{value:'name',size:2},'ip','status','group','os.name','os.version','version', {value: 'dateAdd', offset: true}, {value: 'lastKeepAlive', offset: true}]"
         allow-click="true" rows-per-page="17">
-      </wazuh-table>
+      </wazuh-table-server-side>
     </md-card-contents>
 
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
@@ -195,9 +195,9 @@
                 </button>
               </div>
               <div layout="row" ng-if="agent" class="wz-margin-top-10 wz-margin-bottom-40-inv">
-                <wazuh-table is-registry-value="true" agent-id="agent.id" flex path="'/syscheck/' + agent.id" implicit-filter="[{name:'type',value:'registry_key'}]"
+                <wazuh-table-server-side is-registry-value="true" agent-id="agent.id" flex path="'/syscheck/' + agent.id" implicit-filter="[{name:'type',value:'registry_key'}]"
                   row-sizes="[6,6,6]" extra-limit="true" keys="['file','sha1','md5']">
-                </wazuh-table>
+                </wazuh-table-server-side>
                 </div>
               <div layout="row" class="ruleset-csv-formater" style="margin:-20px; padding:15px;">
                 <span flex></span>
@@ -228,10 +228,10 @@
                 </button>
               </div>
               <div layout="row" ng-if="agent" class="wz-margin-top-10 wz-margin-bottom-40-inv">
-                <wazuh-table flex path="'/syscheck/' + agent.id" implicit-filter="[{name:'type',value:'file'}]"
+                <wazuh-table-server-side flex path="'/syscheck/' + agent.id" implicit-filter="[{name:'type',value:'file'}]"
                   row-sizes="[6,6,6]" extra-limit="true"
                   keys="['file', 'size', 'uname', 'perm','sha256','uid','mtime']">
-                </wazuh-table>
+                </wazuh-table-server-side>
               </div>
               <div layout="row" class="ruleset-csv-formater" style="margin:-20px; padding:15px;">
                 <span flex></span>
@@ -261,9 +261,9 @@
                 </button>
               </div>
               <div layout="row" ng-if="agent" class="wz-margin-top-10 wz-margin-bottom-40-inv">
-                <wazuh-table custom-columns="true" flex path="'/syscheck/' + agent.id" row-sizes="[12,10,8]"
+                <wazuh-table-server-side custom-columns="true" flex path="'/syscheck/' + agent.id" row-sizes="[12,10,8]"
                   extra-limit="true" keys="['file','size','gname','uname','perm','sha256','uid','gid','mtime']">
-                </wazuh-table>
+                </wazuh-table-server-side>
               </div>
               <div layout="row" class="ruleset-csv-formater" style="margin:-20px; padding:15px;">
                 <span flex></span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agentsFimCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agentsFimCtrl.js
@@ -184,7 +184,7 @@ define([
           IP: this.agent.data.data.affected_items[0].ip,
           Version: this.agent.data.data.affected_items[0].version,
           Manager: this.agent.data.data.affected_items[0].manager,
-          OS: this.agent.data.data.os.affected_items[0].name,
+          OS: this.agent.data.data.affected_items[0].os.name,
           dateAdd: this.agent.data.data.affected_items[0].dateAdd,
           lastKeepAlive: this.agent.data.data.affected_items[0].lastKeepAlive,
           group: this.agent.data.data.affected_items[0].group.toString()

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders-id.html
@@ -163,11 +163,11 @@
 
         </div>
         <div layout="row" class="md-padding">
-          <wazuh-table custom-columns="true" flex path="'/decoders'"
+          <wazuh-table-server-side custom-columns="true" flex path="'/decoders'"
             implicit-filter="[{ name:'filename',value: currentDecoder.filename}]"
             keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'filename',{value:'relative_dirname',nosortable:true}]"
             allow-click="true">
-          </wazuh-table>
+          </wazuh-table-server-side>
         </div>
         <div ng-show="!editingFile" layout="row" class="ruleset-csv-formater">
           <span flex></span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/decoders/manager-decoders.html
@@ -123,22 +123,22 @@
                     </md-chip>
                   </md-chips>
                   <div layout="row" layout-padding>
-                    <wazuh-table custom-columns="true" ng-if="!localFilter && !rulesetFiles" implicit-filter="appliedFilters" flex
+                    <wazuh-table-server-side custom-columns="true" ng-if="!localFilter && !rulesetFiles" implicit-filter="appliedFilters" flex
                       path="'/decoders'"
                       keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'filename',{value:'relative_dirname',nosortable:true}]"
                       allow-click="true" rows-per-page="14">
-                    </wazuh-table>
-                    <wazuh-table custom-columns="true" ng-if="localFilter && !rulesetFiles" implicit-filter="appliedCustomFilters"
+                    </wazuh-table-server-side>
+                    <wazuh-table-server-side custom-columns="true" ng-if="localFilter && !rulesetFiles" implicit-filter="appliedCustomFilters"
                       flex path="'/decoders'"
                       keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'filename',{value:'relative_dirname',nosortable:true}]"
                       allow-click="true" rows-per-page="14">
-                    </wazuh-table>
-                    <wazuh-table admin-mode="adminMode" ng-if="rulesetFiles && !localFilter" flex path="'/decoders/files'"
+                    </wazuh-table-server-side>
+                    <wazuh-table-server-side admin-mode="adminMode" ng-if="rulesetFiles && !localFilter" flex path="'/decoders/files'"
                       keys="['filename']" rows-per-page="[16,13,11]">
-                    </wazuh-table>
-                    <wazuh-table admin-mode="adminMode" ng-if="rulesetFiles && localFilter" flex path="'/decoders/files'"
+                    </wazuh-table-server-side>
+                    <wazuh-table-server-side admin-mode="adminMode" ng-if="rulesetFiles && localFilter" flex path="'/decoders/files'"
                       implicit-filter="[{ name:'relative_dirname',value: 'etc/decoders'}]" keys="['filename']" rows-per-page="[16,13,11]">
-                    </wazuh-table>
+                    </wazuh-table-server-side>
                   </div>
                 </md-card-contents>
               </md-card>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset-id.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset-id.html
@@ -276,11 +276,11 @@
               </h1>
             </div>
             <div layout="row" class="md-padding">
-              <wazuh-table custom-columns="true" flex path="'/rules'"
+              <wazuh-table-server-side custom-columns="true" flex path="'/rules'"
                 implicit-filter="[{ name:'relative_dirname',value: ruleInfo.relative_dirname}]"
                 keys="['id',{value:'relative_dirname',size:2},{value:'description',size:4},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},{value:'hipaa',nosortable:true},{value:'nist-800-53',nosortable:true},'level']"
                 allow-click="true">
-              </wazuh-table>
+              </wazuh-table-server-side>
             </div>
             <div ng-show="!editingFile" layout="row" class="ruleset-csv-formater">
               <span flex></span>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/rules/manager-ruleset.html
@@ -206,20 +206,20 @@
                   </md-chip>
                 </md-chips>
                 <div layout="row" layout-padding>
-                  <wazuh-table custom-columns="true" ng-if="!localFilter && !rulesetFiles" implicit-filter="appliedFilters" flex
+                  <wazuh-table-server-side custom-columns="true" ng-if="!localFilter && !rulesetFiles" implicit-filter="appliedFilters" flex
                     path="'/rules'" keys="['id',{value:'description',size:4},{value:'groups',nosortable:true,size:2},{value:'pci_dss',nosortable:true,size:2},{value:'gdpr',nosortable:true},{value:'hipaa',nosortable:true},{value:'nist-800-53',nosortable:true},'level',{value:'filename',size:2},{value:'relative_dirname',nosortable:true}]"
                     allow-click="true" rows-per-page="14">
-                  </wazuh-table>
-                  <wazuh-table custom-columns="true" ng-if="localFilter && !rulesetFiles" implicit-filter="appliedCustomFilters"
+                  </wazuh-table-server-side>
+                  <wazuh-table-server-side custom-columns="true" ng-if="localFilter && !rulesetFiles" implicit-filter="appliedCustomFilters"
                     flex path="'/rules'" keys="['id',{value:'description',size:4},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},{value:'hipaa',nosortable:true},{value:'nist-800-53',nosortable:true},'level',{value:'filename',size:2},{value:'relative_dirname',nosortable:true}]"
                     allow-click="true" rows-per-page="14">
-                  </wazuh-table>
-                  <wazuh-table admin-mode="adminMode" ng-if="rulesetFiles && !localFilter" flex path="'/rules/files'" keys="['filename']"
+                  </wazuh-table-server-side>
+                  <wazuh-table-server-side admin-mode="adminMode" ng-if="rulesetFiles && !localFilter" flex path="'/rules/files'" keys="['filename']"
                     rows-per-page="[16,13,11]">
-                  </wazuh-table>
-                  <wazuh-table admin-mode="adminMode" ng-if="rulesetFiles && localFilter" flex path="'/rules/files'"
+                  </wazuh-table-server-side>
+                  <wazuh-table-server-side admin-mode="adminMode" ng-if="rulesetFiles && localFilter" flex path="'/rules/files'"
                     implicit-filter="[{ name:'relative_dirname',value: 'etc/rules'}]" keys="['filename']" rows-per-page="[16,13,11]">
-                  </wazuh-table>
+                  </wazuh-table-server-side>
                 </div>
               </md-card-contents>
             </md-card>

--- a/SplunkAppForWazuh/appserver/static/js/directives/index.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/index.js
@@ -1,6 +1,7 @@
 define([
   './wz-menu/wz-menu',
   './wz-table/index',
+  './wz-table-server-side/index',
   './wz-data-table/wz-data-table',
   './wz-enter/wz-enter',
   './wz-dynamic/wz-dynamic',

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/index.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/index.js
@@ -1,0 +1,12 @@
+/*
+ * Wazuh app - Wazuh table directive
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define(['./wz-table-server-side-directive'], function() {})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/check-gap.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/check-gap.js
@@ -12,14 +12,12 @@
 define([], function() {
   'use strict'
   /**
-   * Checks the gap of results
+   * Checks the gap of results in order to render valid page numbers
    * @param {*} $scope
    * @param {Array} items
    */
-  return function checkGap($scope, items) {
-    const gap = items.length / $scope.itemsPerPage
-    const gapInteger = parseInt(gap)
-    $scope.gap = gap - gapInteger > 0 ? gapInteger + 1 : gapInteger
-    if ($scope.gap > 5) $scope.gap = 5
+  return function checkGap($scope) {
+    $scope.gap = $scope.totalPages
+    if ($scope.gap > 4) $scope.gap = 4
   }
 })

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/click-action.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/click-action.js
@@ -1,0 +1,61 @@
+/*
+ * Wazuh app - Wazuh table directive click wrapper
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define([], function() {
+  'use strict'
+  return function clickAction(
+    instance,
+    item,
+    $state,
+    $navigationService,
+    $currentDataService,
+    $scope,
+    state = null
+  ) {
+    if (
+      instance.path === '/agents' ||
+      new RegExp(/^\/agents\/groups\/[a-zA-Z0-9_\-\.]*$/).test(instance.path) ||
+      new RegExp(/^\/groups\/[a-zA-Z0-9_\-\.]*\/agents$/).test(instance.path)// eslint-disable-line
+    ) {
+      // Go to and store an agent details
+      $currentDataService.setCurrentAgent(item.id)
+      $currentDataService.addFilter(
+        `{"agent.id":"${item.id}", "implicit":true}`
+      )
+      $navigationService.storeRoute('agents')
+      if (!state) {
+        $state.go('agent-overview', { id: item.id })
+      } else {
+        $state.go(state, { id: item.id })
+      }
+    } else if (instance.path === '/groups') {
+      $scope.$emit('wazuhShowGroup', { group: item })
+    } else if (
+      new RegExp(/^\/agents\/groups\/[a-zA-Z0-9_\-.]*\/files$/).test(
+        // eslint-disable-line
+        instance.path
+      )
+    ) {
+      $scope.$emit('wazuhShowGroupFile', {
+        groupName: instance.path.split('groups/')[1].split('/files')[0],
+        fileName: item.filename
+      })
+    } else if (instance.path === '/rules') {
+      $state.go('mg-rules-id', { id: item.id })
+    } else if (instance.path === '/decoders') {
+      $state.go('mg-decoders-id', { file: item.file, name: item.name })
+    } else if (instance.path === '/lists/files') {
+      $state.go('mg-cdb-id', { name: item.filename, path: item.relative_dirname })
+    } else if (instance.path === '/cluster/nodes') {
+      $scope.$emit('wazuhShowClusterNode', { node: item })
+    }
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/data.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/data.js
@@ -1,0 +1,128 @@
+/*
+ * Wazuh app - Wazuh table directive data methods
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define([], function() {
+  'use strict'
+  return {
+    searchData: async (
+      term,
+      removeFilters,
+      $scope,
+      instance,
+      fetch,
+      $tableFilterService,
+      $notificationService
+    ) => {
+      try {
+        $scope.error = false
+        $scope.wazuhTableLoading = true
+        if (removeFilters) instance.removeFilters()
+        instance.addFilter('search', term)
+        $tableFilterService.set(instance.filters)
+        await fetch()
+        $scope.wazuhTableLoading = false
+      } catch (error) {
+        $scope.wazuhTableLoading = false
+        $scope.error = `Error searching - ${error.message || error}.`
+        $notificationService.showErrorToast(
+          `Error searching. ${error.message || error}`
+        )
+      }
+      $scope.$applyAsync()
+      return
+    },
+
+    filterData: async (
+      filter,
+      $scope,
+      instance,
+      $tableFilterService,
+      fetch,
+      $notificationService
+    ) => {
+      try {
+        $scope.error = false
+        $scope.wazuhTableLoading = true
+        if (Array.isArray(filter)) {
+          filter.forEach(item => {
+            if (item.name === 'platform' && instance.path === '/agents') {
+              const platform = item.value.split(' - ')[0]
+              const version = item.value.split(' - ')[1]
+              instance.addFilter('os.platform', platform)
+              instance.addFilter('os.version', version)
+            } else {
+              instance.addFilter(item.name, item.value)
+            }
+          })
+        } else if (filter.name === 'platform' && instance.path === '/agents') {
+          const platform = filter.value.split(' - ')[0]
+          const version = filter.value.split(' - ')[1]
+          instance.addFilter('os.platform', platform)
+          instance.addFilter('os.version', version)
+        } else {
+          instance.addFilter(filter.name, filter.value)
+        }
+        $tableFilterService.set(instance.filters)
+        await fetch()
+        $scope.wazuhTableLoading = false
+        $scope.$applyAsync()
+      } catch (error) {
+        $scope.wazuhTableLoading = false
+        $scope.error = `Error filtering by ${
+          filter ? filter.value : 'undefined'
+        }. ${error.message || error}.`
+        $notificationService.showErrorToast(
+          `Error filtering by ${
+            filter ? filter.value : 'undefined'
+          }. ${error.message || error}`
+        )
+      }
+      $scope.$applyAsync()
+      return
+    },
+
+    queryData: async (
+      query,
+      term,
+      instance,
+      wzTableFilter,
+      $scope,
+      fetch,
+      errorHandler
+    ) => {
+      try {
+        $scope.error = false
+        $scope.wazuh_table_loading = true
+        instance.removeFilters()
+        if (term) {
+          instance.addFilter('search', term)
+        }
+        if (query) {
+          instance.addFilter('q', query)
+        }
+        wzTableFilter.set(instance.filters)
+        await fetch()
+        $scope.wazuh_table_loading = false
+      } catch (error) {
+        $scope.wazuh_table_loading = false
+        $scope.error = `Query error ${
+          query ? query.value : 'undefined'
+        } - ${error.message || error}.`
+        errorHandler.showErrorToast(
+          `Query error ${query ? query.value : 'undefined'}. ${error.message ||
+            error}`
+        )
+      }
+      $scope.$applyAsync()
+      return
+    }
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/init.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/init.js
@@ -1,0 +1,66 @@
+/*
+ * Wazuh app - Wazuh table directive init function
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define(['../../../utils/filter-handler'], function(FilterHandler) {
+  'use strict'
+
+  return async function initTable(
+    $scope,
+    fetch,
+    $tableFilterService,
+    instance,
+    errorHandler,
+    appState,
+    globalState,
+    $window
+  ) {
+    try {
+      if ($scope.path.includes('/rules')) {
+        try {
+          const filterHandler = new FilterHandler(appState.getCurrentPattern())
+          const checkGlobalFilters = () => {
+            if (!globalState.filters || !Array.isArray(globalState.filters)) {
+              globalState.filters = []
+            }
+          }
+
+          $scope.searchRuleId = (e, ruleId) => {
+            e.stopPropagation()
+            checkGlobalFilters()
+            const ruleIdFilter = filterHandler.ruleIdQuery(ruleId)
+            if (globalState.filters.length) {
+              globalState.filters = globalState.filters.filter(
+                item => item && item.meta && item.meta.key !== 'rule.id'
+              )
+            }
+            globalState.filters.push(ruleIdFilter)
+            $window.location.href = '#/wazuh-discover'
+          }
+        } catch (error) {
+          return
+        }
+      }
+      $scope.error = false
+      $scope.wazuhTableLoading = true
+      await fetch()
+      $tableFilterService.set(instance.filters)
+      $scope.wazuhTableLoading = false
+    } catch (error) {
+      $scope.wazuhTableLoading = false
+      $scope.error = `Error while init table.`
+      errorHandler.showSimpleToast(
+        `Error while init table. ${error.message || error}`
+      )
+    }
+    $scope.$applyAsync()
+    return
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/listeners.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/listeners.js
@@ -1,0 +1,48 @@
+/*
+ * Wazuh app - Wazuh table directive event listeners
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define([], function() {
+  'use strict'
+  return {
+    wazuhUpdateInstancePath: (parameters, instance, init) => {
+      instance.filters = []
+      instance.path = parameters.path
+      return init()
+    },
+
+    wazuhFilter: (parameters, filter) => {
+      return filter(parameters.filter)
+    },
+
+    wazuhQuery: (parameters, query) => {
+      return query(parameters.query, parameters.search)
+    },
+
+    wazuhSearch: (parameters, instance, search) => {
+      if (
+        parameters &&
+        parameters.specificPath &&
+        !instance.path.includes(parameters.specificPath)
+      ) {
+        return
+      }
+      return search(parameters.term, parameters.removeFilters)
+    },
+
+    wazuhRemoveFilter: (parameters, instance, $tableFilterService, init) => {
+      instance.filters = instance.filters.filter(
+        item => item.name !== parameters.filterName
+      )
+      $tableFilterService.set(instance.filters)
+      return init()
+    }
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/pagination.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/pagination.js
@@ -1,0 +1,62 @@
+/*
+ * Wazuh app - Wazuh table directive helper
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define([], function() {
+  'use strict'
+  return {
+    setPage: async function($scope, errorHandler, fetch) {
+      try {
+        $scope.error = false
+               
+        $scope.wazuhTableLoading = true
+        const offset = $scope.itemsPerPage * $scope.currentPage;
+
+        await fetch({ offset, limit: $scope.itemsPerPage })
+        $scope.wazuhTableLoading = false        
+        $scope.$applyAsync()
+
+      } catch (error) {
+        $scope.wazuhTableLoading = false
+        $scope.error = `Error paginating table - ${error.message || error}.`
+        errorHandler.showSimpleToast(
+          `Error paginating table due to ${error.message || error}`
+        )
+      }
+    },
+    nextPage: async function($scope, errorHandler, fetch) {
+      if ($scope.currentPage < $scope.totalPages) {
+        $scope.currentPage++
+      }
+      await this.setPage($scope, errorHandler, fetch)
+    },
+
+    range: (size, start, end, gap) => {
+      const ret = []
+      if (size < end) {
+        end = size
+        start = size - gap
+      }
+      for (let i = start; i <= end; i++) {
+        ret.push(i)
+      }
+      return ret
+    },
+
+
+    prevPage: async function($scope, errorHandler, fetch) {
+      if ($scope.currentPage > 0) {
+        $scope.currentPage--
+      }
+      await this.setPage($scope, errorHandler, fetch)
+    },
+
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/parse-value.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/parse-value.js
@@ -1,0 +1,107 @@
+/*
+ * Wazuh app - Wazuh table directive helper
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+define([], function() {
+  'use strict'
+  /**
+   * Splits an array in parts
+   * @param {Array} array
+   */
+  const splitArray = array => {
+    if (Array.isArray(array)) {
+      if (!array.length) return false
+      let str = ''
+      for (const item of array) str += `${item}, `
+      str = str.substring(0, str.length - 2)
+      return str
+    }
+    return array
+  }
+
+  /**
+   * Checks if an item is already in the array
+   * @param {*} item
+   */
+  const checkIfArray = item => {
+    return typeof item === 'object' ? splitArray(item) : item == 0 ? '0' : item
+  }
+
+  /**
+   * Parses value
+   * @param {Object} ProcessEquivalence
+   * @param {String} key
+   * @param {String} item
+   * @param {String} instancePath
+   */
+  return function parseValue(
+    ProcessEquivalence,
+    key,
+    item,
+    instancePath,
+    $sce = null,
+    dateDiffService = null
+  ) {
+    if (
+      (key === 'event' || (key.value && key.value === 'event')) &&
+      instancePath.includes('rootcheck') &&
+      $sce
+    ) {
+      if (typeof (item || {}).event === 'string') {
+        const urlRegex = new RegExp(
+          /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/,
+          'g'
+        )
+
+        const matched = item.event.match(urlRegex)
+        if (matched) {
+          item.event = item.event.replace(
+            matched,
+            `<a href="${matched}">${matched}</a>`
+          )
+          item.event = $sce.trustAsHtml(item.event)
+        }
+      }
+    }
+
+    if (key.offset && dateDiffService) {
+      const date = (item || {})[key.value]
+      if (!item[`${key.value}offset`]) {
+        item[`${key.value}offset`] = date
+      }
+      if (date) {
+        item[key.value] = dateDiffService.setBrowserOffset(
+          item[`${key.value}offset`]
+        )
+      }
+    }
+
+    if (key === 'state' && instancePath.includes('processes')) {
+      return ProcessEquivalence[item.state] || 'Unknown'
+    }
+    if (
+      (key === 'description' || (key.value && key.value === 'description')) &&
+      !item.description
+    ) {
+      return '-'
+    }
+    const isComposedString = typeof key === 'string' && key.includes('.')
+    const isComposedObject =
+      typeof key === 'object' && key.value && key.value.includes('.')
+    if (isComposedString || isComposedObject) {
+      const split = isComposedString ? key.split('.') : key.value.split('.')
+      const [first, second] = split
+      return item[first] && item[first][second] ? item[first][second] : '-'
+    } else {
+      return checkIfArray(item[key.value || key]) || '-'
+    }
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/rows.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/rows.js
@@ -12,14 +12,14 @@
 define([], function() {
   'use strict'
   /**
-   * Checks the gap of results
-   * @param {*} $scope
-   * @param {Array} items
+   * Calculates the number of rows
+   * @param {Number} windowHeight
+   * @param {Number} sizes
    */
-  return function checkGap($scope, items) {
-    const gap = items.length / $scope.itemsPerPage
-    const gapInteger = parseInt(gap)
-    $scope.gap = gap - gapInteger > 0 ? gapInteger + 1 : gapInteger
-    if ($scope.gap > 5) $scope.gap = 5
+  return function calcTableRows(windowHeight, sizes) {
+    if (windowHeight >= 950) return sizes[0]
+    if (windowHeight >= 850 && windowHeight < 950) return sizes[1]
+    if (windowHeight >= 750 && windowHeight < 850) return sizes[2]
+    return sizes.length === 4 ? sizes[3] : 8
   }
 })

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/sort.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/lib/sort.js
@@ -1,0 +1,46 @@
+/*
+ * Wazuh app - Wazuh table directive helper
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+define([], function() {
+  'use strict'
+  /**
+   * Sorts table
+   * @param {String} field
+   * @param {*} $scope
+   * @param {String} instance
+   * @param {Function} fetch
+   * @param {Function} errorHandler
+   */
+  return async function sort(field, $scope, instance, fetch, errorHandler) {
+    try {
+      $scope.error = false
+      $scope.currentPage = 0
+      $scope.wazuhTableLoading = true
+      instance.addSorting(field.value || field)
+      $scope.sortValue = instance.sortValue
+      $scope.sortDir = instance.sortDir
+      await fetch()
+      $scope.wazuhTableLoading = false
+    } catch (error) {
+      $scope.wazuhTableLoading = false
+      $scope.error = `Error sorting table by ${
+        field ? field.value : 'undefined'
+      } - ${error.message || error}.`
+      errorHandler.showSimpleToast(
+        `Error sorting table by ${
+          field ? field.value : 'undefined'
+        }. ${error.message || error}`
+      )
+    }
+    $scope.$applyAsync()
+    return
+  }
+})

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/wz-table-server-side.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/wz-table-server-side.html
@@ -52,7 +52,7 @@
       </thead>
       <tbody>
         <tr ng-class="allowClick ? 'cursor-pointer' : ''" class="wz-word-wrap"
-          ng-repeat="item in pagedItems[currentPage] | filter:{item:'!'}" ng-click="clickAction(item)">
+          ng-repeat="item in items | filter:{item:'!'}" ng-click="clickAction(item)">
           <td ng-repeat="key in keys | filter: showKey"
             ng-class="{'table-width-id': key === 'id', 'table-width-filename': key.value === 'filename' }"
             ng-if="path !== '/decoders' && path !== '/rules'">
@@ -208,23 +208,23 @@
           colspan="{{ (path === '/agents' || (path === '/groups' && adminMode) || (path === '/rules/files' || path === '/decoders/files' || path === '/lists/files') || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
           <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
             seconds)</span>
-          <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+          <div ng-show="totalItems > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
             <ul layout="row">
               <li ng-show="currentPage > 0" class="md-padding">
-                <a href ng-click="firstPage()">First</a>
+                <a href ng-click="getFirstPage()">First</a>
               </li>
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
-              <li ng-repeat="n in range(pagedItems.length, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range"
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 0" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
-                <a href ng-click="setPage(pagedItems.length - 1,  true)">Last</a>
+              <li ng-show="(totalPages - currentPage) > 5" class="md-padding">
+                <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
           </div>
@@ -254,7 +254,7 @@
       </thead>
       <tbody>
         <tr ng-class="{'cursor-pointer':allowClick, 'backgroundSky':item.expanded, 'noBorderBottom':item.expanded}"
-          class="wz-word-wrap" ng-repeat-start="item in pagedItems[currentPage] | filter:{item:'!'}"
+          class="wz-word-wrap" ng-repeat-start="item in items | filter:{item:'!'}"
           ng-click="expandPolicyMonitoringCheck(item)">
           <td ng-repeat="key in keys | filter: showKey" ng-class="{'noBorderBottom':item.expanded}">
             <span ng-show="key === 'result'" class="no-wrap">
@@ -319,25 +319,25 @@
           colspan="{{ (path === '/agents' || (path === '/groups' && adminMode) || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
           <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
             seconds)</span>
-          <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+          <div ng-show="totalItems > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
             <ul layout="row">
               <li ng-show="currentPage > 0" class="md-padding">
-                <a href ng-click="firstPage()">First</a>
+                <a href ng-click="getFirstPage()">First</a>
               </li>
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
 
-              <li ng-repeat="n in range(pagedItems.length, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range"
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
 
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 1" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
-                <a href ng-click="setPage(pagedItems.length - 1,  true)">Last</a>
+              <li ng-show="(totalPages - currentPage) > 5" class="md-padding">
+                <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
           </div>
@@ -362,7 +362,7 @@
       </thead>
       <tbody>
         <tr ng-class="allowClick ? 'cursor-pointer' : ''" class="wz-word-wrap"
-          ng-repeat-start="item in pagedItems[currentPage] | filter:{item:'!'}" ng-click="expandItem(item)">
+          ng-repeat-start="item in items | filter:{item:'!'}" ng-click="expandItem(item)">
           <td ng-repeat="key in keys | filter: showKey">
             <span>
               {{
@@ -399,25 +399,25 @@
           colspan="{{ (path === '/agents' || (path === '/groups' && adminMode) || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
           <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
             seconds)</span>
-          <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+          <div ng-show="totalItems > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
             <ul layout="row">
               <li ng-show="currentPage > 0" class="md-padding">
-                <a href ng-click="firstPage()">First</a>
+                <a href ng-click="getFirstPage()">First</a>
               </li>
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
 
-              <li ng-repeat="n in range(pagedItems.length, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range"
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
 
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 1" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
-                <a href ng-click="setPage(pagedItems.length - 1,  true)">Last</a>
+              <li ng-show="(totalPages - currentPage) > 5" class="md-padding">
+                <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
           </div>

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/check-gap.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/check-gap.js
@@ -12,14 +12,12 @@
 define([], function() {
   'use strict'
   /**
-   * Checks the gap of results
+   * Checks the gap of results in order to render valid page numbers
    * @param {*} $scope
    * @param {Array} items
    */
-  return function checkGap($scope, items) {
-    const gap = $scope.totalItems / $scope.itemsPerPage
-    const gapInteger = parseInt(gap)
-    $scope.gap = gap - gapInteger > 0 ? gapInteger + 1 : gapInteger
-    if ($scope.gap > 5) $scope.gap = 5
+  return function checkGap($scope) {
+    $scope.gap = $scope.totalPages//($scope.totalPages - $scope.currentPage) || 1
+    if ($scope.gap > 4) $scope.gap = 4
   }
 })

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/check-gap.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/check-gap.js
@@ -17,7 +17,7 @@ define([], function() {
    * @param {Array} items
    */
   return function checkGap($scope, items) {
-    const gap = items.length / $scope.itemsPerPage
+    const gap = $scope.totalItems / $scope.itemsPerPage
     const gapInteger = parseInt(gap)
     $scope.gap = gap - gapInteger > 0 ? gapInteger + 1 : gapInteger
     if ($scope.gap > 5) $scope.gap = 5

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/pagination.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/pagination.js
@@ -12,36 +12,17 @@
 define([], function() {
   'use strict'
   return {
-    nextPage: async (currentPage, $scope, errorHandler, fetch, last) => {
+    nextPage: async ($scope, errorHandler, fetch) => {
       try {
         $scope.error = false
-        if (
-          !currentPage &&
-          currentPage !== 0 &&
-          $scope.currentPage < $scope.pagedItems.length - 1
-        ) {
-          $scope.currentPage++
-        }
-        if (
-          ($scope.pagedItems[currentPage || $scope.currentPage] || []).includes(
-            null
-          )
-        ) {
-          const copy = $scope.currentPage
-          $scope.wazuhTableLoading = true
-          let currentNonNull = $scope.items.filter(item => !!item)
-          if (!last) {
-            await fetch({ offset: currentNonNull.length })
-          } else {
-            while (currentNonNull.length < $scope.items.length) {
-              await fetch({ offset: currentNonNull.length })
-              currentNonNull = $scope.items.filter(item => !!item)
-            }
-          }
-          $scope.wazuhTableLoading = false
-          $scope.currentPage = copy
-          $scope.$applyAsync()
-        }
+               
+        $scope.wazuhTableLoading = true
+        const offset = $scope.itemsPerPage * $scope.currentPage;
+
+        await fetch({ offset, limit: $scope.itemsPerPage })
+        $scope.wazuhTableLoading = false
+        $scope.$applyAsync()
+
       } catch (error) {
         $scope.wazuhTableLoading = false
         $scope.error = `Error paginating table - ${error.message || error}.`
@@ -64,20 +45,6 @@ define([], function() {
       return ret
     },
 
-    groupToPages: $scope => {
-      $scope.pagedItems = []
-      for (let i = 0; i < $scope.filteredItems.length; i++) {
-        if (i % $scope.itemsPerPage === 0) {
-          $scope.pagedItems[Math.floor(i / $scope.itemsPerPage)] = [
-            $scope.filteredItems[i]
-          ]
-        } else {
-          $scope.pagedItems[Math.floor(i / $scope.itemsPerPage)].push(
-            $scope.filteredItems[i]
-          )
-        }
-      }
-    },
 
     prevPage: $scope => {
       if ($scope.currentPage > 0) {
@@ -85,11 +52,5 @@ define([], function() {
       }
     },
 
-    searchTable: ($scope, items) => {
-      $scope.filteredItems = items
-      $scope.currentPage = 0
-      // now group by pages
-      $scope.groupToPages()
-    }
   }
 })

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/pagination.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/lib/pagination.js
@@ -12,7 +12,7 @@
 define([], function() {
   'use strict'
   return {
-    nextPage: async ($scope, errorHandler, fetch) => {
+    setPage: async function($scope, errorHandler, fetch) {
       try {
         $scope.error = false
                
@@ -21,6 +21,7 @@ define([], function() {
 
         await fetch({ offset, limit: $scope.itemsPerPage })
         $scope.wazuhTableLoading = false
+        $scope.range = this.range($scope.totalPages, $scope.currentPage, $scope.currentPage + $scope.gap, $scope.gap)
         $scope.$applyAsync()
 
       } catch (error) {
@@ -30,7 +31,12 @@ define([], function() {
           `Error paginating table due to ${error.message || error}`
         )
       }
-      return
+    },
+    nextPage: async function($scope, errorHandler, fetch) {
+      if ($scope.currentPage < $scope.totalPages) {
+        $scope.currentPage++
+      }
+      await this.setPage($scope, errorHandler, fetch)
     },
 
     range: (size, start, end, gap) => {
@@ -39,17 +45,18 @@ define([], function() {
         end = size
         start = size - gap
       }
-      for (let i = start; i < end; i++) {
+      for (let i = start; i <= end; i++) {
         ret.push(i)
       }
       return ret
     },
 
 
-    prevPage: $scope => {
+    prevPage: async function($scope, errorHandler, fetch) {
       if ($scope.currentPage > 0) {
         $scope.currentPage--
       }
+      await this.setPage($scope, errorHandler, fetch)
     },
 
   }

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table-directive.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table-directive.js
@@ -231,13 +231,12 @@ define([
                 $scope.emptyResults || 'Empty results for this table.'
             }
             const result = await instance.fetch(options)
-            items = result.items
             $scope.time = result.time
-            $scope.totalItems = items.length
-            $scope.items = items
-            checkGap($scope, items)
-            $scope.searchTable()
-            $scope.$emit('wazuhFetched', { items })
+            $scope.totalItems = result.totalItems
+            $scope.items = result.items
+            checkGap($scope, $scope.items)
+            // $scope.searchTable()
+            $scope.$emit('wazuhFetched', { items:$scope.items })
             return
           } catch (error) {
             if (
@@ -392,7 +391,7 @@ define([
         const init = async () => {
           try {
             $scope.error = false
-            await fetch()
+            await fetch({limit: $scope.itemsPerPage})
             //getStoredKeys()
             $tableFilterService.set(instance.filters)
             $scope.wazuhTableLoading = false
@@ -417,30 +416,28 @@ define([
         $scope.itemsPerPage = $scope.rowsPerPage || 10
         $scope.pagedItems = []
         $scope.currentPage = 0
-        let items = []
         $scope.gap = 0
-        $scope.searchTable = () => pagination.searchTable($scope, items)
-        $scope.groupToPages = () => pagination.groupToPages($scope)
         $scope.range = (size, start, end) =>
           pagination.range(size, start, end, $scope.gap)
-        $scope.prevPage = () => pagination.prevPage($scope)
-        $scope.nextPage = async (currentPage, last) =>
+        // $scope.prevPage = () => pagination.prevPage($scope)
+        $scope.nextPage = async ( last) =>
           pagination.nextPage(
-            currentPage,
             $scope,
             $notificationService,
-            fetch,
-            last
+            fetch
           )
-        $scope.setPage = function(page = false, last = false, first = false) {
-          $scope.currentPage = page || this.n
-          if (!first) {
-            $scope.nextPage(this.n, last)
-          }
+        $scope.setPage = function(page = false) {
+          $scope.currentPage = typeof page == 'number'? page : this.n
+          $scope.nextPage($scope.currentPage)
         }
-        $scope.firstPage = () => {
-          $scope.setPage(1, false, true)
-          $scope.prevPage()
+        $scope.getFirstPage = () => {
+          $scope.setPage(0)
+          // $scope.prevPage()
+        }
+        $scope.getLastPage = () => {
+          const lastPage = Math.floor($scope.totalItems/$scope.itemsPerPage)
+          $scope.setPage(lastPage)
+          // $scope.prevPage()
         }
 
         /**

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
@@ -216,14 +216,14 @@
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
-              <li ng-repeat="n in range(totalItems, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range"
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
-              <li ng-show="currentPage < totalItems - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 1" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < totalItems - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 5" class="md-padding">
                 <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
@@ -322,22 +322,22 @@
           <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
             <ul layout="row">
               <li ng-show="currentPage > 0" class="md-padding">
-                <a href ng-click="firstPage()">First</a>
+                <a href ng-click="getFirstPage()">First</a>
               </li>
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
 
-              <li ng-repeat="n in range(pagedItems.length, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range"
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
 
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 1" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
-                <a href ng-click="setPage(pagedItems.length - 1,  true)">Last</a>
+              <li ng-show="(totalPages - currentPage) > 5" class="md-padding">
+                <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
           </div>
@@ -402,22 +402,22 @@
           <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
             <ul layout="row">
               <li ng-show="currentPage > 0" class="md-padding">
-                <a href ng-click="firstPage()">First</a>
+                <a href ng-click="getFirstPage()">First</a>
               </li>
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
 
-              <li ng-repeat="n in range(pagedItems.length, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range"
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
 
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
+              <li ng-show="(totalPages - currentPage) > 1" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
-                <a href ng-click="setPage(pagedItems.length - 1,  true)">Last</a>
+              <li ng-show="(totalPages - currentPage) > 5" class="md-padding">
+                <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
           </div>

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table.html
@@ -52,7 +52,7 @@
       </thead>
       <tbody>
         <tr ng-class="allowClick ? 'cursor-pointer' : ''" class="wz-word-wrap"
-          ng-repeat="item in pagedItems[currentPage] | filter:{item:'!'}" ng-click="clickAction(item)">
+          ng-repeat="item in items | filter:{item:'!'}" ng-click="clickAction(item)">
           <td ng-repeat="key in keys | filter: showKey"
             ng-class="{'table-width-id': key === 'id', 'table-width-filename': key.value === 'filename' }"
             ng-if="path !== '/decoders' && path !== '/rules'">
@@ -208,23 +208,23 @@
           colspan="{{ (path === '/agents' || (path === '/groups' && adminMode) || (path === '/rules/files' || path === '/decoders/files' || path === '/lists/files') || (isLookingGroup() && adminMode))  ? keys.length + 1 : keys.length}}">
           <span ng-show="!wazuhTableLoading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
             seconds)</span>
-          <div ng-show="items.length > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
+          <div ng-show="totalItems > itemsPerPage" class="pagination pull-right" style="margin:0 !important">
             <ul layout="row">
               <li ng-show="currentPage > 0" class="md-padding">
-                <a href ng-click="firstPage()">First</a>
+                <a href ng-click="getFirstPage()">First</a>
               </li>
               <li ng-show="currentPage" class="md-padding">
                 <a href ng-click="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
               </li>
-              <li ng-repeat="n in range(pagedItems.length, currentPage, currentPage + gap) "
+              <li ng-repeat="n in range(totalItems, currentPage, currentPage + gap) "
                 ng-class="{'wz-text-active': n == currentPage}" ng-click="setPage()" class="md-padding">
                 <a href ng-bind="n + 1">1</a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
+              <li ng-show="currentPage < totalItems - 1" class="md-padding">
                 <a href ng-click="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
               </li>
-              <li ng-show="currentPage < pagedItems.length - 1" class="md-padding">
-                <a href ng-click="setPage(pagedItems.length - 1,  true)">Last</a>
+              <li ng-show="currentPage < totalItems - 1" class="md-padding">
+                <a href ng-click="getLastPage()">Last</a>
               </li>
             </ul>
           </div>

--- a/SplunkAppForWazuh/appserver/static/js/services/dataService/dataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/dataService/dataService.js
@@ -92,9 +92,8 @@ define(['../module', 'splunkjs/mvc'], function(module) {
           if (this.busy) return { items: this.items, time: 0 }
           this.busy = true
           const start = new Date()
-
-          // If offset is not given, it means we need to start again
-          if (!options.offset) this.items = []
+          
+          this.items = []
           const offset = options.offset || 0
           const limit = options.limit || 500
           const parameters = { limit, offset }
@@ -107,26 +106,26 @@ define(['../module', 'splunkjs/mvc'], function(module) {
             this.busy = false
             return Promise.reject(firstPage.data.message)
           } else {
-            this.items = this.items.filter(item => !!item)
+            // this.items = this.items.filter(item => !!item)
             this.items.push(...firstPage.data.data.affected_items)
 
-            const totalItems = firstPage.data.data.totalItems
+            const totalItems = firstPage.data.data.totalItems !== undefined ? firstPage.data.data.totalItems : firstPage.data.data.total_affected_items
 
-            const remaining =
-              this.items.length === totalItems
-                ? 0
-                : totalItems - this.items.length
+            // const remaining =
+            //   this.items.length === totalItems
+            //     ? 0
+            //     : totalItems - this.items.length
 
             // Ignore manager as an agent, once the team solves this issue, review this line
             if (this.path === '/agents')
               this.items = this.items.filter(item => item.id !== '000')
 
-            if (remaining > 0) this.items.push(...Array(remaining).fill(null))
+            // if (remaining > 0) this.items.push(...Array(remaining).fill(null))
 
             const end = new Date()
             const elapsed = (end - start) / 1000
             this.busy = false
-            return { items: this.items, time: elapsed }
+            return { totalItems, items: this.items, time: elapsed }
           }
         } catch (error) {
           this.busy = false


### PR DESCRIPTION
Hi team,

this creates a new server side pagination table directive. This allows to load unlimited items but only 1 page at a time preserving client and server resources.

Closes #941 

![image](https://user-images.githubusercontent.com/9343732/115433832-5b35db80-a1de-11eb-8f54-ecff801cf3ec.png)

**This directive is used in the following views:**

- agents
- agentsFim
- manager-decoders
- manager-decoders-id
- manager-ruleset
- manager-ruleset-id
