### PR TITLE
Switch restart

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/status/status.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/status/status.html
@@ -49,7 +49,7 @@
         class='btn wz-button-cancel pull-right wz-margin-left-10'>
         <span><i aria-hidden='true' class='wz-margin-left-10'></i>Cancel</span>
       </button>
-      <button style="height: 30px;" ng-if="clusterEnabled ? canRestartCluster : canRestartManager" ng-click="restart(); switchRestart()"
+      <button style="height: 30px;" ng-if="clusterEnabled ? canRestartCluster : canRestartManager" ng-click="restart()"
         class='btn wz-button-empty pull-right wz-margin-left-10'>
         <span><i aria-hidden='true' class='fa fa-fw fa-check wz-margin-left-10'></i>Confirm</span>
       </button>


### PR DESCRIPTION
**Description:**

Restart manager options still displayed after the restarting of the manager process ended

**Resolve:**

Removed one of the functions that was executed when clicking commit

**Test:**

Navigate to management/status
Click on the restart manager option
Click on Confirm button

**Close:** 

[1202](https://github.com/wazuh/wazuh-splunk/issues/1202)