### PR TITLE
Added condition for destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
+- Fixed console error when agents view is re-initialized [#1223](https://github.com/wazuh/wazuh-splunk/pull/1223)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
@@ -199,7 +199,7 @@ define([
       this.scope.versionModel = 'all'
       this.scope.downloadCsv = () => this.downloadCsv()
       this.scope.$on('$destroy', () => {
-        this.linearChartAgent.destroy();
+        this.linearChartAgent && this.linearChartAgent.destroy();
         this.topAgent.destroy()
       })
       this.scope.reloadList = () => this.reloadList()


### PR DESCRIPTION
**Descriptionv**

Using an user with no permissions to enter the Agents section produces an error on the controller. There is already a component with such DOM element's ID.

**Resolve:**

Added destroy if `this.linearChartAgent` exists to call `this.linearChartAgent.destroy()`, which did not allow doing `this.topAgent.destroy()`

**Steps to reproduce**
Using RBAC and an user with no agents:read permissions:

1.Open the browser's Dev Tools (F12) and Console
2.Go to 'Agents' view
3.The App is hidden (Ok)
4.Navigate out of Agents and then back in.
5.See that no error appears

**Close:**

searchTopAgent component failes to be re-initiailized [#1222](https://github.com/wazuh/wazuh-splunk/issues/1222)

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/151428586-46f34a04-eb07-4034-889c-f2b5e2734799.png)
![image](https://user-images.githubusercontent.com/63758389/151428617-f8e1c5de-03f7-42a7-a44d-7aab53d1ce30.png)
![image](https://user-images.githubusercontent.com/63758389/151428642-eeaef809-88cd-4016-958e-b40f45b5b4a5.png)
