### PR TITLE
Read only create new agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
+- Fixed being able to add an agent without create permissions [#1216](https://github.com/wazuh/wazuh-splunk/pull/1216)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
@@ -125,6 +125,7 @@
     <md-card class="wz-md-card wz-margin-top-15">
       <!-- Table -->
       <md-card-actions layout="row" layout-align="start center"
+        ng-if='canAddAgents'
         class="layout-align-start-center layout-row wz-card-actions wz-card-actions-top md-actions-ruleset">
         <a class="cursor-pointer green-href" ng-click="addNewAgent()">Add new agent</a>
       </md-card-actions>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
@@ -178,6 +178,7 @@ define([
         "AGENT_ID",
         "AGENT_GROUP",
       ]);
+      this.scope.canAddAgents = this.isAllowed('AGENT_CREATE', ['RESOURCELESS'])
 
       this.scope.expandChartAgent = false;
       this.scope.$applyAsync();


### PR DESCRIPTION
**Description:**

Users that have read-only access can access to "Add new agent option"

**Resolve:**

add create agent check

**Test:**

Preconditions: Log with a user that has read-only access

1. Go to the Agent page

**Close:**

[1193](https://github.com/wazuh/wazuh-splunk/issues/1193)

**Screenshot:**

User with `agent:create`
![image](https://user-images.githubusercontent.com/63758389/151225782-c4ebf7c0-4d7e-4746-a503-2b2c49d8b2b8.png)

User without `agent:create`
![image](https://user-images.githubusercontent.com/63758389/151225907-48b599dd-b088-4959-85c8-fdbba46baa35.png)
