### PR TITLE
1174 [RBAC] Implement auth context login

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -443,7 +443,7 @@ class api(controllers.BaseController):
         kwargs : dict
             Request parameters
         """
-        self.logger.debug("api:is_wazuh_ready()")
+        self.logger.debug("api:is_wazuh_ready() called")
         try:
             # Get current API data
             if not 'apiId' in kwargs:
@@ -929,7 +929,7 @@ class api(controllers.BaseController):
     """
     @expose_page(must_login=False, methods=['GET'])
     def getSyscollector(self, **kwargs):
-        self.logger.debug("api::getSysCollector()")
+        self.logger.debug("api::getSysCollector() called")
         try:
             # Get current API data
             if not 'apiId' in kwargs:

--- a/SplunkAppForWazuh/appserver/controllers/api.py
+++ b/SplunkAppForWazuh/appserver/controllers/api.py
@@ -57,10 +57,10 @@ class api(controllers.BaseController):
             api = self.db.get(the_id)
             api = jsonbak.loads(api)
             if api:
-                opt_username = api['data']["userapi"]
-                opt_password = api['data']["passapi"]
-                opt_base_url = api['data']["url"]
-                opt_base_port = api['data']["portapi"]
+                opt_username = api['data']['userapi']
+                opt_password = api['data']['passapi']
+                opt_base_url = api['data']['url']
+                opt_base_port = api['data']['portapi']
                 url = str(opt_base_url) + ":" + str(opt_base_port)
                 auth = requestsbak.auth.HTTPBasicAuth(
                     opt_username, opt_password)
@@ -87,39 +87,39 @@ class api(controllers.BaseController):
         try:
             self.logger.debug("api: Offuscating keys.")
             hide = "********"
-            if "data" in response and type(response["data"]) == dict:
+            if "data" in response and type(response['data']) == dict:
                 # Remove agent key
-                if "internal_key" in response["data"]:
-                    response["data"]["internal_key"] = hide
+                if "internal_key" in response['data']:
+                    response['data']['internal_key'] = hide
 
                 # Remove cluster key (/come/cluster)
-                if "node_type" in response["data"]:
-                    if "key" in response["data"]:
-                        response["data"]["key"] = hide
+                if "node_type" in response['data']:
+                    if "key" in response['data']:
+                        response['data']['key'] = hide
 
                 # Remove cluster key (/manager/configuration)
-                if "cluster" in response["data"]:
-                    if "node_type" in response["data"]["cluster"]:
-                        if "key" in response["data"]["cluster"]:
-                            response["data"]["cluster"]["key"] = hide
+                if "cluster" in response['data']:
+                    if "node_type" in response['data']['cluster']:
+                        if "key" in response['data']['cluster']:
+                            response['data']['cluster']['key'] = hide
 
                 # Remove AWS keys
-                if "wmodules" in response["data"]:
-                    for wmod in response["data"]["wmodules"]:
+                if "wmodules" in response['data']:
+                    for wmod in response['data']['wmodules']:
                         if "aws-s3" in wmod:
-                            if "buckets" in wmod["aws-s3"]:
-                                for bucket in wmod["aws-s3"]["buckets"]:
-                                    bucket["access_key"] = hide
-                                    bucket["secret_key"] = hide
-                            if "services" in wmod["aws-s3"]:
-                                for service in wmod["aws-s3"]["services"]:
-                                    service["access_key"] = hide
-                                    service["secret_key"] = hide
+                            if "buckets" in wmod['aws-s3']:
+                                for bucket in wmod['aws-s3']['buckets']:
+                                    bucket['access_key'] = hide
+                                    bucket['secret_key'] = hide
+                            if "services" in wmod['aws-s3']:
+                                for service in wmod['aws-s3']['services']:
+                                    service['access_key'] = hide
+                                    service['secret_key'] = hide
 
                 # Remove integrations keys
