### PR TITLE
Agent status chart data disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed the underlapping navigation bar for Security options [#1217](https://github.com/wazuh/wazuh-splunk/pull/1217)
 - Fixed error when agents view is re-initialized [#1223](https://github.com/wazuh/wazuh-splunk/pull/1223)
 - Fixed not being able to see actions after adding first API [#1230](https://github.com/wazuh/wazuh-splunk/pull/1230)
+- Fixed agent status chart data disappearing [#1232](https://github.com/wazuh/wazuh-splunk/pull/1232)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
@@ -383,6 +383,7 @@ define([
      * Switchs view to add a new agent
      */
     addNewAgent() {
+      this.linearChartAgent && this.linearChartAgent.destroy();
       this.scope.addingAgents = true
       this.scope.$applyAsync()
     }


### PR DESCRIPTION
**Description:**

The agent status chart data disappear when the user click add new agent and close the window

**Resolve:**

The destruction of the chart was added when it disappears by the add agent button.

**Steps to reproduce**

1. Go to the agent page
2. Click on add new agent button
3. Close add new agent window

Close:

[#1194 ](https://github.com/wazuh/wazuh-splunk/issues/1194)

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/151837162-9cd06502-590c-41ea-bc1d-e27f9e09eda3.png)
![image](https://user-images.githubusercontent.com/63758389/151837192-e4e30a73-57e1-439f-a239-39c9a1fb1f41.png)
![image](https://user-images.githubusercontent.com/63758389/151837246-cc9e11a7-577d-4ea7-94ef-4ad32fb52d7b.png)


