### PR TITLE
Added persitence to modules in overview panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ package-lock.json
 .vscode
 SplunkAppForWazuh/metadata/local.meta
 SplunkAppForWazuh/default/app.conf
+SplunkAppForWazuh/local/
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Support for Splunk v8.1.4
 - Added new source type selector to customize queries used by dashboards [#1104](https://github.com/wazuh/wazuh-splunk/pull/1104)
 - Added quick settings to improve the view and selection of API, index, and source type [#1107](https://github.com/wazuh/wazuh-splunk/pull/1107)
+- Added persitence to modules in overview panel [#1135](https://github.com/wazuh/wazuh-splunk/pull/1135)
 
 ### Fixed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 
 - Fixed missing node name for agent overview [#1103](https://github.com/wazuh/wazuh-splunk/pull/1103)
 - Fixed missing columns for some tables in reports [#1103](https://github.com/wazuh/wazuh-splunk/pull/1103)
+- Fixed extensions panel not being persistent [#1115](https://github.com/wazuh/wazuh-splunk/pull/1134)
 
 ## Wazuh v4.1.4 - Splunk Enterprise v8.1.2 - Revision 68
 

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -66,6 +66,16 @@ def putConfStanza(file,stanzaDict):
         raise e
     return { 'error': False }
 
+def rmConfStanza(file,stanza):
+    try:
+        conf = cli.readConfFile(getLocalConfPath(file))
+        response = stanza in conf
+        if response:
+            conf.pop(stanza)
+        cli.writeConfFile(getLocalConfPath(file),conf)
+        return response
+    except Exception as e:
+        raise e
 
 def diff_keys_dic_update_api(kwargs_dic):
     """Get the missing fields for the API entry.
@@ -161,6 +171,16 @@ class manager(controllers.BaseController):
         return data_temp
     
     @expose_page(must_login=False, methods=['POST'])
+    def remove_extensions(self, **kwargs):
+        try:
+            self.logger.debug("manager: Removing extensions.")
+            id = kwargs['id']
+            response = rmConfStanza("extensions",id)
+            return response
+        except Exception as e:
+            return {'error':str(e)}
+
+    @expose_page(must_login=False, methods=['POST'])
     def save_extensions(self, **kwargs):
         """Save extensions to file
 
@@ -171,7 +191,6 @@ class manager(controllers.BaseController):
         """
         try:
             self.logger.debug("manager: Saving extensions.")
-            self.logger.debug(kwargs)
             id = kwargs['id']
             extensions = kwargs['extensions']
             response = {}

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/agentsOverviewCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/agentsOverviewCtrl.js
@@ -388,8 +388,8 @@ define(['../../module'], function(app) {
     toggleExtension(extension, state) {
       try {
         this.extensions[extension] = state.toString()
-        this.currentDataService.setExtensions(this.api, this.extensions)
-        this.extensions = this.currentDataService.getExtensions(this.api)
+        this.currentDataService.setExtensionsById(this.api, this.extensions)
+        this.extensions = this.currentDataService.getExtensionsById(this.api)
         this.refreshExtensions()
       } catch (error) {
         console.error(error)

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
@@ -68,11 +68,11 @@ define(['../../module'], function(controllers) {
      * @param {String} extension
      * @param {String} state
      */
-    toggleExtension(extension, state) {
+    async toggleExtension(extension, state) {
       try {
         this.extensions[extension] = state.toString()
-        this.currentDataService.setExtensions(this.api, this.extensions)
-        this.extensions = this.currentDataService.getExtensions(this.api)
+        await this.currentDataService.setExtensionsById(this.api, this.extensions)
+        this.extensions = await this.currentDataService.getExtensionsById(this.api)
         this.refreshExtensions()
       } catch (error) {
         console.error(error)

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/api/settingsApiCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/api/settingsApiCtrl.js
@@ -104,6 +104,7 @@ define(['../../module'], function (controllers) {
           this.notification.showSuccessToast('Manager was removed')
           this.scope.$emit('updatedAPI', () => { })
         }
+        this.currentDataService.removeExtensionsById(entry['_key'])
       } catch (err) {
         this.notification.showErrorToast(
           `Cannot remove API: ${err.message || err}`

--- a/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
@@ -70,56 +70,6 @@ define(['../module'], function(app) {
         return Promise.reject(err)
       }
     }
-
-    getExtensions(id) {
-      try {
-        if (this.sessionStorage.extensions) {
-          const currentExtensions = JSON.parse(this.sessionStorage.extensions)
-          const result =
-            currentExtensions.length >= 1
-              ? currentExtensions.filter(item => item.id === id)[0]
-              : false
-          return result
-        }
-      } catch (err) {
-        return false
-      }
-    }
-
-    setExtensions(id, extensions) {
-      try {
-        const newExtensions = Object.assign(extensions, { id })
-        if (extensions.length && this.sessionStorage.getItem('extensions')) {
-          let parsedExtensions = JSON.parse(
-            this.sessionStorage.getItem('extensions')
-          )
-          let existentApi = false
-          for (let i = 0; i < parsedExtensions.length; i++) {
-            if (parsedExtensions[i].id === id) {
-              parsedExtensions[i] = newExtensions //eslint-disable-line
-              existentApi = true
-              break
-            }
-          }
-          if (!existentApi) {
-            parsedExtensions.push(newExtensions)
-          }
-          this.sessionStorage.setItem(
-            'extensions',
-            JSON.stringify(parsedExtensions) || []
-          )
-        } else if (extensions) {
-          const newSet = []
-          newSet.push(newExtensions)
-          this.sessionStorage.setItem(
-            'extensions',
-            JSON.stringify(newSet) || []
-          )
-        }
-      } catch (err) {
-        return
-      }
-    }
   }
   app.service('$apiIndexStorageService', ApiIndexStorageService)
 })

--- a/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
@@ -110,14 +110,6 @@ define(['../module'], function(module) {
       return $apiMgrService.setApi(api)
     }
 
-    const getExtensions = id => {
-      return $apiIndexStorageService.getExtensions(id)
-    }
-
-    const setExtensions = (api, extensions) => {
-      return $apiIndexStorageService.setExtensions(api, extensions)
-    }
-
     const removeCurrentApi = () => {
       return $apiIndexStorageService.removeAPI()
     }
@@ -288,13 +280,11 @@ define(['../module'], function(module) {
       setApi: setApi,
       getCurrentAgent: getCurrentAgent,
       setCurrentAgent: setCurrentAgent,
-      getExtensions: getExtensions,
       getAdminExtensions: getAdminExtensions,
       getCurrentExtensions: getCurrentExtensions,
       getCurrentConfiguration: getCurrentConfiguration,
       getExtensionsById: getExtensionsById,
       extensionIsEnabled: extensionIsEnabled,
-      setExtensions: setExtensions,
       setExtensionsById: setExtensionsById,
       addApi: addApi,
       isAdmin: isAdmin,

--- a/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
@@ -135,20 +135,34 @@ define(['../module'], function(module) {
      * @param {String} id
      */
     const getExtensionsById = async id => {
+      const result = {}
       try {
-        const currentExtensions = getExtensions(id)
-        const result = {}
-        if (currentExtensions) {
-          Object.assign(result, currentExtensions)
-        } else {
-          const ext = await $requestService.httpReq(
-            `GET`,
-            `/manager/extensions`
-          )
-          Object.assign(result, ext.data)
-        }
+        const ext = await $requestService.httpReq(
+          `POST`,
+          `/manager/extensions`,
+          {id:id}
+        )
+        Object.assign(result, ext.data)
         return result
       } catch (err) {
+        console.log(err)
+        return Promise.reject(false)
+      }
+    }
+
+    const setExtensionsById = async (id, extensions) => {
+      const result = {}
+      try {
+        const ext = await $requestService.httpReq(
+          `POST`,
+          `/manager/save_extensions`,
+          {id: id,
+          extensions: JSON.stringify(extensions)}
+        )
+        Object.assign(result, ext.data)
+        return result
+      } catch (err) {
+        console.log(err)
         return Promise.reject(false)
       }
     }
@@ -281,6 +295,7 @@ define(['../module'], function(module) {
       getExtensionsById: getExtensionsById,
       extensionIsEnabled: extensionIsEnabled,
       setExtensions: setExtensions,
+      setExtensionsById: setExtensionsById,
       addApi: addApi,
       isAdmin: isAdmin,
       getReportingStatus: getReportingStatus,

--- a/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
@@ -159,6 +159,22 @@ define(['../module'], function(module) {
       }
     }
 
+    const removeExtensionsById = async (id) => {
+      const result = {}
+      try {
+        const response = await $requestService.httpReq(
+          `POST`,
+          `/manager/remove_extensions`,
+          {id:id}
+        )
+        Object.assign(result,response.data)
+        return result
+      } catch (err) {
+        console.log(err)
+        return Promise.reject(false)
+      }
+    }
+
     /**
      * Gets admin extensions by ID
      * @param {String} id
@@ -284,6 +300,7 @@ define(['../module'], function(module) {
       getCurrentExtensions: getCurrentExtensions,
       getCurrentConfiguration: getCurrentConfiguration,
       getExtensionsById: getExtensionsById,
+      removeExtensionsById: removeExtensionsById,
       extensionIsEnabled: extensionIsEnabled,
       setExtensionsById: setExtensionsById,
       addApi: addApi,


### PR DESCRIPTION
This pull request adds the functionality to make the selection for visible modules persistent across refreshes, browsers and devices by storing the state in a file in the server and reading from it.

Closes https://github.com/wazuh/wazuh-splunk/issues/1115

### To test

**Fresh State**
- **Given** There is no file `SplunkAppForWazuh/local/extensions.conf`
- **When** the user navigates to `Overview/Welcome`
- **Then** the extensions are shown as described in `SplunkAppForWazuh/default/config.conf`

**Create Extensions.conf**
- **Given** There is no file `SplunkAppForWazuh/local/extensions.conf`
- **And** The browser is in `Overview/Welcome`
- **When** The user enables or disables an extension
- **Then** the file `SplunkAppForWazuh/local/extensions.conf` is created
- **And** It contains a stanza that shows the correct extension configuration

**With previous Extensions**
- **Given** There is file `SplunkAppForWazuh/local/extensions.conf`
- **When** the user navigates to `Overview/Welcome`
- **Then** the extensions are shown as described in `SplunkAppForWazuh/local/extensions.conf`

**Edit previous extensions**
- **Given** There is a file `SplunkAppForWazuh/local/extensions.conf`
- **And** The browser is in `Overview/Welcome`
- **When** The user enables or disables an extension
- **Then** the stanza in  `SplunkAppForWazuh/local/extensions.conf` is updated accordingly

**Remove API**

- **Given** There is a stanza for an api in extensions.conf
- **When** The user removes this api
- **Then** the stanza is also removed from the file
