### PR TITLE
Add margin-top to security options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
-- fixed overlapping security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
+- Fixed overlapping security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
+- fixed overlapping security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
-- Fixed overlapping security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
+- Fixed the underlapping navigation bar for Security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/css/styles/component.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/component.css
@@ -430,6 +430,10 @@ border-bottom: 1px solid;
   margin-right: 10px;
 }
 
+.wz-margin-top-10 {
+  margin-top: 10px;
+}
+
 .euiButtonIcon--primary {
   color: rgba(34, 129, 55, 0.767);
 }

--- a/SplunkAppForWazuh/appserver/static/css/styles/component.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/component.css
@@ -430,10 +430,6 @@ border-bottom: 1px solid;
   margin-right: 10px;
 }
 
-.wz-margin-top-10 {
-  margin-top: 10px;
-}
-
 .euiButtonIcon--primary {
   color: rgba(34, 129, 55, 0.767);
 }

--- a/SplunkAppForWazuh/appserver/static/js/controllers/security/main/security.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/security/main/security.html
@@ -8,7 +8,7 @@
       nav-bar-aria-label="Security navigation links">
 
       <md-nav-item 
-        class="wz-nav-item" 
+        class="wz-nav-item wz-margin-top-10" 
         ui-sref='security.users' 
         md-nav-click="switchTab('users')" 
         name="users">
@@ -16,7 +16,7 @@
       </md-nav-item>
 
       <md-nav-item 
-        class="wz-nav-item" 
+        class="wz-nav-item wz-margin-top-10" 
         ui-sref='security.roles' 
         md-nav-click="switchTab('roles')" 
         name="roles">
@@ -24,7 +24,7 @@
       </md-nav-item>
 
       <md-nav-item 
-        class="wz-nav-item" 
+        class="wz-nav-item wz-margin-top-10" 
         ui-sref='security.policies' 
         md-nav-click="switchTab('policies')" 
         name="policies">
@@ -32,7 +32,7 @@
       </md-nav-item>
 
       <md-nav-item 
-        class="wz-nav-item" 
+        class="wz-nav-item wz-margin-top-10" 
         ui-sref='security.roles-mapping' 
         md-nav-click="switchTab('roles-mapping')"
         name="roles-mapping">


### PR DESCRIPTION
**Description:**

The background of Splunk headers is overlapping with the security options

**Resolve:**

added class `wz-margin-top-10` to security options

**Test:**

Navigates to security option

**Close:**

[1190](https://github.com/wazuh/wazuh-splunk/issues/1190)

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/151231115-5164139f-8967-4bb1-8145-fdbf5abb5b03.png)