-                if "integration" in response["data"]:
-                    for integ in response["data"]["integration"]:
-                        integ["api_key"] = hide
+                if "integration" in response['data']:
+                    for integ in response['data']['integration']:
+                        integ['api_key'] = hide
             return response
         except Exception as e:
             self.logger.error(
@@ -314,7 +314,7 @@ class api(controllers.BaseController):
                 del kwargs['method']
             the_id = kwargs['id']
             url, auth, verify, cluster_enabled = self.get_credentials(the_id)
-            opt_endpoint = kwargs["endpoint"]
+            opt_endpoint = kwargs['endpoint']
             del kwargs['id']
             del kwargs['endpoint']
             daemons_ready = self.check_daemons(
@@ -452,7 +452,7 @@ class api(controllers.BaseController):
                 del kwargs['method']
             the_id = kwargs['apiId']
             url, auth, verify, cluster_enabled = self.get_credentials(the_id)
-            opt_endpoint = kwargs["endpoint"]
+            opt_endpoint = kwargs['endpoint']
             del kwargs['apiId']
             del kwargs['endpoint']
             daemons_ready = self.check_daemons(
@@ -516,10 +516,10 @@ class api(controllers.BaseController):
             the_id = kwargs['id']
             api = self.db.get(the_id)
             api = jsonbak.loads(api)
-            opt_username = api["data"]["userapi"]
-            opt_password = api["data"]["passapi"]
-            opt_base_url = api["data"]["url"]
-            opt_base_port = api["data"]["portapi"]
+            opt_username = api['data']['userapi']
+            opt_password = api['data']['passapi']
+            opt_base_url = api['data']['url']
+            opt_base_port = api['data']['portapi']
             opt_endpoint = kwargs['path']
             url = str(opt_base_url) + ":" + str(opt_base_port)
             auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)
@@ -543,7 +543,7 @@ class api(controllers.BaseController):
                 if is_list_export_keys_values:
                     items_list = [
                         {"Key": k, "Value": v}
-                        for k, v in request["data"]["affected_items"][0].items()
+                        for k, v in request['data']['affected_items'][0].items()
                     ]
 
                     dict_writer = csv.DictWriter(
@@ -561,12 +561,12 @@ class api(controllers.BaseController):
                     self.logger.debug("api: CSV file generated.")
                     return csv_result
                 else:
-                    final_obj = request["data"]["affected_items"]
+                    final_obj = request['data']['affected_items']
                 if isinstance(final_obj, list):
                     keys = final_obj[0].keys()
                     self.format_output(keys)
                     final_obj_dict = self.format_output(final_obj)
-                    total_items = request["data"]["total_affected_items"]
+                    total_items = request['data']['total_affected_items']
                     # initializes CSV buffer
                     if total_items > 0:
                         dict_writer = csv.DictWriter(

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -433,9 +433,9 @@ class manager(controllers.BaseController):
         """
         Check API connection BEFORE registration.
 
-        FIXME API registration logic is wrongly done on the frontend. The 
+        FIXME API registration logic is wrongly done on the frontend. The
         registration process takes 2 steps guided by the frontend:
-            - 1. This endpoint is accessed to check API connectivity. 
+            - 1. This endpoint is accessed to check API connectivity.
                  Full API info is sent.
             - 2. If the connection was successful (checked on the frontend),
                  then the frontend sends another request to register the API
@@ -513,7 +513,7 @@ class manager(controllers.BaseController):
             current_api_json = jsonbak.loads(self.db.get(api_id))["data"]
 
             output = self.get_cluster_info(current_api_json)
-            
+
             # Hide API password
             del current_api_json["passapi"]
             output["api"] = {"data": current_api_json}
@@ -541,7 +541,7 @@ class manager(controllers.BaseController):
             current_api_json = jsonbak.loads(self.db.get(api_id))["data"]
         except Exception as e:
             self.logger.error(str(e))
-        
+
         opt_username = str(current_api_json["userapi"])
         opt_password = str(current_api_json["passapi"])
         opt_base_url = str(current_api_json["url"])
@@ -602,7 +602,6 @@ class manager(controllers.BaseController):
     # ------------------------------------------------------------ #
     #   Utility methods
     # ------------------------------------------------------------ #
-
 
     def get_cluster_info(self, current_api):
         """
@@ -671,7 +670,7 @@ class manager(controllers.BaseController):
             The request's parameters
         """
         self.logger.debug("manager::check_wazuh_version()")
-        
+
         opt_username = str(current_api["userapi"])
         opt_password = str(current_api["passapi"])
         opt_base_url = str(current_api["url"])
@@ -713,7 +712,7 @@ class manager(controllers.BaseController):
 
     def check_daemons(self, current_api):
         """
-        Request to check the status of this daemons: 
+        Request to check the status of this daemons:
         execd, modulesd, wazuhdb and clusterd
 
         Parameters
@@ -722,7 +721,7 @@ class manager(controllers.BaseController):
             API object
         """
         self.logger.debug("manager: Checking Wazuh daemons.")
-        
+
         opt_username = str(current_api["userapi"])
         opt_password = str(current_api["passapi"])
         opt_base_url = str(current_api["url"])
@@ -747,7 +746,7 @@ class manager(controllers.BaseController):
             except Exception as e:
                 cluster_enabled = False
             # Var to check the cluster demon or not
-            cc = check_cluster and cluster_enabled  
+            cc = check_cluster and cluster_enabled
             opt_endpoint = "/manager/status"
             daemons_status = self.session.get(
                 url + opt_endpoint,

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -304,7 +304,6 @@ class manager(controllers.BaseController):
         try:
             self.logger.debug("manager: Getting API list.")
             apis = self.db.all()
-            self.logger.debug(apis)
             parsed_apis = jsonbak.loads(apis)
             # Remove the password from the list of apis
             for api in parsed_apis:
@@ -450,7 +449,7 @@ class manager(controllers.BaseController):
             pass: str: API user password.
             cluster: str: true or false
         """
-        self.logger.debug("manager::check_connection()")
+        self.logger.debug("manager::check_connection() called")
 
         try:
             # runAs is not given as a parameter but accesed by the auxiliary
@@ -504,7 +503,7 @@ class manager(controllers.BaseController):
         kwargs : dict
             The request's parameters
         """
-        self.logger.debug("manager::check_connection_by_id()")
+        self.logger.debug("manager::check_connection_by_id() called")
         try:
             # Get current API data
             if not 'apiId' in kwargs:
@@ -606,7 +605,7 @@ class manager(controllers.BaseController):
         """
         Get info about the cluster.
         """
-        self.logger.debug("manager::get_cluster_info()")
+        self.logger.debug("manager::get_cluster_info() called")
 
         opt_username = str(current_api['userapi'])
         opt_password = str(current_api['passapi'])
@@ -668,7 +667,7 @@ class manager(controllers.BaseController):
         kwargs : dict
             The request's parameters
         """
-        self.logger.debug("manager::check_wazuh_version()")
+        self.logger.debug("manager::check_wazuh_version() called")
 
         opt_username = str(current_api['userapi'])
         opt_password = str(current_api['passapi'])

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -29,7 +29,7 @@ from wazuhtoken import wazuhtoken
 
 from . import api
 
-splunk_home = os.path.normpath(os.environ["SPLUNK_HOME"])
+splunk_home = os.path.normpath(os.environ['SPLUNK_HOME'])
 
 
 def getLocalConfPath(file):
@@ -309,7 +309,7 @@ class manager(controllers.BaseController):
             # Remove the password from the list of apis
             for api in parsed_apis:
                 if "passapi" in api:
-                    del api["passapi"]
+                    del api['passapi']
             result = jsonbak.dumps(parsed_apis)
         except Exception as e:
             self.logger.error(jsonbak.dumps({"error": str(e)}))
@@ -382,11 +382,11 @@ class manager(controllers.BaseController):
             if '_user' in kwargs:
                 del kwargs['_user']
             if not "passapi" in entry:
-                opt_id = entry["_key"]
+                opt_id = entry['_key']
                 data_temp = self.db.get(opt_id)
                 current_api = jsonbak.loads(data_temp)
-                current_api = current_api["data"]
-                entry["passapi"] = current_api["passapi"]
+                current_api = current_api['data']
+                entry['passapi'] = current_api['passapi']
             keys_list = ['_key', 'url', 'portapi', 'userapi', 'passapi',
                          'filterName', 'filterType', 'managerName', 'runAs']
             if set(entry.keys()) == set(keys_list):
@@ -456,11 +456,11 @@ class manager(controllers.BaseController):
             # runAs is not given as a parameter but accesed by the auxiliary
             # methods, thus why we set it to False.
             api = {
-                "userapi": str(kwargs["user"]),
-                "passapi": str(kwargs["pass"]),
-                "url": str(kwargs["ip"]),
-                "portapi": str(kwargs["port"]),
-                "cluster": str(kwargs["cluster"]) == "true",
+                "userapi": str(kwargs['user']),
+                "passapi": str(kwargs['pass']),
+                "url": str(kwargs['ip']),
+                "portapi": str(kwargs['port']),
+                "cluster": str(kwargs['cluster']) == "true",
                 "runAs": False
             }
         except KeyError as e:
@@ -509,14 +509,14 @@ class manager(controllers.BaseController):
             # Get current API data
             if not 'apiId' in kwargs:
                 raise Exception("Missing API Key")
-            api_id = kwargs["apiId"]
-            current_api_json = jsonbak.loads(self.db.get(api_id))["data"]
+            api_id = kwargs['apiId']
+            current_api_json = jsonbak.loads(self.db.get(api_id))['data']
 
             output = self.get_cluster_info(current_api_json)
 
             # Hide API password
-            del current_api_json["passapi"]
-            output["api"] = {"data": current_api_json}
+            del current_api_json['passapi']
+            output['api'] = {"data": current_api_json}
             result = jsonbak.dumps(output)
         except KeyError as e:
             self.logger.error(f"KeyError {e}")
@@ -537,16 +537,16 @@ class manager(controllers.BaseController):
             # Get current API data
             if not 'apiId' in kwargs:
                 raise Exception("Missing API Key")
-            api_id = kwargs["apiId"]
-            current_api_json = jsonbak.loads(self.db.get(api_id))["data"]
+            api_id = kwargs['apiId']
+            current_api_json = jsonbak.loads(self.db.get(api_id))['data']
         except Exception as e:
             self.logger.error(str(e))
 
-        opt_username = str(current_api_json["userapi"])
-        opt_password = str(current_api_json["passapi"])
-        opt_base_url = str(current_api_json["url"])
-        opt_base_port = str(current_api_json["portapi"])
-        api_run_as = str(current_api_json["runAs"])
+        opt_username = str(current_api_json['userapi'])
+        opt_password = str(current_api_json['passapi'])
+        opt_base_url = str(current_api_json['url'])
+        opt_base_port = str(current_api_json['portapi'])
+        api_run_as = str(current_api_json['runAs'])
 
         # API requests auth
         auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)
@@ -555,11 +555,11 @@ class manager(controllers.BaseController):
 
         try:
             # Get file name and file content
-            file_info = kwargs["file"].__dict__
+            file_info = kwargs['file'].__dict__
             file_name = file_info['filename']
             file_content = kwargs['file'].file
             # Get path
-            dest_resource = kwargs["resource"]
+            dest_resource = kwargs['resource']
 
             response = self.session.put(
                 url + '/' + dest_resource + '/files/' + file_name,
@@ -580,7 +580,7 @@ class manager(controllers.BaseController):
                 return jsonbak.dumps(
                     {
                         "status": "400",
-                        "text": "Error adding file: %s. Cause: %s" % (file_name, result["detail"])
+                        "text": "Error adding file: %s. Cause: %s" % (file_name, result['detail'])
                     }
                 )
             return jsonbak.dumps(
@@ -609,10 +609,10 @@ class manager(controllers.BaseController):
         """
         self.logger.debug("manager::get_cluster_info()")
 
-        opt_username = str(current_api["userapi"])
-        opt_password = str(current_api["passapi"])
-        opt_base_url = str(current_api["url"])
-        opt_base_port = str(current_api["portapi"])
+        opt_username = str(current_api['userapi'])
+        opt_password = str(current_api['passapi'])
+        opt_base_url = str(current_api['url'])
+        opt_base_port = str(current_api['portapi'])
 
         url = opt_base_url + ":" + opt_base_port
         auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)
@@ -650,8 +650,8 @@ class manager(controllers.BaseController):
             self.logger.error("manager: Cannot connect to API : %s" % (e))
             return Exception("Unreachable API, please check the URL and port.")
         # Checks if daemons are up and running
-        if "error" in request_manager and request_manager["error"] != 0:
-            raise Exception(request_manager["message"])
+        if "error" in request_manager and request_manager['error'] != 0:
+            raise Exception(request_manager['message'])
         output = {}
         output['managerName'] = {
             'name': request_manager['data']['affected_items'][0]['name']
@@ -671,11 +671,11 @@ class manager(controllers.BaseController):
         """
         self.logger.debug("manager::check_wazuh_version()")
 
-        opt_username = str(current_api["userapi"])
-        opt_password = str(current_api["passapi"])
-        opt_base_url = str(current_api["url"])
-        opt_base_port = str(current_api["portapi"])
-        api_run_as = str(current_api["runAs"])
+        opt_username = str(current_api['userapi'])
+        opt_password = str(current_api['passapi'])
+        opt_base_url = str(current_api['url'])
+        opt_base_port = str(current_api['portapi'])
+        api_run_as = str(current_api['runAs'])
 
         url = opt_base_url + ":" + opt_base_port
         auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)
@@ -722,12 +722,12 @@ class manager(controllers.BaseController):
         """
         self.logger.debug("manager: Checking Wazuh daemons.")
 
-        opt_username = str(current_api["userapi"])
-        opt_password = str(current_api["passapi"])
-        opt_base_url = str(current_api["url"])
-        opt_base_port = str(current_api["portapi"])
-        api_run_as = str(current_api["runAs"])
-        check_cluster = str(current_api["cluster"]) == "true"
+        opt_username = str(current_api['userapi'])
+        opt_password = str(current_api['passapi'])
+        opt_base_url = str(current_api['url'])
+        opt_base_port = str(current_api['portapi'])
+        api_run_as = str(current_api['runAs'])
+        check_cluster = str(current_api['cluster']) == "true"
 
         url = opt_base_url + ":" + opt_base_port
         auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)

--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -13,6 +13,7 @@ Find more information about this on the LICENSE file.
 """
 
 
+import json
 import os
 
 import jsonbak
@@ -374,10 +375,11 @@ class manager(controllers.BaseController):
         kwargs : dict
             The request's parameters
         """
+        self.logger.debug("manager::update_api() called")
         try:
-            self.logger.debug("manager: Updating API information.")
             entry = kwargs
-            self.logger.debug(entry)
+            self.logger.debug(f'''manager: Updating API information
+                {json.dumps(entry, indent=4)}''')
             if '_user' in kwargs:
                 del kwargs['_user']
             if not "passapi" in entry:

--- a/SplunkAppForWazuh/appserver/controllers/users.py
+++ b/SplunkAppForWazuh/appserver/controllers/users.py
@@ -71,8 +71,8 @@ class Users(controllers.BaseController):
         """
         Returns the user logged in.
         """
+        self.logger.debug("Users::get_current_user() called")
         try:
-            self.logger.debug("Users: get_current_user()")
             user = splunk_auth.getCurrentUser()
             return json.dumps(user)
         except Exception as e:
@@ -84,8 +84,8 @@ class Users(controllers.BaseController):
         """
         Returns a list with every user registered in this Splunk's instance.
         """
+        self.logger.debug("Users::get_users() called")
         try:
-            self.logger.debug("Users: get_users()")
             # The method listUsers() returns an EntityCollection object, which 
             # is not JSON serializable. The string representation does not match
             # a JSON representation neither, so a few fixes must be done first.

--- a/SplunkAppForWazuh/bin/get_agents_status.py
+++ b/SplunkAppForWazuh/bin/get_agents_status.py
@@ -63,7 +63,7 @@ def check_status():
             agent_list = {}
             url = str(opt_base_url) + ":" + str(opt_base_port)
             auth = requestsbak.auth.HTTPBasicAuth(opt_username, opt_password)
-            wazuh_token = wztoken.get_auth_token(url, auth)
+            wazuh_token = wztoken.get_auth_token(url, auth, api)
             verify = False
             agents_url_total_items = url + '/agents?limit=1&q=id!=000'
             try:

--- a/SplunkAppForWazuh/bin/log.py
+++ b/SplunkAppForWazuh/bin/log.py
@@ -48,7 +48,7 @@ class log():
                     backupCount=50
                 )
                 self.formatter = logging.Formatter(
-                    "%(levelname)s: %(asctime)s: '%(message)s'", "%Y/%m/%d %H:%M:%S")                    
+                    "%(levelname)s: %(asctime)s: '%(message)s'", "%Y/%m/%d %H:%M:%S")
                 self.file_handler.setFormatter(self.formatter)
                 self.logger.addHandler(self.file_handler)
                 loggers['splunk.appserver.%s.controllers.logs' %
@@ -74,7 +74,8 @@ class log():
     def get_last_log_lines(self, lines):
         """Return the last logs messages."""
         try:
-            current_tail = tailer.tail(open(make_splunkhome_path(['var', 'log', 'splunk', 'SplunkAppForWazuh.log'])), lines)
+            current_tail = tailer.tail(open(make_splunkhome_path(
+                ['var', 'log', 'splunk', 'SplunkAppForWazuh.log'])), lines)
             result = list(reversed(current_tail))
         except Exception as e:
             self.error('[log.py][get_last_log_lines] %s' % (e))
@@ -86,5 +87,6 @@ class log():
             config = cli.getConfStanza("config", "configuration")
             return config
         except Exception as e:
-            self.logger.error("log: Error getting the configuration on memory: %s" % (e))
+            self.logger.error(
+                "log: Error getting the configuration on memory: %s" % (e))
             raise e

--- a/SplunkAppForWazuh/bin/log.py
+++ b/SplunkAppForWazuh/bin/log.py
@@ -13,9 +13,10 @@ Find more information about this on the LICENSE file.
 """
 
 import logging
+
 from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
 from splunk.clilib import cli_common as cli
-# sys.path.insert(0, os.path.join(os.path.dirname(__file__), "."))
+
 import tailer
 
 _APPNAME = 'SplunkAppForWazuh'

--- a/SplunkAppForWazuh/bin/wazuhtoken.py
+++ b/SplunkAppForWazuh/bin/wazuhtoken.py
@@ -35,7 +35,7 @@ class wazuhtoken():
             self.logger.error(
                 "wazuh-token: error in the constructor: %s" % (e))
 
-    def get_auth_token(self, api_url, api_user):
+    def get_auth_token(self, api_url, api_user, api_object: dict = None):
         """
         Fetches a new authorization token for the given manager API and API user.
         The token can be obtained from the session cache or he Wazuh Manager API.
@@ -46,6 +46,13 @@ class wazuhtoken():
         :return: String with the authorization token from the Wazuh API
         """
         token_key = f'token-{api_url}-{api_user}'
+        
+        self.logger.debug("wazuhtoken::get_auth_token()")
+        if api_object is None:
+            self.logger.debug("Missing API object")
+        else:
+            self.logger.debug(f"wazuhtoken: {api_object}")
+
         try:
             # Return cached token, if it exists
             auth_token = self.cache.get(token_key)

--- a/SplunkAppForWazuh/default/config.conf
+++ b/SplunkAppForWazuh/default/config.conf
@@ -16,5 +16,5 @@ reporting = true
 
 [configuration]
 admin = true
-log.level = info
+log.level = debug
 timeout = 20


### PR DESCRIPTION
closes #1174

This PR provides a second login method for the users, by using an [authorization context](https://documentation.wazuh.com/current/user-manual/api/rbac/auth-context.html).

The user's token provided by the Wazuh API is managed by the Python backend on the Splunk's App. By default, the [auth context login](https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.run_as_login) is prefered, and if it fails, a basic login is performed instead.

The authorization context provided to the Wazuh API is the internal Splunk's username, as follows:

```json
{
    "username": "admin"
}
```

## Testing
Proper testing must be done with the integration of the Security section.

As for now:

1. (Optional) Set the log level to `debug`, either on `Settings < Configuration` or directly on the `config.conf` file. Indexer restart is required.
2. Open and watch the log file: `docker-compose exec -u root indexer tail -f /opt/splunk/var/log/splunk/SplunkAppForWazuh.log`
3. Navigate through the app and check for errors on the logs.

The step 1 can be ignored as the last commit mistakenly included the debug log level. This is to be fixed later.