### PR TITLE
Quicksettings dialog show api alias 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Wazuh rebranding [#1186](https://github.com/wazuh/wazuh-splunk/pull/1186)
 - Updated deprecated authd options [#1172](https://github.com/wazuh/wazuh-splunk/pull/1172)
 - Refactored branding color styles to improve maintainability [#1236](https://github.com/wazuh/wazuh-splunk/pull/1236)
+- Changed Wazuh API's name to its alias in the quick settings selector [#1243](https://github.com/wazuh/wazuh-splunk/pull/1243)
 
 ### Fixed
 

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.js
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-menu/wz-menu.js
@@ -149,7 +149,7 @@ define([
             {
               id: `menuSelectAPI`,
               choices: $scope.apiList.map((item) => ({
-                label: item.managerName,
+                label: item.alias || item.managerName,
                 value: item._key,
               })),
               value: $scope.currentAPI._key,


### PR DESCRIPTION
Hi team,

this PR changes the quick settings dialog dropdown api's `name` to its `alias` to improve readability.

Closes #1241 

![image](https://user-images.githubusercontent.com/9343732/153205583-f75eac5f-dc0c-4479-adcd-a6a5a11d4504.png)
