### PR TITLE
Created Requirement service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Support for Splunk v8.1.4
 - Added new source type selector to customize queries used by dashboards [#1104](https://github.com/wazuh/wazuh-splunk/pull/1104)
 - Added quick settings to improve the view and selection of API, index, and source type [#1107](https://github.com/wazuh/wazuh-splunk/pull/1107)
+- Added requirement service [#1162](https://github.com/wazuh/wazuh-splunk/pull/1162)
 - Support for Splunk v8.2.2
 
 ### Changed 

--- a/SplunkAppForWazuh/appserver/static/js/services/index.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/index.js
@@ -25,5 +25,6 @@ define([
   './restartService/restartService',
   './checkDaemons/checkDaemonsService',
   './app-version/appVersionService',
-  './sourceTypeStorageService/sourceTypeStorageService'
+  './sourceTypeStorageService/sourceTypeStorageService',
+  './requirementService/requirementService'
 ], function() {})

--- a/SplunkAppForWazuh/appserver/static/js/services/requirementService/requirementService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requirementService/requirementService.js
@@ -1,0 +1,289 @@
+define(['../module'], function (module) {
+    'use strict'
+
+    module.service('$requirementService', function () {
+        /**
+         * Gets a valid resource string with an optional parameter,
+         * returns a wildcard resource if no param is specified
+         * @param {
+         *  "RESOURCELESS" |
+         *  "AGENT_GROUP" |
+         *  "AGENT_ID" |
+         *  "GROUP_ID" |
+         *  "NODE_ID" |
+         *  "DECODER_FILE" |
+         *  "LIST_FILE" |
+         *  "RULE_FILE" |
+         *  "POLICY_ID" |
+         *  "ROLE_ID" |
+         *  "RULE_ID" |
+         *  "USER_ID"
+         * } resource 
+         * @param {string} param 
+         * @returns {string}
+         */
+        const getResource = (resource, param = '*') => {
+            const resourceDic = {
+                RESOURCELESS: '*:*',
+                AGENT_GROUP: `agent:group:${param}`,
+                AGENT_ID: `agent:id:${param}`,
+                GROUP_ID: `group:id:${param}`,
+                NODE_ID: `node:id:${param}`,
+                DECODER_FILE: `decoder:file:${param}`,
+                LIST_FILE: `list:file:${param}`,
+                RULE_FILE: `rule:file:${param}`,
+                POLICY_ID: `policy:id:${param}`,
+                ROLE_ID: `role:id:${param}`,
+                RULE_ID: `rule:id:${param}`,
+                USER_ID: `user:id:${param}`,
+            }
+            if (!(resource in resourceDic)) {
+                throw 'Invalid resource'
+            }
+            return resourceDic[resource]
+        }
+
+        const actionDict = {
+            ACTIVE_RESPONSE_COMMAND: 'active-response:command',
+            AGENT_CREATE: 'agent:create',
+            AGENT_DELETE: 'agent:delete',
+            AGENT_MODIFY_GROUP: 'agent:modify_group',
+            AGENT_READ: 'agent:read',
+            AGENT_RESTART: 'agent:restart',
+            AGENT_UPGRADE: 'agent:upgrade',
+            CISCAT_READ: 'ciscat:read',
+            CLUSTER_READ_API_CONFIG: 'cluster:read_api_config',
+            CLUSTER_READ: 'cluster:read',
+            CLUSTER_RESTART: 'cluster:restart',
+            CLUSTER_STATUS: 'cluster:status',
+            DECODERS_READ: 'decoders:read',
+            DECODERS_UPDATE: 'decoders:update',
+            DECODERS_DELETE: 'decoders:delete',
+            GROUP_CREATE: 'group:create',
+            GROUP_DELETE: 'group:delete',
+            GROUP_MODIFY_ASSIGNMENT: 'group:modify_assignments',
+            GROUP_READ: 'group:read',
+            GROUP_UPDATE_CONFIG: 'group:update_config',
+            LISTS_READ: 'lists:read',
+            LISTS_UPDATE: 'lists:update',
+            LISTS_DELETE: 'lists:delete',
+            LOGTEST_RUN: 'logtest:run',
+            MANAGER_READ_API_CONFIG: 'manager:read_api_config',
+            MANAGER_READ: 'manager:read',
+            MANAGER_RESTART: 'manager:restart',
+            MANAGER_UPDATE_CONFIG: 'manager:update_config',
+            MITRE_READ: 'mitre:read',
+            ROOTCHECK_CLEAR: 'rootcheck:clear',
+            ROOTCHECK_READ: 'rootcheck:read',
+            ROOTCHECK_RUN: 'rootcheck:run',
+            RULES_READ: 'rules:read',
+            RULES_UPDATE: 'rules:update',
+            RULES_DELETE: 'rules:delete',
+            SCA_READ: 'sca:read',
+            SECURITY_CREATE_USER: 'security:create_user',
+            SECURITY_CREATE: 'security:create',
+            SECURITY_DELETE: 'security:delete',
+            SECURITY_EDIT_RUN_AS: 'security:edit_run_as',
+            SECURITY_READ_CONFIG: 'security:read_config',
+            SECURITY_READ: 'security:read',
+            SECURITY_REVOKE: 'security:revoke',
+            SECURITY_UPDATE_CONFIG: 'security:update_config',
+            SECURITY_UPDATE: 'security:update',
+            SYSCHECK_CLEAR: 'syscheck:clear',
+            SYSCHECK_READ: 'syscheck:read',
+            SYSCHECK_RUN: 'syscheck:run',
+            SYSCOLLECTOR_READ: 'syscollector:read',
+            TASK_STATUS: 'task:status',
+            VULNERABILITY_READ: 'vulnerability:read',
+        }
+
+        /**
+         * Returns a valid action string
+         * @param {
+         * "ACTIVE_RESPONSE_COMMAND" |
+         * "AGENT_CREATE" |
+         * "AGENT_DELETE" |
+         * "AGENT_MODIFY_GROUP" |
+         * "AGENT_READ" |
+         * "AGENT_RESTART" |
+         * "AGENT_UPGRADE" |
+         * "CISCAT_READ" |
+         * "CLUSTER_READ_API_CONFIG" |
+         * "CLUSTER_READ" |
+         * "CLUSTER_RESTART" |
+         * "CLUSTER_STATUS" |
+         * "CLUSTER_UPDATE_CONFIG" |
+         * "DECODERS_READ" |
+         * "DECODERS_UPDATE" |
+         * "DECODERS_DELETE" |
+         * "GROUP_CREATE" |
+         * "GROUP_DELETE" |
+         * "GROUP_MODIFY_ASSIGNMENT" |
+         * "GROUP_READ" |
+         * "GROUP_UPDATE_CONFIG" |
+         * "LISTS_READ" |
+         * "LISTS_UPDATE" |
+         * "LISTS_DELETE" |
+         * "LOGTEST_RUN" |
+         * "MANAGER_READ_API_CONFIG" |
+         * "MANAGER_READ" |
+         * "MANAGER_RESTART" |
+         * "MANAGER_UPDATE_CONFIG" |
+         * "MITRE_READ" |
+         * "ROOTCHECK_CLEAR" |
+         * "ROOTCHECK_READ" |
+         * "ROOTCHECK_RUN" |
+         * "RULES_READ" |
+         * "RULES_UPDATE" |
+         * "RULES_DELETE" |
+         * "SCA_READ" |
+         * "SECURITY_CREATE_USER" |
+         * "SECURITY_CREATE" |
+         * "SECURITY_DELETE" |
+         * "SECURITY_EDIT_RUN_AS" |
+         * "SECURITY_READ_CONFIG" |
+         * "SECURITY_READ" |
+         * "SECURITY_REVOKE" |
+         * "SECURITY_UPDATE_CONFIG" |
+         * "SECURITY_UPDATE" |
+         * "SYSCHECK_CLEAR" |
+         * "SYSCHECK_READ" |
+         * "SYSCHECK_RUN" |
+         * "SYSCOLLECTOR_READ" |
+         * "TASK_STATUS" |
+         * "VULNERABILITY_READ"
+         * } action 
+         * @returns {string}
+         */
+        const getAction = action => {
+            if (!(action in actionDict)) {
+                throw 'Invalid action'
+            }
+            return actionDict[action]
+        }
+
+        //Dictionary of possible resource keys to be used with each action
+        const actionResourcesDict = {
+            ACTIVE_RESPONSE_COMMAND: ['AGENT_ID', 'AGENT_GROUP'],
+            AGENT_CREATE: ['RESOURCELESS'],
+            AGENT_DELETE: ['AGENT_ID', 'AGENT_GROUP'],
+            AGENT_MODIFY_GROUP: ['AGENT_ID', 'AGENT_GROUP'],
+            AGENT_READ: ['AGENT_ID', 'AGENT_GROUP'],
+            AGENT_RESTART: ['AGENT_ID', 'AGENT_GROUP'],
+            AGENT_UPGRADE: ['AGENT_ID', 'AGENT_GROUP'],
+            CISCAT_READ: ['AGENT_ID', 'AGENT_GROUP'],
+            CLUSTER_READ_API_CONFIG: ['NODE_ID'],
+            CLUSTER_READ: ['NODE_ID'],
+            CLUSTER_RESTART: ['NODE_ID'],
+            CLUSTER_STATUS: ['RESOURCELESS'],
+            DECODERS_READ: ['DECODER_FILE'],
+            DECODERS_UPDATE: ['RESOURCELESS'],
+            DECODERS_DELETE: ['DECODER_FILE'],
+            GROUP_CREATE: ['RESOURCELESS'],
+            GROUP_DELETE: ['GROUP_ID'],
+            GROUP_MODIFY_ASSIGNMENT: ['GROUP_ID'],
+            GROUP_READ: ['GROUP_ID'],
+            GROUP_UPDATE_CONFIG: ['GROUP_ID'],
+            LISTS_READ: ['LIST_FILE'],
+            LISTS_UPDATE: ['RESOURCELESS'],
+            LISTS_DELETE: ['RESOURCELESS'],
+            LOGTEST_RUN: ['RESOURCELESS'],
+            MANAGER_READ_API_CONFIG: ['RESOURCELESS'],
+            MANAGER_READ: ['RESOURCELESS'],
+            MANAGER_RESTART: ['RESOURCELESS'],
+            MANAGER_UPDATE_CONFIG: ['RESOURCELESS'],
+            MITRE_READ: ['RESOURCELESS'],
+            ROOTCHECK_CLEAR: ['AGENT_ID', 'AGENT_GROUP'],
+            ROOTCHECK_READ: ['AGENT_ID', 'AGENT_GROUP'],
+            ROOTCHECK_RUN: ['AGENT_ID', 'AGENT_GROUP'],
+            RULES_READ: ['RULE_FILE'],
+            RULES_UPDATE: ['RESOURCELESS'],
+            RULES_DELETE: ['RULE_FILE'],
+            SCA_READ: ['AGENT_ID', 'AGENT_GROUP'],
+            SECURITY_CREATE_USER: ['RESOURCELESS'],
+            SECURITY_CREATE: ['RESOURCELESS'],
+            SECURITY_DELETE: ['POLICY_ID', 'ROLE_ID', 'RULE_ID', 'USER_ID'],
+            SECURITY_EDIT_RUN_AS: ['RESOURCELESS'],
+            SECURITY_READ_CONFIG: ['RESOURCELESS'],
+            SECURITY_READ: ['POLICY_ID', 'ROLE_ID', 'RULE_ID', 'USER_ID'],
+            SECURITY_REVOKE: ['RESOURCELESS'],
+            SECURITY_UPDATE_CONFIG: ['RESOURCELESS'],
+            SECURITY_UPDATE: ['POLICY_ID', 'ROLE_ID', 'RULE_ID', 'USER_ID'],
+            SYSCHECK_CLEAR: ['AGENT_ID', 'AGENT_GROUP'],
+            SYSCHECK_READ: ['AGENT_ID', 'AGENT_GROUP'],
+            SYSCHECK_RUN: ['AGENT_ID', 'AGENT_GROUP'],
+            SYSCOLLECTOR_READ: ['AGENT_ID', 'AGENT_GROUP'],
+            TASK_STATUS: ['RESOURCELESS'],
+            VULNERABILITY_READ: ['AGENT_ID', 'AGENT_GROUP'],
+        }
+        /**
+         * Returns a valid resource key
+         * @param {
+         * "ACTIVE_RESPONSE_COMMAND" |
+         * "AGENT_CREATE" |
+         * "AGENT_DELETE" |
+         * "AGENT_MODIFY_GROUP" |
+         * "AGENT_READ" |
+         * "AGENT_RESTART" |
+         * "AGENT_UPGRADE" |
+         * "CISCAT_READ" |
+         * "CLUSTER_READ_API_CONFIG" |
+         * "CLUSTER_READ" |
+         * "CLUSTER_RESTART" |
+         * "CLUSTER_STATUS" |
+         * "CLUSTER_UPDATE_CONFIG" |
+         * "DECODERS_READ" |
+         * "DECODERS_UPDATE" |
+         * "DECODERS_DELETE" |
+         * "GROUP_CREATE" |
+         * "GROUP_DELETE" |
+         * "GROUP_MODIFY_ASSIGNMENT" |
+         * "GROUP_READ" |
+         * "GROUP_UPDATE_CONFIG" |
+         * "LISTS_READ" |
+         * "LISTS_UPDATE" |
+         * "LISTS_DELETE" |
+         * "LOGTEST_RUN" |
+         * "MANAGER_READ_API_CONFIG" |
+         * "MANAGER_READ" |
+         * "MANAGER_RESTART" |
+         * "MANAGER_UPDATE_CONFIG" |
+         * "MITRE_READ" |
+         * "ROOTCHECK_CLEAR" |
+         * "ROOTCHECK_READ" |
+         * "ROOTCHECK_RUN" |
+         * "RULES_READ" |
+         * "RULES_UPDATE" |
+         * "RULES_DELETE" |
+         * "SCA_READ" |
+         * "SECURITY_CREATE_USER" |
+         * "SECURITY_CREATE" |
+         * "SECURITY_DELETE" |
+         * "SECURITY_EDIT_RUN_AS" |
+         * "SECURITY_READ_CONFIG" |
+         * "SECURITY_READ" |
+         * "SECURITY_REVOKE" |
+         * "SECURITY_UPDATE_CONFIG" |
+         * "SECURITY_UPDATE" |
+         * "SYSCHECK_CLEAR" |
+         * "SYSCHECK_READ" |
+         * "SYSCHECK_RUN" |
+         * "SYSCOLLECTOR_READ" |
+         * "TASK_STATUS" |
+         * "VULNERABILITY_READ"
+         * } action 
+         * @returns {string}
+         */
+        const getActionResourceKeys = action => {
+            if (!(action in actionResourcesDict)) {
+                throw 'Invalid action'
+            }
+            return actionResourcesDict[action]
+        }
+        return {
+            getAction,
+            getResource,
+            getActionResourceKeys
+        }
+    })
+})

--- a/SplunkAppForWazuh/appserver/static/js/services/requirementService/requirementService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requirementService/requirementService.js
@@ -1,289 +1,465 @@
-define(['../module'], function (module) {
-    'use strict'
+define(["../module"], function(module) {
+  "use strict";
 
-    module.service('$requirementService', function () {
-        /**
-         * Gets a valid resource string with an optional parameter,
-         * returns a wildcard resource if no param is specified
-         * @param {
-         *  "RESOURCELESS" |
-         *  "AGENT_GROUP" |
-         *  "AGENT_ID" |
-         *  "GROUP_ID" |
-         *  "NODE_ID" |
-         *  "DECODER_FILE" |
-         *  "LIST_FILE" |
-         *  "RULE_FILE" |
-         *  "POLICY_ID" |
-         *  "ROLE_ID" |
-         *  "RULE_ID" |
-         *  "USER_ID"
-         * } resource 
-         * @param {string} param 
-         * @returns {string}
-         */
-        const getResource = (resource, param = '*') => {
-            const resourceDic = {
-                RESOURCELESS: '*:*',
-                AGENT_GROUP: `agent:group:${param}`,
-                AGENT_ID: `agent:id:${param}`,
-                GROUP_ID: `group:id:${param}`,
-                NODE_ID: `node:id:${param}`,
-                DECODER_FILE: `decoder:file:${param}`,
-                LIST_FILE: `list:file:${param}`,
-                RULE_FILE: `rule:file:${param}`,
-                POLICY_ID: `policy:id:${param}`,
-                ROLE_ID: `role:id:${param}`,
-                RULE_ID: `rule:id:${param}`,
-                USER_ID: `user:id:${param}`,
-            }
-            if (!(resource in resourceDic)) {
-                throw 'Invalid resource'
-            }
-            return resourceDic[resource]
-        }
+  module.service("$requirementService", function() {
+    /**
+     * Gets a valid resource string with an optional parameter,
+     * returns a wildcard resource if no param is specified
+     * @param {
+     *  "RESOURCELESS" |
+     *  "AGENT_GROUP" |
+     *  "AGENT_ID" |
+     *  "GROUP_ID" |
+     *  "NODE_ID" |
+     *  "DECODER_FILE" |
+     *  "LIST_FILE" |
+     *  "RULE_FILE" |
+     *  "POLICY_ID" |
+     *  "ROLE_ID" |
+     *  "RULE_ID" |
+     *  "USER_ID"
+     * } resource
+     * @param {string} param
+     * @returns {string}
+     */
+    const getResource = (resource, param = "*") => {
+      const resourceDic = {
+        RESOURCELESS: "*:*",
+        AGENT_GROUP: `agent:group:${param}`,
+        AGENT_ID: `agent:id:${param}`,
+        GROUP_ID: `group:id:${param}`,
+        NODE_ID: `node:id:${param}`,
+        DECODER_FILE: `decoder:file:${param}`,
+        LIST_FILE: `list:file:${param}`,
+        RULE_FILE: `rule:file:${param}`,
+        POLICY_ID: `policy:id:${param}`,
+        ROLE_ID: `role:id:${param}`,
+        RULE_ID: `rule:id:${param}`,
+        USER_ID: `user:id:${param}`,
+      };
+      if (!(resource in resourceDic)) {
+        throw "Invalid resource";
+      }
+      return resourceDic[resource];
+    };
 
-        const actionDict = {
-            ACTIVE_RESPONSE_COMMAND: 'active-response:command',
-            AGENT_CREATE: 'agent:create',
-            AGENT_DELETE: 'agent:delete',
-            AGENT_MODIFY_GROUP: 'agent:modify_group',
-            AGENT_READ: 'agent:read',
-            AGENT_RESTART: 'agent:restart',
-            AGENT_UPGRADE: 'agent:upgrade',
-            CISCAT_READ: 'ciscat:read',
-            CLUSTER_READ_API_CONFIG: 'cluster:read_api_config',
-            CLUSTER_READ: 'cluster:read',
-            CLUSTER_RESTART: 'cluster:restart',
-            CLUSTER_STATUS: 'cluster:status',
-            DECODERS_READ: 'decoders:read',
-            DECODERS_UPDATE: 'decoders:update',
-            DECODERS_DELETE: 'decoders:delete',
-            GROUP_CREATE: 'group:create',
-            GROUP_DELETE: 'group:delete',
-            GROUP_MODIFY_ASSIGNMENT: 'group:modify_assignments',
-            GROUP_READ: 'group:read',
-            GROUP_UPDATE_CONFIG: 'group:update_config',
-            LISTS_READ: 'lists:read',
-            LISTS_UPDATE: 'lists:update',
-            LISTS_DELETE: 'lists:delete',
-            LOGTEST_RUN: 'logtest:run',
-            MANAGER_READ_API_CONFIG: 'manager:read_api_config',
-            MANAGER_READ: 'manager:read',
-            MANAGER_RESTART: 'manager:restart',
-            MANAGER_UPDATE_CONFIG: 'manager:update_config',
-            MITRE_READ: 'mitre:read',
-            ROOTCHECK_CLEAR: 'rootcheck:clear',
-            ROOTCHECK_READ: 'rootcheck:read',
-            ROOTCHECK_RUN: 'rootcheck:run',
-            RULES_READ: 'rules:read',
-            RULES_UPDATE: 'rules:update',
-            RULES_DELETE: 'rules:delete',
-            SCA_READ: 'sca:read',
-            SECURITY_CREATE_USER: 'security:create_user',
-            SECURITY_CREATE: 'security:create',
-            SECURITY_DELETE: 'security:delete',
-            SECURITY_EDIT_RUN_AS: 'security:edit_run_as',
-            SECURITY_READ_CONFIG: 'security:read_config',
-            SECURITY_READ: 'security:read',
-            SECURITY_REVOKE: 'security:revoke',
-            SECURITY_UPDATE_CONFIG: 'security:update_config',
-            SECURITY_UPDATE: 'security:update',
-            SYSCHECK_CLEAR: 'syscheck:clear',
-            SYSCHECK_READ: 'syscheck:read',
-            SYSCHECK_RUN: 'syscheck:run',
-            SYSCOLLECTOR_READ: 'syscollector:read',
-            TASK_STATUS: 'task:status',
-            VULNERABILITY_READ: 'vulnerability:read',
-        }
+    /**
+     * Returns a valid action string
+     * @param {
+     * "ACTIVE_RESPONSE_COMMAND" |
+     * "AGENT_CREATE" |
+     * "AGENT_DELETE" |
+     * "AGENT_MODIFY_GROUP" |
+     * "AGENT_READ" |
+     * "AGENT_RESTART" |
+     * "AGENT_UPGRADE" |
+     * "CISCAT_READ" |
+     * "CLUSTER_READ_API_CONFIG" |
+     * "CLUSTER_READ" |
+     * "CLUSTER_RESTART" |
+     * "CLUSTER_STATUS" |
+     * "CLUSTER_UPDATE_CONFIG" |
+     * "DECODERS_READ" |
+     * "DECODERS_UPDATE" |
+     * "DECODERS_DELETE" |
+     * "GROUP_CREATE" |
+     * "GROUP_DELETE" |
+     * "GROUP_MODIFY_ASSIGNMENT" |
+     * "GROUP_READ" |
+     * "GROUP_UPDATE_CONFIG" |
+     * "LISTS_READ" |
+     * "LISTS_UPDATE" |
+     * "LISTS_DELETE" |
+     * "LOGTEST_RUN" |
+     * "MANAGER_READ_API_CONFIG" |
+     * "MANAGER_READ" |
+     * "MANAGER_RESTART" |
+     * "MANAGER_UPDATE_CONFIG" |
+     * "MITRE_READ" |
+     * "ROOTCHECK_CLEAR" |
+     * "ROOTCHECK_READ" |
+     * "ROOTCHECK_RUN" |
+     * "RULES_READ" |
+     * "RULES_UPDATE" |
+     * "RULES_DELETE" |
+     * "SCA_READ" |
+     * "SECURITY_CREATE_USER" |
+     * "SECURITY_CREATE" |
+     * "SECURITY_DELETE" |
+     * "SECURITY_EDIT_RUN_AS" |
+     * "SECURITY_READ_CONFIG" |
+     * "SECURITY_READ" |
+     * "SECURITY_REVOKE" |
+     * "SECURITY_UPDATE_CONFIG" |
+     * "SECURITY_UPDATE" |
+     * "SYSCHECK_CLEAR" |
+     * "SYSCHECK_READ" |
+     * "SYSCHECK_RUN" |
+     * "SYSCOLLECTOR_READ" |
+     * "TASK_STATUS" |
+     * "VULNERABILITY_READ"
+     * } action
+     * @returns {string}
+     */
+    const getAction = (action) => {
+      const actionDict = {
+        ACTIVE_RESPONSE_COMMAND: "active-response:command",
+        AGENT_CREATE: "agent:create",
+        AGENT_DELETE: "agent:delete",
+        AGENT_MODIFY_GROUP: "agent:modify_group",
+        AGENT_READ: "agent:read",
+        AGENT_RESTART: "agent:restart",
+        AGENT_UPGRADE: "agent:upgrade",
+        CISCAT_READ: "ciscat:read",
+        CLUSTER_READ_API_CONFIG: "cluster:read_api_config",
+        CLUSTER_READ: "cluster:read",
+        CLUSTER_RESTART: "cluster:restart",
+        CLUSTER_STATUS: "cluster:status",
+        DECODERS_READ: "decoders:read",
+        DECODERS_UPDATE: "decoders:update",
+        DECODERS_DELETE: "decoders:delete",
+        GROUP_CREATE: "group:create",
+        GROUP_DELETE: "group:delete",
+        GROUP_MODIFY_ASSIGNMENT: "group:modify_assignments",
+        GROUP_READ: "group:read",
+        GROUP_UPDATE_CONFIG: "group:update_config",
+        LISTS_READ: "lists:read",
+        LISTS_UPDATE: "lists:update",
+        LISTS_DELETE: "lists:delete",
+        LOGTEST_RUN: "logtest:run",
+        MANAGER_READ_API_CONFIG: "manager:read_api_config",
+        MANAGER_READ: "manager:read",
+        MANAGER_RESTART: "manager:restart",
+        MANAGER_UPDATE_CONFIG: "manager:update_config",
+        MITRE_READ: "mitre:read",
+        ROOTCHECK_CLEAR: "rootcheck:clear",
+        ROOTCHECK_READ: "rootcheck:read",
+        ROOTCHECK_RUN: "rootcheck:run",
+        RULES_READ: "rules:read",
+        RULES_UPDATE: "rules:update",
+        RULES_DELETE: "rules:delete",
+        SCA_READ: "sca:read",
+        SECURITY_CREATE_USER: "security:create_user",
+        SECURITY_CREATE: "security:create",
+        SECURITY_DELETE: "security:delete",
+        SECURITY_EDIT_RUN_AS: "security:edit_run_as",
+        SECURITY_READ_CONFIG: "security:read_config",
+        SECURITY_READ: "security:read",
+        SECURITY_REVOKE: "security:revoke",
+        SECURITY_UPDATE_CONFIG: "security:update_config",
+        SECURITY_UPDATE: "security:update",
+        SYSCHECK_CLEAR: "syscheck:clear",
+        SYSCHECK_READ: "syscheck:read",
+        SYSCHECK_RUN: "syscheck:run",
+        SYSCOLLECTOR_READ: "syscollector:read",
+        TASK_STATUS: "task:status",
+        VULNERABILITY_READ: "vulnerability:read",
+      };
+      if (!(action in actionDict)) {
+        throw "Invalid action";
+      }
+      return actionDict[action];
+    };
 
-        /**
-         * Returns a valid action string
-         * @param {
-         * "ACTIVE_RESPONSE_COMMAND" |
-         * "AGENT_CREATE" |
-         * "AGENT_DELETE" |
-         * "AGENT_MODIFY_GROUP" |
-         * "AGENT_READ" |
-         * "AGENT_RESTART" |
-         * "AGENT_UPGRADE" |
-         * "CISCAT_READ" |
-         * "CLUSTER_READ_API_CONFIG" |
-         * "CLUSTER_READ" |
-         * "CLUSTER_RESTART" |
-         * "CLUSTER_STATUS" |
-         * "CLUSTER_UPDATE_CONFIG" |
-         * "DECODERS_READ" |
-         * "DECODERS_UPDATE" |
-         * "DECODERS_DELETE" |
-         * "GROUP_CREATE" |
-         * "GROUP_DELETE" |
-         * "GROUP_MODIFY_ASSIGNMENT" |
-         * "GROUP_READ" |
-         * "GROUP_UPDATE_CONFIG" |
-         * "LISTS_READ" |
-         * "LISTS_UPDATE" |
-         * "LISTS_DELETE" |
-         * "LOGTEST_RUN" |
-         * "MANAGER_READ_API_CONFIG" |
-         * "MANAGER_READ" |
-         * "MANAGER_RESTART" |
-         * "MANAGER_UPDATE_CONFIG" |
-         * "MITRE_READ" |
-         * "ROOTCHECK_CLEAR" |
-         * "ROOTCHECK_READ" |
-         * "ROOTCHECK_RUN" |
-         * "RULES_READ" |
-         * "RULES_UPDATE" |
-         * "RULES_DELETE" |
-         * "SCA_READ" |
-         * "SECURITY_CREATE_USER" |
-         * "SECURITY_CREATE" |
-         * "SECURITY_DELETE" |
-         * "SECURITY_EDIT_RUN_AS" |
-         * "SECURITY_READ_CONFIG" |
-         * "SECURITY_READ" |
-         * "SECURITY_REVOKE" |
-         * "SECURITY_UPDATE_CONFIG" |
-         * "SECURITY_UPDATE" |
-         * "SYSCHECK_CLEAR" |
-         * "SYSCHECK_READ" |
-         * "SYSCHECK_RUN" |
-         * "SYSCOLLECTOR_READ" |
-         * "TASK_STATUS" |
-         * "VULNERABILITY_READ"
-         * } action 
-         * @returns {string}
-         */
-        const getAction = action => {
-            if (!(action in actionDict)) {
-                throw 'Invalid action'
-            }
-            return actionDict[action]
-        }
-
-        //Dictionary of possible resource keys to be used with each action
-        const actionResourcesDict = {
-            ACTIVE_RESPONSE_COMMAND: ['AGENT_ID', 'AGENT_GROUP'],
-            AGENT_CREATE: ['RESOURCELESS'],
-            AGENT_DELETE: ['AGENT_ID', 'AGENT_GROUP'],
-            AGENT_MODIFY_GROUP: ['AGENT_ID', 'AGENT_GROUP'],
-            AGENT_READ: ['AGENT_ID', 'AGENT_GROUP'],
-            AGENT_RESTART: ['AGENT_ID', 'AGENT_GROUP'],
-            AGENT_UPGRADE: ['AGENT_ID', 'AGENT_GROUP'],
-            CISCAT_READ: ['AGENT_ID', 'AGENT_GROUP'],
-            CLUSTER_READ_API_CONFIG: ['NODE_ID'],
-            CLUSTER_READ: ['NODE_ID'],
-            CLUSTER_RESTART: ['NODE_ID'],
-            CLUSTER_STATUS: ['RESOURCELESS'],
-            DECODERS_READ: ['DECODER_FILE'],
-            DECODERS_UPDATE: ['RESOURCELESS'],
-            DECODERS_DELETE: ['DECODER_FILE'],
-            GROUP_CREATE: ['RESOURCELESS'],
-            GROUP_DELETE: ['GROUP_ID'],
-            GROUP_MODIFY_ASSIGNMENT: ['GROUP_ID'],
-            GROUP_READ: ['GROUP_ID'],
-            GROUP_UPDATE_CONFIG: ['GROUP_ID'],
-            LISTS_READ: ['LIST_FILE'],
-            LISTS_UPDATE: ['RESOURCELESS'],
-            LISTS_DELETE: ['RESOURCELESS'],
-            LOGTEST_RUN: ['RESOURCELESS'],
-            MANAGER_READ_API_CONFIG: ['RESOURCELESS'],
-            MANAGER_READ: ['RESOURCELESS'],
-            MANAGER_RESTART: ['RESOURCELESS'],
-            MANAGER_UPDATE_CONFIG: ['RESOURCELESS'],
-            MITRE_READ: ['RESOURCELESS'],
-            ROOTCHECK_CLEAR: ['AGENT_ID', 'AGENT_GROUP'],
-            ROOTCHECK_READ: ['AGENT_ID', 'AGENT_GROUP'],
-            ROOTCHECK_RUN: ['AGENT_ID', 'AGENT_GROUP'],
-            RULES_READ: ['RULE_FILE'],
-            RULES_UPDATE: ['RESOURCELESS'],
-            RULES_DELETE: ['RULE_FILE'],
-            SCA_READ: ['AGENT_ID', 'AGENT_GROUP'],
-            SECURITY_CREATE_USER: ['RESOURCELESS'],
-            SECURITY_CREATE: ['RESOURCELESS'],
-            SECURITY_DELETE: ['POLICY_ID', 'ROLE_ID', 'RULE_ID', 'USER_ID'],
-            SECURITY_EDIT_RUN_AS: ['RESOURCELESS'],
-            SECURITY_READ_CONFIG: ['RESOURCELESS'],
-            SECURITY_READ: ['POLICY_ID', 'ROLE_ID', 'RULE_ID', 'USER_ID'],
-            SECURITY_REVOKE: ['RESOURCELESS'],
-            SECURITY_UPDATE_CONFIG: ['RESOURCELESS'],
-            SECURITY_UPDATE: ['POLICY_ID', 'ROLE_ID', 'RULE_ID', 'USER_ID'],
-            SYSCHECK_CLEAR: ['AGENT_ID', 'AGENT_GROUP'],
-            SYSCHECK_READ: ['AGENT_ID', 'AGENT_GROUP'],
-            SYSCHECK_RUN: ['AGENT_ID', 'AGENT_GROUP'],
-            SYSCOLLECTOR_READ: ['AGENT_ID', 'AGENT_GROUP'],
-            TASK_STATUS: ['RESOURCELESS'],
-            VULNERABILITY_READ: ['AGENT_ID', 'AGENT_GROUP'],
-        }
-        /**
-         * Returns a valid resource key
-         * @param {
-         * "ACTIVE_RESPONSE_COMMAND" |
-         * "AGENT_CREATE" |
-         * "AGENT_DELETE" |
-         * "AGENT_MODIFY_GROUP" |
-         * "AGENT_READ" |
-         * "AGENT_RESTART" |
-         * "AGENT_UPGRADE" |
-         * "CISCAT_READ" |
-         * "CLUSTER_READ_API_CONFIG" |
-         * "CLUSTER_READ" |
-         * "CLUSTER_RESTART" |
-         * "CLUSTER_STATUS" |
-         * "CLUSTER_UPDATE_CONFIG" |
-         * "DECODERS_READ" |
-         * "DECODERS_UPDATE" |
-         * "DECODERS_DELETE" |
-         * "GROUP_CREATE" |
-         * "GROUP_DELETE" |
-         * "GROUP_MODIFY_ASSIGNMENT" |
-         * "GROUP_READ" |
-         * "GROUP_UPDATE_CONFIG" |
-         * "LISTS_READ" |
-         * "LISTS_UPDATE" |
-         * "LISTS_DELETE" |
-         * "LOGTEST_RUN" |
-         * "MANAGER_READ_API_CONFIG" |
-         * "MANAGER_READ" |
-         * "MANAGER_RESTART" |
-         * "MANAGER_UPDATE_CONFIG" |
-         * "MITRE_READ" |
-         * "ROOTCHECK_CLEAR" |
-         * "ROOTCHECK_READ" |
-         * "ROOTCHECK_RUN" |
-         * "RULES_READ" |
-         * "RULES_UPDATE" |
-         * "RULES_DELETE" |
-         * "SCA_READ" |
-         * "SECURITY_CREATE_USER" |
-         * "SECURITY_CREATE" |
-         * "SECURITY_DELETE" |
-         * "SECURITY_EDIT_RUN_AS" |
-         * "SECURITY_READ_CONFIG" |
-         * "SECURITY_READ" |
-         * "SECURITY_REVOKE" |
-         * "SECURITY_UPDATE_CONFIG" |
-         * "SECURITY_UPDATE" |
-         * "SYSCHECK_CLEAR" |
-         * "SYSCHECK_READ" |
-         * "SYSCHECK_RUN" |
-         * "SYSCOLLECTOR_READ" |
-         * "TASK_STATUS" |
-         * "VULNERABILITY_READ"
-         * } action 
-         * @returns {string}
-         */
-        const getActionResourceKeys = action => {
-            if (!(action in actionResourcesDict)) {
-                throw 'Invalid action'
-            }
-            return actionResourcesDict[action]
-        }
-        return {
-            getAction,
-            getResource,
-            getActionResourceKeys
-        }
-    })
-})
+    /**
+     * Generates an object from an action with the resources used by that action and a method to construct a requirements object for that action
+     * @param {
+     * "ACTIVE_RESPONSE_COMMAND" |
+     * "AGENT_CREATE" |
+     * "AGENT_DELETE" |
+     * "AGENT_MODIFY_GROUP" |
+     * "AGENT_READ" |
+     * "AGENT_RESTART" |
+     * "AGENT_UPGRADE" |
+     * "CISCAT_READ" |
+     * "CLUSTER_READ_API_CONFIG" |
+     * "CLUSTER_READ" |
+     * "CLUSTER_RESTART" |
+     * "CLUSTER_STATUS" |
+     * "DECODERS_READ" |
+     * "DECODERS_UPDATE" |
+     * "DECODERS_DELETE" |
+     * "GROUP_CREATE" |
+     * "GROUP_DELETE" |
+     * "GROUP_MODIFY_ASSIGNMENT" |
+     * "GROUP_READ" |
+     * "GROUP_UPDATE_CONFIG" |
+     * "LISTS_READ" |
+     * "LISTS_UPDATE" |
+     * "LISTS_DELETE" |
+     * "LOGTEST_RUN" |
+     * "MANAGER_READ_API_CONFIG" |
+     * "MANAGER_READ" |
+     * "MANAGER_RESTART" |
+     * "MANAGER_UPDATE_CONFIG" |
+     * "MITRE_READ" |
+     * "ROOTCHECK_CLEAR" |
+     * "ROOTCHECK_READ" |
+     * "ROOTCHECK_RUN" |
+     * "RULES_READ" |
+     * "RULES_UPDATE" |
+     * "RULES_DELETE" |
+     * "SCA_READ" |
+     * "SECURITY_CREATE_USER" |
+     * "SECURITY_CREATE" |
+     * "SECURITY_DELETE_POLICY" |
+     * "SECURITY_DELETE_ROLE" |
+     * "SECURITY_DELETE_POLICY_FROM_ROLE" |
+     * "SECURITY_DELETE_RULE_FROM_ROLE" |
+     * "SECURITY_DELETE_RULE" |
+     * "SECURITY_DELETE_USER" |
+     * "SECURITY_DELETE_RULE_FROM_USER" |
+     * "SECURITY_EDIT_RUN_AS" |
+     * "SECURITY_READ_CONFIG" |
+     * "SECURITY_READ" |
+     * "SECURITY_REVOKE" |
+     * "SECURITY_UPDATE_CONFIG" |
+     * "SECURITY_UPDATE_POLICIES_IN_ROLE" |
+     * "SECURITY_UPDATE_RULES_IN_ROLE" |
+     * "SECURITY_UPDATE_ROLES_IN_USER" |
+     * "SECURITY_UPDATE_POLICY" |
+     * "SECURITY_UPDATE_ROLE" |
+     * "SECURITY_UPDATE_RULE" |
+     * "SECURITY_UPDATE_USER" |
+     * "SYSCHECK_CLEAR" |
+     * "SYSCHECK_READ" |
+     * "SYSCHECK_RUN" |
+     * "SYSCOLLECTOR_READ" |
+     * "TASK_STATUS" |
+     * "VULNERABILITY_READ"
+     * } actionKey
+     * @returns {}
+     */
+    const generateRequirementFactory = (actionKey) => {
+      //Dictionary of possible resource keys to be used with each action
+      const actionResourcesDict = {
+        ACTIVE_RESPONSE_COMMAND: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "ACTIVE_RESPONSE_COMMAND",
+        },
+        AGENT_CREATE: { resources: ["RESOURCELESS"], action: "AGENT_CREATE" },
+        AGENT_DELETE: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "AGENT_DELETE",
+        },
+        AGENT_MODIFY_GROUP: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "AGENT_MODIFY_GROUP",
+        },
+        AGENT_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "AGENT_READ",
+        },
+        AGENT_RESTART: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "AGENT_RESTART",
+        },
+        AGENT_UPGRADE: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "AGENT_UPGRADE",
+        },
+        CISCAT_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "CISCAT_READ",
+        },
+        CLUSTER_READ_API_CONFIG: {
+          resources: ["NODE_ID"],
+          action: "CLUSTER_READ_API_CONFIG",
+        },
+        CLUSTER_READ: { resources: ["NODE_ID"], action: "CLUSTER_READ" },
+        CLUSTER_RESTART: { resources: ["NODE_ID"], action: "CLUSTER_RESTART" },
+        CLUSTER_STATUS: {
+          resources: ["RESOURCELESS"],
+          action: "CLUSTER_STATUS",
+        },
+        DECODERS_READ: { resources: ["DECODER_FILE"], action: "DECODERS_READ" },
+        DECODERS_UPDATE: {
+          resources: ["RESOURCELESS"],
+          action: "DECODERS_UPDATE",
+        },
+        DECODERS_DELETE: {
+          resources: ["DECODER_FILE"],
+          action: "DECODERS_DELETE",
+        },
+        GROUP_CREATE: { resources: ["RESOURCELESS"], action: "GROUP_CREATE" },
+        GROUP_DELETE: { resources: ["GROUP_ID"], action: "GROUP_DELETE" },
+        GROUP_MODIFY_ASSIGNMENT: {
+          resources: ["GROUP_ID"],
+          action: "GROUP_MODIFY_ASSIGNMENT",
+        },
+        GROUP_READ: { resources: ["GROUP_ID"], action: "GROUP_READ" },
+        GROUP_UPDATE_CONFIG: {
+          resources: ["GROUP_ID"],
+          action: "GROUP_UPDATE_CONFIG",
+        },
+        LISTS_READ: { resources: ["LIST_FILE"], action: "LISTS_READ" },
+        LISTS_UPDATE: { resources: ["RESOURCELESS"], action: "LISTS_UPDATE" },
+        LISTS_DELETE: { resources: ["RESOURCELESS"], action: "LISTS_DELETE" },
+        LOGTEST_RUN: { resources: ["RESOURCELESS"], action: "LOGTEST_RUN" },
+        MANAGER_READ_API_CONFIG: {
+          resources: ["RESOURCELESS"],
+          action: "MANAGER_READ_API_CONFIG",
+        },
+        MANAGER_READ: { resources: ["RESOURCELESS"], action: "MANAGER_READ" },
+        MANAGER_RESTART: {
+          resources: ["RESOURCELESS"],
+          action: "MANAGER_RESTART",
+        },
+        MANAGER_UPDATE_CONFIG: {
+          resources: ["RESOURCELESS"],
+          action: "MANAGER_UPDATE_CONFIG",
+        },
+        MITRE_READ: { resources: ["RESOURCELESS"], action: "MITRE_READ" },
+        ROOTCHECK_CLEAR: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "ROOTCHECK_CLEAR",
+        },
+        ROOTCHECK_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "ROOTCHECK_READ",
+        },
+        ROOTCHECK_RUN: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "ROOTCHECK_RUN",
+        },
+        RULES_READ: { resources: ["RULE_FILE"], action: "RULES_READ" },
+        RULES_UPDATE: { resources: ["RESOURCELESS"], action: "RULES_UPDATE" },
+        RULES_DELETE: { resources: ["RULE_FILE"], action: "RULES_DELETE" },
+        SCA_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "SCA_READ",
+        },
+        SECURITY_CREATE_USER: {
+          resources: ["RESOURCELESS"],
+          action: "SECURITY_CREATE_USER",
+        },
+        SECURITY_CREATE: {
+          resources: ["RESOURCELESS"],
+          action: "SECURITY_CREATE",
+        },
+        SECURITY_DELETE_POLICY: {
+          resources: ["POLICY_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_DELETE_ROLE: {
+          resources: ["ROLE_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_DELETE_POLICY_FROM_ROLE: {
+          resources: ["POLICY_ID", "ROLE_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_DELETE_RULE_FROM_ROLE: {
+          resources: ["ROLE_ID", "RULE_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_DELETE_RULE: {
+          resources: ["RULE_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_DELETE_USER: {
+          resources: ["USER_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_DELETE_RULE_FROM_USER: {
+          resources: ["RULE_ID", "USER_ID"],
+          action: "SECURITY_DELETE",
+        },
+        SECURITY_EDIT_RUN_AS: {
+          resources: ["RESOURCELESS"],
+          action: "SECURITY_EDIT_RUN_AS",
+        },
+        SECURITY_READ_CONFIG: {
+          resources: ["RESOURCELESS"],
+          action: "SECURITY_READ_CONFIG",
+        },
+        SECURITY_READ: {
+          resources: ["POLICY_ID", "ROLE_ID", "RULE_ID", "USER_ID"],
+          action: "SECURITY_READ",
+        },
+        SECURITY_REVOKE: {
+          resources: ["RESOURCELESS"],
+          action: "SECURITY_REVOKE",
+        },
+        SECURITY_UPDATE_CONFIG: {
+          resources: ["RESOURCELESS"],
+          action: "SECURITY_UPDATE_CONFIG",
+        },
+        SECURITY_UPDATE_POLICIES_IN_ROLE: {
+          resources: ["POLICY_ID", "ROLE_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SECURITY_UPDATE_RULES_IN_ROLE: {
+          resources: ["ROLE_ID", "RULE_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SECURITY_UPDATE_ROLES_IN_USER: {
+          resources: ["ROLE_ID", "USER_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SECURITY_UPDATE_POLICY: {
+          resources: ["POLICY_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SECURITY_UPDATE_ROLE: {
+          resources: ["ROLE_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SECURITY_UPDATE_RULE: {
+          resources: ["RULE_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SECURITY_UPDATE_USER: {
+          resources: ["USER_ID"],
+          action: "SECURITY_UPDATE",
+        },
+        SYSCHECK_CLEAR: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "SYSCHECK_CLEAR",
+        },
+        SYSCHECK_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "SYSCHECK_READ",
+        },
+        SYSCHECK_RUN: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "SYSCHECK_RUN",
+        },
+        SYSCOLLECTOR_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "SYSCOLLECTOR_READ",
+        },
+        TASK_STATUS: { resources: ["RESOURCELESS"], action: "TASK_STATUS" },
+        VULNERABILITY_READ: {
+          resources: ["AGENT_ID", "AGENT_GROUP"],
+          action: "VULNERABILITY_READ",
+        },
+      };
+      const { action, resources } = actionResourcesDict[actionKey];
+      return {
+        resourceKeys: resources,
+        generateRequirement: (params = []) =>
+          generateRequirement(action, resources, params),
+      };
+    };
+    /**
+     * This function generates a requirement object that may be used with the validation service.
+     * @param {string} action Action key to parse
+     * @param {string[]} resources Array of resource keys
+     * @param {string[]} params Params to complete the resource keys in same order as resources array. A missing element will yield a '*'
+     * @returns
+     */
+    const generateRequirement = (action, resources, params = []) => {
+      const resourcesStr = resources.map((resource, key) =>
+        getResource(resource, params[key])
+      );
+      return { [getAction(action)]: resourcesStr };
+    };
+    return {
+      getAction,
+      getResource,
+      generateRequirement,
+      generateRequirementFactory,
+    };
+  });
+});


### PR DESCRIPTION
This PR creates a requirement service that makes it simpler to generate requirement objects with the appropriate resources.
It contains several dictionaries that contain the information showed in the [RBAC Reference](https://documentation.wazuh.com/current/user-manual/api/rbac/reference.html)

It contains several functions:

- **getAction**: returns an action string given a key
- **getResource**: returns a resource string given a key and optional paramter
- **generateRequirement**: constructs a requirement object given an action key, an array of resource keys and array of parameters
- **generateRequirementFactory**: returns an array of used resource keys and a method to generate a requirement object given an array of parameters based on an action key.

Closes #1159 
### To test

- **Given** the attached patch file is installed using `git apply requirementService.txt` - [requirementService.txt](https://github.com/wazuh/wazuh-splunk/files/7352987/requirementService.txt)
- **When** the browser navigates to Overview Welcome
- **Then** several console logs appear showing several resources and requirement objects