### PR TITLE
Ensure backwards compatibility (alias & run_as)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 
 - Support for Wazuh 4.3.0
 - Added Alias field to API to facilitate distinguishing between different managers [#1166](https://github.com/wazuh/wazuh-splunk/pull/1166)
+- Ensure backwards compatibility [#1126](https://github.com/wazuh/wazuh-splunk/pull/1226)
 - Added a Security Section to manage security related configurations [#1148](https://github.com/wazuh/wazuh-splunk/issues/1148)
 - Added Crud Policies on security section. [#1171](https://github.com/wazuh/wazuh-splunk/pull/1171)
 - Added Crud Roles on security section. [#1168](https://github.com/wazuh/wazuh-splunk/pull/1168)

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.js
@@ -77,25 +77,11 @@ define([
           setTimeout(() => document.body.removeChild(overlay), 100);
         };
 
-          $scope.openModal = () => {
-            const modal = document.getElementById('quick-settings-modal');
-            const overlay = document.createElement('div');
-            overlay.id = 'quick-settings-overlay';
-            document.body.appendChild(overlay);
-            overlay.classList.add('modal-backdrop', 'fade');
-            overlay.onclick = () => $scope.closeModal();
-            setTimeout(() => {
-              overlay.classList.add('in')
-              modal.classList.remove('fade')
-              modal.classList.replace('hide', 'show');
-            }, 100);
-          }
+        let dropdownAPI;
+        let dropdownIndex;
+        let dropdownSourceType;
 
-          let dropdownAPI;
-          let dropdownIndex;
-          let dropdownSourceType;
-  
-          let onChangeListeners = [];
+        let onChangeListeners = [];
 
         const onChangeDropdownAPI = () => {
           onChangeListeners.push(

--- a/SplunkAppForWazuh/bin/get_api_by_id.py
+++ b/SplunkAppForWazuh/bin/get_api_by_id.py
@@ -32,16 +32,12 @@ def get_api_by_id(id: int):
         api_as_json = json.loads(db.get(id))['data']
 
         # Ensure backwards compatibility (add the new fields to the registries)
-        if not 'runAs' in api_as_json:
-            api_as_json['runAs'] = False
+        if not 'runAs' in api_as_json or not 'alias' in api_as_json:
+            if not 'runAs' in api_as_json:
+                api_as_json['runAs'] = False
+            if not 'alias' in api_as_json:
+                api_as_json['alias'] = f"manager-{id}"
             db.update(api_as_json)
-        # FIXME use this code when the ALIAS stuff is merged
-        # if not 'runAs' in api_as_json or not 'alias' in api_as_json:
-        #     if not 'runAs' in api_as_json:
-        #         api_as_json['runAs'] = False
-        #     if not 'alias' in api_as_json:
-        #         api_as_json['alias'] = f"manager-{id}"
-        #     db.update(api_as_json)
 
         return API_model(
             address=api_as_json['url'],


### PR DESCRIPTION
This PR adds some code to ensure the backwards compatibility with pre 4.3 enviroments already running Wazuh. 

Two new fields have been added to the KV store that holds the APIs information, so the registries added on 4.2.x or earlier enviroments must be updated to contain such fields (placeholder data will be inserted).

This is somewhat related with the issue reported on #1220 

A duplictaed JS function has been deleted.