### PR TITLE
jQuery 3.5.0 on Splunk. Workaround #1

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.html
@@ -52,7 +52,7 @@
         </md-tooltip>
       </span>
       <!-- API/Index pattern section -->
-      <a ng-show="theresAPI" class="view---simplexml---dev---EXZlQ   " aria-haspopup="true" role="button" onclick="$('#quick-settings-modal').modal('show');"><span class="label---simplexml---dev---14s46 label---simplexml---dev---16QEW icon-settings" data-role="label">&nbsp;Quick settings</span><i
+      <a ng-show="theresAPI" class="view---simplexml---dev---EXZlQ   " aria-haspopup="true" role="button" ng-click="openModal()"><span class="label---simplexml---dev---14s46 label---simplexml---dev---16QEW icon-settings" data-role="label">&nbsp;Quick settings</span><i
           data-cid="view21194" data-view="views/shared/Icon"
           class="view---simplexml---dev---18scF triangleDownSmall---simplexml---dev---2oEma" data-icon="triangleDownSmall"
           data-render-time="0" style="font-size: 1em;"></i></a>
@@ -73,7 +73,7 @@
   <!-- Current Configuration modal -->
   <div class="modal hide fade" id="quick-settings-modal">
     <div class="modal-header">
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true" ng-click="closeModal()">&times;</button>
       <h3>Quick settings</h3>
     </div>
     <div class="modal-body">

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.js
@@ -50,6 +50,29 @@ function(directives, Dropdown, DropdownViz, mvc) {
           $scope.openDiscover(data)
         })
 
+        $scope.openModal = () => {
+          const modal = document.getElementById('quick-settings-modal');
+          const overlay = document.createElement('div');
+          overlay.id = 'quick-settings-overlay';
+          document.body.appendChild(overlay);
+          overlay.classList.add('modal-backdrop', 'fade');
+          overlay.onclick = () => $scope.closeModal();
+          setTimeout(() => {
+            overlay.classList.add('in')
+            modal.classList.remove('fade')
+            modal.classList.replace('hide', 'show');
+          }, 100);
+        }
+
+        $scope.closeModal = () => {
+          const modal = document.getElementById('quick-settings-modal');
+          const overlay = document.getElementById('quick-settings-overlay');
+          overlay.classList.remove('in');
+          modal.classList.add('fade')
+          modal.classList.replace('show', 'hide');
+          setTimeout(() => document.body.removeChild(overlay), 100);
+        }
+
         let dropdownAPI;
         let dropdownIndex;
         let dropdownSourceType;
@@ -103,7 +126,7 @@ function(directives, Dropdown, DropdownViz, mvc) {
 
         const renderDropdownAPI = () => {
           mvc.Components.revokeInstance('menuSelectAPI')
-          $(`#menuSelectAPI`).html('')
+          document.getElementById(`menuSelectAPI`).innerHTML = '';
 
           dropdownAPI = new Dropdown(
             {
@@ -111,7 +134,7 @@ function(directives, Dropdown, DropdownViz, mvc) {
               choices: $scope.apiList.map((item)=> ({ label:item.managerName, value:item._key })),
               value: $scope.currentAPI._key,
               selectFirstChoice: false,                    
-              el: $(`#menuSelectAPI`)
+              el: document.getElementById(`menuSelectAPI`)
             },
             { tokens: false}
           ).render()
@@ -124,7 +147,7 @@ function(directives, Dropdown, DropdownViz, mvc) {
             mvc.Components.revokeInstance('menuSelectIndex')
             mvc.Components.revokeInstance('menuSelectIndex')
           }
-          $(`#menuSelectIndex`).html('')
+          document.getElementById(`menuSelectIndex`).innerHTML='';
 
           dropdownIndex = new DropdownViz(
             'menuSelectIndex',
@@ -146,7 +169,7 @@ function(directives, Dropdown, DropdownViz, mvc) {
             mvc.Components.revokeInstance('menuSelectSourceType')
             mvc.Components.revokeInstance('menuSelectSourceTypeSearch')
           }
-          $(`#menuSelectSourceType`).html('');
+          document.getElementById(`menuSelectSourceType`).innerHTML='';
 
           dropdownSourceType = new DropdownViz(
             'menuSelectSourceType',

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/wz-table-server-side-directive.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table-server-side/wz-table-server-side-directive.js
@@ -30,7 +30,6 @@ define([
   './lib/data',
   './lib/click-action',
   './lib/check-gap',
-  'jQuery',
   'JqueryUI'
 ], function(
   app,

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table-directive.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-table/wz-table-directive.js
@@ -30,7 +30,6 @@ define([
   './lib/data',
   './lib/click-action',
   './lib/check-gap',
-  'jQuery',
   'JqueryUI'
 ], function(
   app,

--- a/SplunkAppForWazuh/appserver/static/js/main.js
+++ b/SplunkAppForWazuh/appserver/static/js/main.js
@@ -30,9 +30,6 @@ require.config({
     // dom-to-image
     domToImg: 'js/libs/required-dom-to-image/src/dom-to-image',
 
-    // jQuery
-    jQuery: 'js/libs/jquery-3.5.0.min',
-
     // JqueryUI
     JqueryUI: 'js/libs/jquery-ui'
   },

--- a/SplunkAppForWazuh/default/data/ui/html/index.html
+++ b/SplunkAppForWazuh/default/data/ui/html/index.html
@@ -41,6 +41,11 @@
   <script src="{{SPLUNKWEB_URL_PREFIX}}/static/js/i18n.js"></script>
   <script src="{{SPLUNKWEB_URL_PREFIX}}/i18ncatalog?autoload=1"></script>
   <script src="{{SPLUNKWEB_URL_PREFIX}}/static/build/simplexml/index.js"></script>
+  <!-- Workoaround to have jQuery 2.1.0 and 3.5.0 working together -->
+  <script type="text/javascript">
+    var jQuery_2_1_0 = $.noConflict(true);
+  </script>
+  <script src="{{SPLUNKWEB_URL_PREFIX}}/static/app/SplunkAppForWazuh/js/libs/jquery-3.5.0.min.js" type="text/javascript"></script>
   <script src="{{SPLUNKWEB_URL_PREFIX}}/static/app/SplunkAppForWazuh/js/main.js" type="text/javascript"></script>
 
 


### PR DESCRIPTION
Workaround #1 to add jQuery 3.5.0 to the Wazuh App for Splunk

This workaround uses the `index.html` method. It first loads jQuery 2.1.0 shipped with Splunk (SimpleXML) and makes it accesible with the variable `jQuery_2_1_0`. Then, our jQuery version is loaded (3.5.0), accesible as usual with the dollar sign '$'.

As a result, jQuery 3.5.0 takes preference globally on our app, but jQuery 2.1.0 (or whatever version Splunk uses) is also there.

![image](https://user-images.githubusercontent.com/15186973/133819232-950eb14b-e17c-4f3a-99e3-700e37485b52.png)
