### PR TITLE
Agent count are not centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
+- fixed centering of agent counters [#1215](https://github.com/wazuh/wazuh-splunk/pull/1215)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
@@ -36,7 +36,7 @@
                 <div class="euiText euiText--small euiStat__description">
                   <p>Active</p>
                 </div>
-                <p class="euiTitle euiTitle--small euiStat__title">{{agentsCountActive}}</p>
+                <p class="euiTitle euiTitle--small euiStat__title wz-text-align-center">{{agentsCountActive}}</p>
               </div>
             </div>
             <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -45,7 +45,7 @@
                 <div class="euiText euiText--small euiStat__description">
                   <p>Disconnected</p>
                 </div>
-                <p class="euiTitle euiTitle--small euiStat__title">{{agentsCountDisconnected}}</p>
+                <p class="euiTitle euiTitle--small euiStat__title wz-text-align-center">{{agentsCountDisconnected}}</p>
               </div>
             </div>
             <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -54,7 +54,7 @@
                 <div class="euiText euiText--small euiStat__description">
                   <p>Never connected</p>
                 </div>
-                <p class="euiTitle euiTitle--small euiStat__title">{{agentsCountNeverConnected}}</p>
+                <p class="euiTitle euiTitle--small euiStat__title wz-text-align-center">{{agentsCountNeverConnected}}</p>
               </div>
             </div>
             <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -63,7 +63,7 @@
                 <div class="euiText euiText--small euiStat__description">
                   <p>Agents coverage</p>
                 </div>
-                <p class="euiTitle euiTitle--small euiStat__title">{{(agentsCoverity | number:2)}}%</p>
+                <p class="euiTitle euiTitle--small euiStat__title wz-text-align-center">{{(agentsCoverity | number:2)}}%</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
**Description:**

On the agent page the numbers of connect/disconnect/never-connected agents are not displayed at the center of the label


**Resolve**:

added class wz-text-align-center in counter

**Test**:

Navigate to Agents

**Close**:

[1195](https://github.com/wazuh/wazuh-splunk/issues/1195)

![image](https://user-images.githubusercontent.com/63758389/151216905-e0be4caf-4014-4329-90b8-6d7310c049f4.png)
