### PR TITLE
Added conditional disable to apply button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Wazuh App for Splunk project will be documented in this file.
 
+## Wazuh v4.3.5 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4308
+
+### Added
+- Support for Wazuh 4.3.5
+
+### Changed
+- Added a disabled state to the `Apply changes` button on the Agents group editor when no changes on the group are made. [#1276](https://github.com/wazuh/wazuh-splunk/pull/1276)
+
 ## Wazuh v4.3.4 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4307
 
 ### Changed

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groups.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groups.html
@@ -157,6 +157,7 @@
             </button>
             <button
               ng-hide="moreThan500"
+              ng-disabled="!(currentAdding || currentDeleting)"
               ng-click="saveAddAgents()"
               class="btn wz-button-empty wz-margin-left-8 wz-margin-left-5">
               <i aria-hidden="true" class="fa fa-fw fa-save"></i> Apply changes

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/groups/groupsCtrl.js
@@ -647,7 +647,7 @@ define(['../../module', 'FileSaver'], function (app) {
             `Group has been updated but an error has occurred with ${failedIds.length} agents`
           )
         } else {
-          const responseMsg = (response || {}).data.message
+          const responseMsg = (response || { data: { message: '' } }).data.message
           if (responseMsg) {
             this.notification.showSuccessToast(
               responseMsg || 'Success. Group has been updated'


### PR DESCRIPTION
Hi team,

this PR enables the apply changes button when editing a group only after removing or adding an agent to it. It also has a minor enhancement when no change was made.

Closes #1246 