### PR TITLE
Add step to start agents to the deployment instructions

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
@@ -185,7 +185,7 @@
       ng-if="canAddAgents"
       class="layout-align-start-center layout-row wz-card-actions wz-card-actions-top md-actions-ruleset">
       <a class="cursor-pointer green-href" ng-click="addNewAgent()"
-        >Add new agent</a
+        >Deploy new agent</a
       >
     </md-card-actions>
     <md-card-contents>
@@ -222,7 +222,7 @@
       <span ng-if="noAgents" class="font-size-20"
         >There are no agents registered</span
       >
-      <span ng-if="addingAgents" class="font-size-20">Add a new agent</span>
+      <span ng-if="addingAgents" class="font-size-20">Deploy a new agent</span>
       <span
         ng-if="addingAgents"
         class="close-register-agent cursor-pointer"

--- a/SplunkAppForWazuh/appserver/static/js/directives/wz-register-agent/wz-register-agent.html
+++ b/SplunkAppForWazuh/appserver/static/js/directives/wz-register-agent/wz-register-agent.html
@@ -4,7 +4,7 @@
       <!-- Select the OS-->
       <div>
         <div class="bubble">1</div>
-        <div class="reg-agent-text">Choose your OS</div>
+        <div class="reg-agent-text">Choose the Operating System</div>
         <div class="border-to-div">
           <div class="choose-os">
             <button
@@ -56,7 +56,7 @@
       <div>
         <div class="wz-margin-top-30">
           <div class="bubble">3</div>
-          <div class="reg-agent-text">Complete the installation</div>
+          <div class="reg-agent-text">Install and enroll the agent</div>
           <!-- snippet with install steps-->
           <div
             ng-if="config.osSelected && config.managerIp"


### PR DESCRIPTION
Summary
---------
Closes #1267 

This PR improves the agent deployment guide by making it consistent with the helper used in the Wazuh Kibana App. This task implies the following:

1. The use of the same text labels for each of the steps.
2. The addition of new steps that were not present before, but are on the Kibana App.
3. The addition on a new step to start the new agent once it has been installed and enrolled, as required on the issue https://github.com/wazuh/wazuh-packages/issues/1249