### PR TITLE
Fix `Key not found` error while loading extensions

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
@@ -77,7 +77,7 @@ define(['../module'], function (app) {
     }
 
     getExtensionKey(apiId) {
-      const extensionsKey = this.sessionStorage?.extensions || false
+      const extensionsKey = JSON.parse(this.sessionStorage?.extensions) || false
 
       if (extensionsKey && extensionsKey[apiId]) {
         return extensionsKey[apiId]

--- a/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
@@ -77,10 +77,14 @@ define(['../module'], function (app) {
     }
 
     getExtensionKey(apiId) {
-      const extensionsKey = JSON.parse(this.sessionStorage?.extensions) || false
+      const extensions = this.sessionStorage?.extensions || false
 
-      if (extensionsKey && extensionsKey[apiId]) {
-        return extensionsKey[apiId]
+      if (extensions) {
+        const extensionsKey = JSON.parse(extensions)
+
+        if (extensionsKey && extensionsKey[apiId]) {
+          return extensionsKey[apiId]
+        }
       }
 
       return false

--- a/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
@@ -86,11 +86,7 @@ define(['../module'], function (app) {
             return parsedExtensions[apiId]
           }
         }
-        throw 'Key not found'
-      } catch (e) {
-        this.notification.showErrorToast(
-          'Extensions management failed: ' + (e.message || e)
-        )
+      } catch (_e) {
         return false
       }
     }

--- a/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
@@ -77,18 +77,13 @@ define(['../module'], function (app) {
     }
 
     getExtensionKey(apiId) {
-      try {
-        if (this.sessionStorage.getItem('extensions')) {
-          const parsedExtensions = JSON.parse(
-            this.sessionStorage.getItem('extensions')
-          )
-          if (parsedExtensions[apiId]) {
-            return parsedExtensions[apiId]
-          }
-        }
-      } catch (_e) {
-        return false
+      const extensionsKey = this.sessionStorage?.extensions || false
+
+      if (extensionsKey && extensionsKey[apiId]) {
+        return extensionsKey[apiId]
       }
+
+      return false
     }
 
     setExtensionKey(apiId, extensionKey) {

--- a/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/apiIndexStorageService/apiIndexStorageService.js
@@ -91,6 +91,7 @@ define(['../module'], function (app) {
         this.notification.showErrorToast(
           'Extensions management failed: ' + (e.message || e)
         )
+        return false
       }
     }
 

--- a/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
@@ -133,9 +133,10 @@ define(['../module'], function (module) {
         try {
           let payload = {}
           let updateExtensionKey = false
-          
+
           payload['_key'] = $apiIndexStorageService.getExtensionKey(id)
           if (!payload['_key']) {
+            delete payload['_key']
             payload['api'] = id
             updateExtensionKey = true
           }

--- a/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/currentDataService/currentDataService.js
@@ -133,12 +133,13 @@ define(['../module'], function (module) {
         try {
           let payload = {}
           let updateExtensionKey = false
-          try {
-            payload['_key'] = $apiIndexStorageService.getExtensionKey(id)
-          } catch (err) {
+          
+          payload['_key'] = $apiIndexStorageService.getExtensionKey(id)
+          if (!payload['_key']) {
             payload['api'] = id
             updateExtensionKey = true
           }
+
           const ext = await $requestService.httpReq(
             `POST`,
             `/manager/extensions`,


### PR DESCRIPTION
Closes #1238 

Summary
----------
This PR fixes an error introduced by maintenance tasks run on 4.3.

The design and logic of the functions involved on this erros has been slightly changed.

To test
-----------

1. Go to Overview
2. Check that no error toast is shown
3. Open the browser's dev tools and go to Application
4. Check that there is a `extensions` field on the Sessoin Storage, and that it is not empty.
5. On the dev tools, go to network and look for the a request named `extensions`, and check that a valid key (not empty or null) has been sent as payload. 