### PR TITLE
Fix filter on the daemons logs

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/managerLogsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/managerLogsCtrl.js
@@ -195,11 +195,27 @@ define(['../../module', 'FileSaver'], function (app) {
               `/cluster/${this.scope.selectedNode}/logs/summary`
             )
           : await this.apiReq('/manager/logs/summary')
-        const daemons = data.data.data.affected_items
 
-        this.scope.daemons = daemons.map((item) => ({
-          title: Object.keys(item)[0],
-        }))
+        // NOTE Remove on v4.4.0
+        const daemonsNotIncluded = [
+          'wazuh-modulesd:task-manager',
+          'wazuh-modulesd:agent-upgrade'
+        ]
+        // END NOTE
+
+        const daemons = data.data.data.affected_items
+        // NOTE Remove on v4.4.0
+          .flatMap(Object.keys)
+          .filter(daemon => !daemonsNotIncluded.includes(daemon))
+          
+        this.scope.daemons = daemons.map(d => ({title: d}))
+        // END NOTE
+
+        // NOTE uncomment on v4.4.0
+        // this.scope.daemons = daemons.map((item) => ({
+        //   title: Object.keys(item)[0],
+        // }))
+        // END NOTE
         this.scope.$applyAsync()
         return
       } catch (err) {


### PR DESCRIPTION
Summary
---------
Closes #1253 

This PR solves an error on the filter function for the daemon logs. The daemons `wazuh-modulesd:task-manager` and `wazuh-modulesd:agent-upgrade` are not sortable on the API, so they must be removed from the dropdown list used to filter the logs by deamon.

This issue is solved  on the v4.4.0 of Wazuh (API) so it must be rolled back for that version, or must never reach the branch used for v4.4.0.

How to test
---------

1. Go to `Management < Logs` 
2. Check that the deamons metioned above do not shot on the dropdown list.