### PR TITLE
Fix/1228 switching extensions vibility needs write permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Implemented a server to fetch Splunk's users and its roles. [#1156](https://github.com/wazuh/wazuh-splunk/issues/1156)
 - Added a run_as checkbox to the API configuration [#1149](https://github.com/wazuh/wazuh-splunk/issues/1149)
 - Added the ability to use the Authorization Context login method. [#1174](https://github.com/wazuh/wazuh-splunk/pull/1174)
+- Extensions now can only be changed by Splunk Admins [#1228](https://github.com/wazuh/wazuh-splunk/issues/1228)
 
 ### Changed
 

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -39,6 +39,16 @@ define(['../module'], function (module) {
                 return await $security_service.updateUserPermissions()
               }
             ],
+            isSplunkAdmin: [
+              '$splunkUsers',
+              async $splunkUsers => {
+                try {
+                  return await $splunkUsers.isAdmin()
+                } catch (err) {
+                  return { error: 'Cannot fetch Splunk users from API', detail: err }
+                }
+              }
+            ],
             agentsInfo: [
               '$requestService',
               async $requestService => {

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/overview.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/overview/overview.html
@@ -331,7 +331,7 @@
           <h3 class="euiTitle wc-title welcome-card-main-title">
             Auditing and Policy Monitoring
           </h3>
-          <div class="extensions-eye">
+          <div class="extensions-eye" ng-show="isSplunkAdmin">
             <md-tooltip class="wz-tooltip" md-direction="bottom">
               Show extensions list
             </md-tooltip>
@@ -440,7 +440,7 @@
           <h3 class="euiTitle wc-title welcome-card-main-title">
             Threat Detection and Response
           </h3>
-          <div class="extensions-eye">
+          <div class="extensions-eye" ng-show="isSplunkAdmin">
             <md-tooltip class="wz-tooltip" md-direction="bottom">
               Show extensions list
             </md-tooltip>
@@ -546,7 +546,7 @@
           <h3 class="euiTitle wc-title welcome-card-main-title">
             Regulatory Compliance
           </h3>
-          <div class="extensions-eye">
+          <div class="extensions-eye" ng-show="isSplunkAdmin">
             <md-tooltip class="wz-tooltip" md-direction="bottom">
               Show extensions list
             </md-tooltip>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overview-welcome.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overview-welcome.html
@@ -48,7 +48,7 @@
       <div class="euiFlexItem flex-50">
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Security Information Management</h3>
-          <div class="extensions-eye">
+          <div class="extensions-eye" ng-show="isSplunkAdmin">
             <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('security')" icon="eye" color="#396e3e" class="pull-right"></wz-svg>
           </div>
@@ -82,7 +82,7 @@
       <div class="euiFlexItem flex-50">
         <div class="euiPanel euiPanel--paddingLarge">
           <h3 class="euiTitle wc-title welcome-card-main-title">Auditing and Policy Monitoring</h3>
-          <div class="extensions-eye">
+          <div class="extensions-eye" ng-show="isSplunkAdmin">
             <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
             <wz-svg ng-click="showExtensionsLists('auditing')" icon="eye" color="#396e3e" class="pull-right"></wz-svg>
           </div>
@@ -127,7 +127,7 @@
     <div class="euiFlexItem flex-50">
       <div class="euiPanel euiPanel--paddingLarge">
         <h3 class="euiTitle wc-title welcome-card-main-title">Threat Detection and Response</h3>
-        <div class="extensions-eye">
+        <div class="extensions-eye" ng-show="isSplunkAdmin">
           <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
           <wz-svg ng-click="showExtensionsLists('threadDetection')" icon="eye" color="#396e3e" class="pull-right">
           </wz-svg>
@@ -190,7 +190,7 @@
     <div class="euiFlexItem flex-50">
       <div class="euiPanel euiPanel--paddingLarge">
         <h3 class="euiTitle wc-title welcome-card-main-title">Regulatory Compliance</h3>
-        <div class="extensions-eye">
+        <div class="extensions-eye" ng-show="isSplunkAdmin">
           <md-tooltip class="wz-tooltip" md-direction="bottom">Show extensions list</md-tooltip>
           <wz-svg ng-click="showExtensionsLists('regulatory')" icon="eye" color="#396e3e" class="pull-right"></wz-svg>
         </div>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/welcome/overviewWelcomeCtrl.js
@@ -13,6 +13,7 @@ define(['../../module'], function(controllers) {
      */
     constructor(
       $scope,
+      isSplunkAdmin,
       agentsInfo,
       extensions,
       $notificationService,
@@ -35,6 +36,7 @@ define(['../../module'], function(controllers) {
         "AGENT_ID",
         "AGENT_GROUP",
       ]);
+      this.scope.isSplunkAdmin = isSplunkAdmin
       
       try {
         this.scope.agentsCountTotal = agentsInfo.data.data.total


### PR DESCRIPTION
Closes #1228 

## Summary

This PR restricts the ability to enable/disable the extensions to the Splunk users with Admin powers, as they have the required write permissions to use the KV Store.

In the future, this could be improved by creating a specific user for Wazuh with the required write permissions, and map it to the Wazuh Admins for example.

## To Test

1. Login as admin
2. Check that the 'eye' icon is shown on the extensions cards at Overview and Agents < Agent < Overview
3. Check that the changes on the extensions are persistent (are kept between navigations)
----
1. Login as any other user (with no admin role)
2. Check that the 'eye' icon is NOT shown on the extensions cards at Overview and Agents < Agent < Overview
3. Check that the extenions shown match the ones enabled by the admin.
