### PR TITLE
fix(security_service.js): console log removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
-- Fixed console.log() appearing in console [#1224](https://github.com/wazuh/wazuh-splunk/pull/1224)
 - Fixed the underlapping navigation bar for Security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
+- Fixed console.log() appearing in console [#1224](https://github.com/wazuh/wazuh-splunk/pull/1224)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/services/security_services/security_service.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/security_services/security_service.js
@@ -38,7 +38,7 @@ define(
         this.userPermissions = userPermissions
         // TODO delete me
         this.getUserPolicies()
-          .then(data => { console.log(data); this.userPolicies = data })
+          .then(data => this.userPolicies = data)
       }
 
       /**

--- a/SplunkAppForWazuh/appserver/static/js/services/security_services/security_service.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/security_services/security_service.js
@@ -36,9 +36,6 @@ define(
         this.$requirementService = $requirementService
         this.$validationService = $validationService
         this.userPermissions = userPermissions
-        // TODO delete me
-        this.getUserPolicies()
-          .then(data => this.userPolicies = data)
       }
 
       /**


### PR DESCRIPTION
**Description**

Console log has not been removed

**Resolve:**

The console log that was in security_service was deleted

**Steps to reproduce**

1.Got to Splunk's main page
2.Open the Dev Tools (F12) console
3.Click on the Wazuh plugin
4.See that console.log() doesnt appear in the console

**Close:**

Console log has not been removed [#1221](https://github.com/wazuh/wazuh-splunk/issues/1221)

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/151433279-a6d3f7e0-cc3a-4655-b66a-faf27cb64dd1.png)

