### PR TITLE
Role check added in setting>configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed agent's name overflow in the overview [#1137](https://github.com/wazuh/wazuh-splunk/pull/1137)
 - Fixed unnecessary table requests when resizing browser window [#1141](https://github.com/wazuh/wazuh-splunk/pull/1141)
 - Fixed on save rules or decoders files [#1138](https://github.com/wazuh/wazuh-splunk/pull/1138)
+- fixed not being able to see actions after adding first API [#1230](https://github.com/wazuh/wazuh-splunk/pull/1230)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/settings-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/settings-states.js
@@ -139,6 +139,16 @@ define(['../module'], function(module) {
                   $state.reload()
                 }
               }
+            ],
+            isWazuhAdmin: [
+              '$security_service',
+              async $security_service => {
+                try{
+                  return await $security_service.hasWazuhRole("administrator")
+                }catch(error){
+                  return false;
+                }
+              }
             ]
           }
         })

--- a/SplunkAppForWazuh/appserver/static/js/controllers/settings/configuration/settingsConfigCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/settings/configuration/settingsConfigCtrl.js
@@ -7,10 +7,12 @@ define(['../../module'], function(controllers) {
       $currentDataService,
       $notificationService,
       configuration,
-      $requestService
+      $requestService,
+      isWazuhAdmin
     ) {
       this.scope = $scope
       this.scope.extensions = {}
+      this.scope.isWazuhAdmin = isWazuhAdmin
       this.notification = $notificationService
       this.currentApi = $currentDataService.getApi()
       this.getCurrentConfiguration = $currentDataService.getCurrentConfiguration
@@ -22,7 +24,6 @@ define(['../../module'], function(controllers) {
       try {
         const id = this.currentApi['_key']
         this.scope.configuration = this.configuration.data.data
-
         this.dropDownValue = false
         this.editingNewValue = false
         this.scope.logLevelOptions = ['info', 'debug']


### PR DESCRIPTION
**Description:**

During the first login, the configuration on Settings < Configuration can't be changed, as the buttons to do it are not shown.

**Resolve:**

Added role verification to configuration view

Steps to reproduce

1. Go to 'Settings < API'
2. Delete all the Managers
3. Log out and back in
4. Add a new API
5. Go to 'Settings < Configuration'

