### PR TITLE
Enhance/show-agents-node-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Support for Splunk v8.1.2
 - Support for Splunk v8.1.3
 
+### Fixed 
+
+- Fixed missing node name for agent overview [#1103](https://github.com/wazuh/wazuh-splunk/pull/1103)
+- Fixed missing columns for some tables in reports [#1103](https://github.com/wazuh/wazuh-splunk/pull/1103)
+
 ## Wazuh v4.1.4 - Splunk Enterprise v8.1.2 - Revision 68
 
 ### Added

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/agents-states.js
@@ -30,6 +30,20 @@ define(['../module'], function(module) {
                   $state.go('settings.api')
                 }
               }
+            ],
+            clusterInfo: [
+              '$requestService',
+              '$state',
+              async $requestService => {
+                try {
+                  const clusterData = await $requestService.apiReq(
+                    '/cluster/status'
+                  )
+                  return clusterData.data.data;
+                } catch (err) {
+                  $state.go('settings.api');
+                }
+              }
             ]
           }
         })

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
@@ -120,7 +120,7 @@
     </md-card-actions>
     <md-card-contents>
       <wazuh-table flex path="'/agents'" custom-columns="true"
-        keys="['id',{value:'name',size:2},'ip','status','group','os.name','os.version','version', {value: 'dateAdd', offset: true}, {value: 'lastKeepAlive', offset: true}]"
+        keys="['id',{value:'name',size:2},'ip','status','group','os.name','os.version','version','node_name', {value: 'dateAdd', offset: true}, {value: 'lastKeepAlive', offset: true}]"
         allow-click="true" rows-per-page="17">
       </wazuh-table>
     </md-card-contents>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
