### PR TITLE
Hide the Agents Status bar based on permissions

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overview-welcome.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overview-welcome.html
@@ -2,7 +2,7 @@
   <!-- End headline -->
 
   <!-- Agent stats -->
-  <div layout-padding class="wz-no-padding">
+  <div layout-padding class="wz-no-padding" ng-show="canReadAgents">
     <div class="agent-stats-box">
       <div
         class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive">
@@ -43,7 +43,7 @@
     </div>
   </div>
 
-  <div layout="row" layout-padding>
+  <div layout="row" layout-padding ng-class="{ 'wz-margin-top-20': !canReadAgents }">
     <div class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--responsive">
       <div class="euiFlexItem flex-50">
         <div class="euiPanel euiPanel--paddingLarge">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
@@ -9,6 +9,7 @@ define(['../../module'], function(controllers) {
      * @param {Object} extensions
      * @param {Object} $notificationService
      * @param {Object} $currentDataService
+     * @param {Object} $security_service
      */
     constructor(
       $scope,
@@ -16,6 +17,7 @@ define(['../../module'], function(controllers) {
       extensions,
       $notificationService,
       $currentDataService,
+      $security_service
     ) {
       this.scope = $scope
       this.notificationService = $notificationService
@@ -27,6 +29,13 @@ define(['../../module'], function(controllers) {
         threadDetection: false,
         regulatory: false
       }
+
+      /* RBAC flags */
+      this.scope.canReadAgents = $security_service.isAllowed("AGENT_READ", [
+        "AGENT_ID",
+        "AGENT_GROUP",
+      ]);
+      
       try {
         this.scope.agentsCountTotal = agentsInfo.data.data.total
         this.scope.agentsCountActive = agentsInfo.data.data.active


### PR DESCRIPTION
Hide or showns the Agents Status bar on the Overview section based on the user permissions to read agents.

A 20px margin top is added to the second row when the bar is hidden.

closes #1227 