### PR TITLE
Add the configured timeout to the API's requests

### DIFF
--- a/SplunkAppForWazuh/bin/wazuh_api.py
+++ b/SplunkAppForWazuh/bin/wazuh_api.py
@@ -35,6 +35,7 @@ class Wazuh_API():
             self.wztoken = wazuhtoken()
             self.session = requests.Session()
             self.session.trust_env = False
+            self.timeout = int(self.config['timeout'])
         except Exception as e:
             self.logger.error(
                 "wazuh-api: error in the constructor: %s" % (e))
@@ -126,6 +127,7 @@ class Wazuh_API():
                             headers={
                                 'Authorization': f'Bearer {wazuh_token}'
                             },
+                            timeout=self.timeout,
                             verify=False
                         ).content
                         # FIXME dumps + loads ???
@@ -144,6 +146,7 @@ class Wazuh_API():
                             headers={
                                 'Authorization': f'Bearer {wazuh_token}'
                             },
+                            timeout=self.timeout,
                             verify=False
                         )
                         response = {
@@ -163,6 +166,7 @@ class Wazuh_API():
                         headers={
                             'Authorization': f'Bearer {wazuh_token}'
                         },
+                        timeout=self.timeout,
                         verify=False
                     )
                     response = catch_exceptions(response)
@@ -188,6 +192,7 @@ class Wazuh_API():
                     response = self.session.post(
                         url=current_api.get_url() + endpoint_url,
                         data=kwargs,
+                        timeout=self.timeout,
                         verify=False,
                         headers=headers
                     )
@@ -199,6 +204,7 @@ class Wazuh_API():
                         headers={
                             'Authorization': f'Bearer {wazuh_token}'
                         },
+                        timeout=self.timeout,
                         verify=False
                     )
                     response = catch_exceptions(response)
@@ -225,6 +231,7 @@ class Wazuh_API():
                         url=current_api.get_url() + endpoint_url,
                         data=kwargs,
                         verify=False,
+                        timeout=self.timeout,
                         headers=headers
                     )
                     response = catch_exceptions(response)
@@ -236,6 +243,7 @@ class Wazuh_API():
                         headers={
                             'Authorization': f'Bearer {wazuh_token}'
                         },
+                        timeout=self.timeout,
                         verify=False
                     )
                     response = catch_exceptions(response)
@@ -247,6 +255,7 @@ class Wazuh_API():
                         headers={
                             'Authorization': f'Bearer {wazuh_token}'
                         },
+                        timeout=self.timeout,
                         verify=False
                     )
                     response = catch_exceptions(response)
@@ -258,6 +267,7 @@ class Wazuh_API():
                     headers={
                         'Authorization': f'Bearer {wazuh_token}'
                     },
+                    timeout=self.timeout,
                     verify=False
                 )
                 response = catch_exceptions(response)

--- a/SplunkAppForWazuh/bin/wazuhtoken.py
+++ b/SplunkAppForWazuh/bin/wazuhtoken.py
@@ -38,6 +38,7 @@ class wazuhtoken():
             self.session.trust_env = False
             self.cache = cache()
             self.__refresh = False
+            self.timeout = int(self.config['timeout'])
 
             self.api = API_model()
         except Exception as e:
@@ -147,7 +148,7 @@ class wazuhtoken():
             return self.session.get(
                 f"{self.api.get_url()}/security/user/authenticate",
                 auth=self.api.get_auth(),
-                timeout=20,
+                timeout=self.timeout,
                 verify=False
             )
         except Exception as e:
@@ -178,7 +179,7 @@ class wazuhtoken():
                 f"{self.api.get_url()}/security/user/authenticate/run_as",
                 auth=self.api.get_auth(),
                 json=auth_context,
-                timeout=20,
+                timeout=self.timeout,
                 verify=False
             )
         except Exception as e:


### PR DESCRIPTION
Solves an issue where the configured timeout was not taken into account when building requests towards the Wazuh API.

- [ ] Needs an entry on the CHANGELOG.md