@@ -39,6 +39,7 @@ define([
       $csvRequestService,
       $tableFilterService,
       agentData,
+      clusterInfo,
       $mdDialog,
       $groupHandler,
       $dateDiffService
@@ -51,7 +52,7 @@ define([
       this.apiReq = $requestService.apiReq
       this.state = $state
       this.notification = $notificationService
-      this.currentClusterInfo = this.currentDataService.getClusterInfo()
+      this.clusterInfo = clusterInfo;
       this.filters = this.currentDataService.getSerializedFilters()
       this.csvReq = $csvRequestService
       this.wzTableFilter = $tableFilterService
@@ -139,7 +140,10 @@ define([
             : []
         }
 
-        if (this.clusterInfo && this.clusterInfo.status === 'enabled') {
+        if (this.clusterInfo && 
+            this.clusterInfo.enabled === 'yes' && 
+            this.clusterInfo.running === 'yes'
+          ) {
           this.scope.searchBarModel.node_name = nodes || []
         }
       } catch (error) {} //eslint-disable-line

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/docker/agentsDockerCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/docker/agentsDockerCtrl.js
@@ -116,7 +116,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryRawTable',
-          `${this.filters} sourcetype=wazuh  | stats count sparkline by data.docker.Actor.Attributes.image, data.docker.Actor.Attributes.name, data.docker.Action, timestamp | sort count DESC | rename data.docker.Actor.Attributes.image as Image, data.docker.Actor.Attributes.name as Container, data.docker.Action as Action, timestamp as Date, count as Count`,
+          `${this.filters} sourcetype=wazuh  | stats count sparkline by data.docker.Actor.Attributes.image, data.docker.Actor.Attributes.name, data.docker.Action, timestamp | sort count DESC | rename data.docker.Actor.Attributes.image as Image, data.docker.Actor.Attributes.name as Container, data.docker.Action as Action, timestamp as Date, count as Count, sparkline as Sparkline`,
           'alertsSummaryRawTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/hipaa/agentsHipaaCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/hipaa/agentsHipaaCtrl.js
@@ -112,7 +112,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} sourcetype=wazuh rule.hipaa{}="$hipaa$" | stats count sparkline by agent.name, rule.hipaa{}, rule.description | sort count DESC | rename agent.name as "Agent Name", rule.hipaa{} as Requirement, rule.description as "Rule description", count as Count`,
+          `${this.filters} sourcetype=wazuh rule.hipaa{}="$hipaa$" | stats count by rule.hipaa{},rule.level,rule.description |  sort count DESC | rename rule.hipaa{} as "Requirement", rule.level as "Level", rule.description as "Description", count as "Count"`,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/nist/agentsNistCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/nist/agentsNistCtrl.js
@@ -128,7 +128,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} sourcetype=wazuh rule.nist_800_53{}="$nist$" | stats count sparkline by agent.name, rule.nist_800_53{}, rule.description | sort count DESC | rename agent.name as "Agent Name", rule.nist_800_53{} as "Requirements", rule.description as "Rule description", count as Count`,
+          `${this.filters} sourcetype=wazuh rule.nist_800_53{}="$nist$"  | stats count by rule.nist_800_53{},rule.level,rule.description | sort count DESC |  rename rule.nist_800_53{} as "Requirement", rule.level as "Level", rule.description as "Description", count as "Count"`,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/overview.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/overview.html
@@ -94,6 +94,14 @@
           <div class="euiFlexItem euiFlexItem">
             <div class="euiStat euiStat--leftAligned wz-text-align-center">
               <div class="euiText euiText--small euiStat__description">
+                <p class="agentField">{{ agent.node_name || '-'}}</p>
+              </div>
+              <p class="euiText--small euiStat__description">Cluster node</p>
+            </div>
+          </div>
+          <div class="euiFlexItem euiFlexItem">
+            <div class="euiStat euiStat--leftAligned wz-text-align-center">
+              <div class="euiText euiText--small euiStat__description">
                 <p class="agentField">{{offsetTimestamp('', agent.dateAdd) || '-'}}</p>
               </div>
               <p class="euiText--small euiStat__description">Registration date</p>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
@@ -192,7 +192,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} sourcetype=wazuh data.oscap.check.result="fail" data.oscap.scan.profile.title="$profile$" | stats count by agent.name, data.oscap.check.title, data.oscap.scan.profile.title, data.oscap.scan.id, data.oscap.scan.content | sort count DESC | rename agent.name as "Agent name", data.oscap.check.title as Title, data.oscap.scan.profile.title as Profile, oscap.scan.id as "Scan ID", data.oscap.scan.content as Content`,
+          `${this.filters} sourcetype=wazuh data.oscap.check.result="fail" data.oscap.scan.profile.title="$profile$" | stats count by agent.name, data.oscap.check.title, data.oscap.scan.profile.title, data.oscap.scan.id, data.oscap.scan.content | sort count DESC | rename agent.name as "Agent name", data.oscap.check.title as Title, data.oscap.scan.profile.title as Profile, data.oscap.scan.id as "Scan ID", data.oscap.scan.content as Content`,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agentsVirusTotalCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/virustotal/agentsVirusTotalCtrl.js
@@ -101,7 +101,7 @@ define([
         ),
         new RawTableDataService(
           'lastFilesTable',
-          `${this.filters} | stats count by data.virustotal.source.file,data.virustotal.permalink as Count | sort count DESC | rename data.virustotal.source as File, data.virustotal.permalink as Link`,
+          `${this.filters} | stats count by data.virustotal.source.file,data.virustotal.permalink | sort count DESC | rename  data.virustotal.source.file as File,data.virustotal.permalink as Link, count as Count`,
           'lastFilesToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
@@ -163,7 +163,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} | stats count sparkline by data.vulnerability.title | rename data.vulnerability.title as Title, count as Count, sparkline as Sparkline`,
+          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, count as Count, sparkline as Sparkline `,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/ciscatCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/ciscatCtrl.js
@@ -159,7 +159,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters}  sourcetype=wazuh rule.groups{}="ciscat" | stats count sparkline by data.cis.rule_title, data.cis.remediation,data.cis.group | sort count desc | rename "data.cis.rule_title" as "Title",  "data.cis.group" as "Group" | fields - data.cis.remediation`,
+          `${this.filters} sourcetype=wazuh rule.groups{}="ciscat" | stats count sparkline by data.cis.rule_title, data.cis.remediation,data.cis.group | sort count desc | rename "data.cis.rule_title" as "Title",  "data.cis.remediation" as "Remediation",  "data.cis.group" as "Group" `,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/docker/dockerCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/docker/dockerCtrl.js
@@ -99,7 +99,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryRawTable',
-          `${this.filters} sourcetype=wazuh  | stats count sparkline by data.docker.Actor.Attributes.image, data.docker.Actor.Attributes.name, data.docker.Action, timestamp | sort count DESC | rename data.docker.Actor.Attributes.image as Image, data.docker.Actor.Attributes.name as Container, data.docker.Action as Action, timestamp as Date, count as Count`,
+          `${this.filters} sourcetype=wazuh  | stats count sparkline by data.docker.Actor.Attributes.image, data.docker.Actor.Attributes.name, data.docker.Action, timestamp | sort count DESC | rename data.docker.Actor.Attributes.image as Image, data.docker.Actor.Attributes.name as Container, data.docker.Action as Action, timestamp as Date, count as Count, sparkline as Sparkline`,
           'alertsSummaryRawTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/hipaa/overviewHipaaCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/hipaa/overviewHipaaCtrl.js
@@ -136,7 +136,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} sourcetype=wazuh rule.hipaa{}="$hipaa$" | stats count sparkline by agent.name, rule.hipaa{}, rule.description | sort count DESC | rename agent.name as "Agent Name", rule.hipaa{} as "Requirements", rule.description as "Rule description", count as Count`,
+          `${this.filters} sourcetype=wazuh rule.hipaa{}="$hipaa$" | stats count by agent.name,rule.hipaa{},rule.level,rule.description | sort count DESC | rename rule.hipaa{} as "Requirement", rule.level as "Level", rule.description as "Description", count as "Count", agent.name as "Agent"`,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overviewVirusTotalCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/virustotal/overviewVirusTotalCtrl.js
@@ -138,7 +138,7 @@ define([
         ),
         new RawTableDataService(
           'lastFilesTable',
-          `${this.filters} | stats count by data.virustotal.source.file,data.virustotal.permalink as Count | sort count DESC | rename data.virustotal.source as File, data.virustotal.permalink as Link`,
+          `${this.filters} | stats count by data.virustotal.source.file,data.virustotal.permalink | sort count DESC | rename  data.virustotal.source.file as File,data.virustotal.permalink as Link, count as Count`,
           'lastFilesToken',
           '$result$',
           this.scope,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
@@ -162,7 +162,7 @@ define([
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, count as Count, sparkline as Sparkline`,
+          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity, data.vulnerability.references | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, data.vulnerability.references as Reference, count as Count, sparkline as Sparkline`,
           'alertsSummaryTableToken',
           '$result$',
           this.scope,


### PR DESCRIPTION
#  Display agent's cluster name

1. Add agent's cluster node name on agent's details
1. Add new column to Agents overview table to show their cluster node name.
   - New column's visibility can be toggled as any other column.
   - Found out that there was already some code to display the nodes, but the object holding the data (clusterInfo) returns null. Most probably some change on the API broke this and no one noticed until now.
1. Fix broken request to fetch cluster info.
    
      Agents overview controller launched an API request to detect whether Wazuh works on cluster mode or not.
      It looks like the API endpoints have changed and the requested endpoints does not provide such information
      anymore. This information is used to generate the search filters for the table, so the broken request resulted
      on the filtering by node_name tag not showing on the search-bar filters.
    
    - Add a new route state resolver to 'agents' view in order to fetch cluster information ('/cluster/status/).
    
1. Fixed missing columns for tables in reports
    
 Closes #1102