### PR TITLE
Visualizations init on html wrapper load

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agents-fim.html
@@ -84,7 +84,7 @@
           aria-hidden="true"></i>
       </div>
     </div>
-    <div ng-show="!loadingVizz">
+    <div ng-show="!loadingVizz" ng-init="loadVizz()">
       <div ng-show="!showFiles">
         <div class="wz-margin-right-15 wz-text-align-right">
           <i class="fa fa-fw fa-database formatted-color"></i>&nbsp;

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agentsFimCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/fim/agentsFimCtrl.js
@@ -101,87 +101,6 @@ define([
 
       this.filters = this.getFilters()
 
-      this.vizz = [
-        /**
-         * Visualizations
-         */
-        new AreaChart(
-          'eventsOverTimeElement',
-          `${this.filters} sourcetype="wazuh"  "rule.groups{}"="syscheck" | timechart span=12h count by rule.description`,
-          'eventsOverTimeElement',
-          this.scope,
-          { customAxisTitleX: 'Time span' }
-        ),
-        new ColumnChart(
-          'topGroupOwnersElement',
-          `${this.filters} sourcetype="wazuh" uname_after syscheck.gname_after!=""| top limit=20 "syscheck.gname_after"`,
-          'topGroupOwnersElement',
-          this.scope
-        ),
-        new PieChart(
-          'topUserOwnersElement',
-          `${this.filters} sourcetype="wazuh" uname_after| top limit=20 "syscheck.uname_after"`,
-          'topUserOwnersElement',
-          this.scope
-        ),
-        new PieChart(
-          'topActions',
-          `${this.filters} sourcetype="wazuh" | stats count by "syscheck.event"`,
-          'topActions',
-          this.scope
-        ),
-        new PieChart(
-          'topFileChangesElement',
-          `${this.filters} sourcetype="wazuh" "Integrity checksum changed" location!="syscheck-registry" syscheck.path="*" | top syscheck.path`,
-          'topFileChangesElement',
-          this.scope
-        ),
-        new PieChart(
-          'rootUserFileChangesElement',
-          `${this.filters} sourcetype="wazuh" "Integrity checksum changed" location!="syscheck-registry" syscheck.path="*" | search root | top limit=10 syscheck.path`,
-          'rootUserFileChangesElement',
-          this.scope
-        ),
-        new PieChart(
-          'wordWritableFilesElement',
-          `${this.filters} sourcetype="wazuh" rule.groups{}="syscheck" "syscheck.perm_after"=* | top "syscheck.perm_after" showcount=false showperc=false | head 1`,
-          'wordWritableFilesElement',
-          this.scope
-        ),
-        new Table(
-          'eventsSummaryElement',
-          `${this.filters} sourcetype="wazuh" rule.groups{}="syscheck"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description, count as Count`,
-          'eventsSummaryElement',
-          this.scope
-        ),
-        new RawTableDataService(
-          'eventsSummaryTable',
-          `${this.filters} sourcetype="wazuh" rule.groups{}="syscheck"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description, count as Count`,
-          'eventsSummaryTableToken',
-          '$result$',
-          this.scope,
-          'Events Summary'
-        ),
-        new PieChart(
-          'topNewFiles',
-          `${this.filters} syscheck.event=added  | stats count by syscheck.path | top syscheck.path limit=5`,
-          'topNewFiles',
-          this.scope
-        ),
-        new PieChart(
-          'topModifiedFiles',
-          `${this.filters} syscheck.event=modified  | stats count by syscheck.path | top syscheck.path limit=5`,
-          'topModifiedFiles',
-          this.scope
-        ),
-        new PieChart(
-          'topDeletedFiles',
-          `${this.filters} syscheck.event=deleted  | stats count by syscheck.path | top syscheck.path limit=5`,
-          'topDeletedFiles',
-          this.scope
-        ),
-      ]
-
       // Set agent info
       try {
         this.agentReportData = {
@@ -263,6 +182,92 @@ define([
       this.scope.getAgentStatusClass = (agentStatus) =>
         this.getAgentStatusClass(agentStatus)
       this.scope.downloadCsv = (path, name) => this.downloadCsv(path, name)
+      this.scope.loadVizz = () => {
+        if (!this.vizzLoaded) {
+          this.vizz = [
+            /**
+             * Visualizations
+             */
+            new AreaChart(
+              'eventsOverTimeElement',
+              `${this.filters} sourcetype="wazuh"  "rule.groups{}"="syscheck" | timechart span=12h count by rule.description`,
+              'eventsOverTimeElement',
+              this.scope,
+              { customAxisTitleX: 'Time span' }
+            ),
+            new ColumnChart(
+              'topGroupOwnersElement',
+              `${this.filters} sourcetype="wazuh" uname_after syscheck.gname_after!=""| top limit=20 "syscheck.gname_after"`,
+              'topGroupOwnersElement',
+              this.scope
+            ),
+            new PieChart(
+              'topUserOwnersElement',
+              `${this.filters} sourcetype="wazuh" uname_after| top limit=20 "syscheck.uname_after"`,
+              'topUserOwnersElement',
+              this.scope
+            ),
+            new PieChart(
+              'topActions',
+              `${this.filters} sourcetype="wazuh" | stats count by "syscheck.event"`,
+              'topActions',
+              this.scope
+            ),
+            new PieChart(
+              'topFileChangesElement',
+              `${this.filters} sourcetype="wazuh" "Integrity checksum changed" location!="syscheck-registry" syscheck.path="*" | top syscheck.path`,
+              'topFileChangesElement',
+              this.scope
+            ),
+            new PieChart(
+              'rootUserFileChangesElement',
+              `${this.filters} sourcetype="wazuh" "Integrity checksum changed" location!="syscheck-registry" syscheck.path="*" | search root | top limit=10 syscheck.path`,
+              'rootUserFileChangesElement',
+              this.scope
+            ),
+            new PieChart(
+              'wordWritableFilesElement',
+              `${this.filters} sourcetype="wazuh" rule.groups{}="syscheck" "syscheck.perm_after"=* | top "syscheck.perm_after" showcount=false showperc=false | head 1`,
+              'wordWritableFilesElement',
+              this.scope
+            ),
+            new Table(
+              'eventsSummaryElement',
+              `${this.filters} sourcetype="wazuh" rule.groups{}="syscheck"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description, count as Count`,
+              'eventsSummaryElement',
+              this.scope
+            ),
+            new RawTableDataService(
+              'eventsSummaryTable',
+              `${this.filters} sourcetype="wazuh" rule.groups{}="syscheck"  |stats count sparkline by agent.name, syscheck.path syscheck.event, rule.description | sort count DESC | rename agent.name as Agent, syscheck.path as File, syscheck.event as Event, rule.description as Description, count as Count`,
+              'eventsSummaryTableToken',
+              '$result$',
+              this.scope,
+              'Events Summary'
+            ),
+            new PieChart(
+              'topNewFiles',
+              `${this.filters} syscheck.event=added  | stats count by syscheck.path | top syscheck.path limit=5`,
+              'topNewFiles',
+              this.scope
+            ),
+            new PieChart(
+              'topModifiedFiles',
+              `${this.filters} syscheck.event=modified  | stats count by syscheck.path | top syscheck.path limit=5`,
+              'topModifiedFiles',
+              this.scope
+            ),
+            new PieChart(
+              'topDeletedFiles',
+              `${this.filters} syscheck.event=deleted  | stats count by syscheck.path | top syscheck.path limit=5`,
+              'topDeletedFiles',
+              this.scope
+            ),
+          ]
+          this.vizzLoaded = true
+        }
+        return this.vizzLoaded
+      }
     }
 
     /**

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agents-vulnerabilities.html
@@ -103,7 +103,7 @@
           aria-hidden="true"></i>
       </div>
     </div>
-    <div ng-show="!loadingVizz">
+    <div ng-show="!loadingVizz" ng-init="loadVizz()">
       <!-- first row  -->
       <div layout="row" class="wz-margin-9">
         <md-card flex class="wz-metric-color">

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
@@ -93,104 +93,6 @@ define([
 
       this.filters = this.getFilters()
 
-      this.vizz = [
-        /**
-         * Metrics
-         */
-        new SearchHandler(
-          `criticalSeveritySearch`,
-          `${this.filters} data.vulnerability.severity=critical | stats count`,
-          `criticalSeverityToken`,
-          `$result.count$`,
-          `criticalSeverity`,
-          this.submittedTokenModel,
-          this.scope
-        ),
-        new SearchHandler(
-          `highSeveritySeach`,
-          `${this.filters} data.vulnerability.severity=high | stats count`,
-          `highSeverityToken`,
-          `$result.count$`,
-          `highSeverity`,
-          this.submittedTokenModel,
-          this.scope
-        ),
-        new SearchHandler(
-          `mediumSeveritySeach`,
-          `${this.filters} data.vulnerability.severity=medium | stats count`,
-          `mediumSeverityToken`,
-          `$result.count$`,
-          `mediumSeverity`,
-          this.submittedTokenModel,
-          this.scope
-        ),
-        new SearchHandler(
-          `lowSeveritySeach`,
-          `${this.filters} data.vulnerability.severity=low | stats count`,
-          `lowSeverityToken`,
-          `$result.count$`,
-          `lowSeverity`,
-          this.submittedTokenModel,
-          this.scope
-        ),
-        /**
-         * Visualizations
-         */
-        new AreaChart(
-          'alertsSeverityOverTimeVizz',
-          `${this.filters} rule.groups{}=vulnerability-detector data.vulnerability.severity=* | timechart count by data.vulnerability.severity`,
-          'alertsSeverityOverTimeVizz',
-          this.scope,
-          { customAxisTitleX: 'Time span' }
-        ),
-        new Table(
-          'commonRules',
-          `${this.filters} rule.groups{}="vulnerability-detector" | top rule.id,rule.description limit=5 | rename rule.id as "Rule ID", rule.description as "Rule Description", count as Count, percent as Percent`,
-          'commonRules',
-          this.scope
-        ),
-        new PieChart(
-          'commonCves',
-          `${this.filters} rule.groups{}="vulnerability-detector" | top data.vulnerability.cve limit=5`,
-          'commonCves',
-          this.scope
-        ),
-        new PieChart(
-          'severityDistribution',
-          `${this.filters} rule.groups{}="vulnerability-detector" | top data.vulnerability.severity limit=5`,
-          'severityDistribution',
-          this.scope
-        ),
-        new PieChart(
-          'commonlyAffectedPackVizz',
-          `${this.filters} | top 5 data.vulnerability.package.name`,
-          'commonlyAffectedPackVizz',
-          this.scope
-        ),
-        new Table(
-          'alertsSummaryVizz',
-          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, count as Count, sparkline as Sparkline `,
-          'alertsSummaryVizz',
-          this.scope
-        ),
-        new RawTableDataService(
-          'alertsSummaryTable',
-          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, count as Count, sparkline as Sparkline `,
-          'alertsSummaryTableToken',
-          '$result$',
-          this.scope,
-          'Alerts Summary'
-        ),
-        new RawTableDataService(
-          'commonRulesTable',
-          `${this.filters} rule.groups{}="vulnerability-detector" | top rule.id,rule.description limit=5 | rename rule.id as "Rule ID", rule.description as "Rule description", count as Count, percent as Percent`,
-          'commonRulesTableToken',
-          '$result$',
-          this.scope,
-          'Common Rules'
-        ),
-      ]
-
       // Set agent info
       try {
         this.agentReportData = {
@@ -250,6 +152,108 @@ define([
         this.formatAgentStatus(agentStatus)
       this.scope.getAgentStatusClass = (agentStatus) =>
         this.getAgentStatusClass(agentStatus)
+      this.scope.loadVizz = () => {
+        if (!this.vizzLoaded) {
+          this.vizz = [
+            /**
+             * Metrics
+             */
+            new SearchHandler(
+              `criticalSeveritySearch`,
+              `${this.filters} data.vulnerability.severity=critical | stats count`,
+              `criticalSeverityToken`,
+              `$result.count$`,
+              `criticalSeverity`,
+              this.submittedTokenModel,
+              this.scope
+            ),
+            new SearchHandler(
+              `highSeveritySeach`,
+              `${this.filters} data.vulnerability.severity=high | stats count`,
+              `highSeverityToken`,
+              `$result.count$`,
+              `highSeverity`,
+              this.submittedTokenModel,
+              this.scope
+            ),
+            new SearchHandler(
+              `mediumSeveritySeach`,
+              `${this.filters} data.vulnerability.severity=medium | stats count`,
+              `mediumSeverityToken`,
+              `$result.count$`,
+              `mediumSeverity`,
+              this.submittedTokenModel,
+              this.scope
+            ),
+            new SearchHandler(
+              `lowSeveritySeach`,
+              `${this.filters} data.vulnerability.severity=low | stats count`,
+              `lowSeverityToken`,
+              `$result.count$`,
+              `lowSeverity`,
+              this.submittedTokenModel,
+              this.scope
+            ),
+            /**
+             * Visualizations
+             */
+            new AreaChart(
+              'alertsSeverityOverTimeVizz',
+              `${this.filters} rule.groups{}=vulnerability-detector data.vulnerability.severity=* | timechart count by data.vulnerability.severity`,
+              'alertsSeverityOverTimeVizz',
+              this.scope,
+              { customAxisTitleX: 'Time span' }
+            ),
+            new Table(
+              'commonRules',
+              `${this.filters} rule.groups{}="vulnerability-detector" | top rule.id,rule.description limit=5 | rename rule.id as "Rule ID", rule.description as "Rule Description", count as Count, percent as Percent`,
+              'commonRules',
+              this.scope
+            ),
+            new PieChart(
+              'commonCves',
+              `${this.filters} rule.groups{}="vulnerability-detector" | top data.vulnerability.cve limit=5`,
+              'commonCves',
+              this.scope
+            ),
+            new PieChart(
+              'severityDistribution',
+              `${this.filters} rule.groups{}="vulnerability-detector" | top data.vulnerability.severity limit=5`,
+              'severityDistribution',
+              this.scope
+            ),
+            new PieChart(
+              'commonlyAffectedPackVizz',
+              `${this.filters} | top 5 data.vulnerability.package.name`,
+              'commonlyAffectedPackVizz',
+              this.scope
+            ),
+            new Table(
+              'alertsSummaryVizz',
+              `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, count as Count, sparkline as Sparkline `,
+              'alertsSummaryVizz',
+              this.scope
+            ),
+            new RawTableDataService(
+              'alertsSummaryTable',
+              `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, count as Count, sparkline as Sparkline `,
+              'alertsSummaryTableToken',
+              '$result$',
+              this.scope,
+              'Alerts Summary'
+            ),
+            new RawTableDataService(
+              'commonRulesTable',
+              `${this.filters} rule.groups{}="vulnerability-detector" | top rule.id,rule.description limit=5 | rename rule.id as "Rule ID", rule.description as "Rule description", count as Count, percent as Percent`,
+              'commonRulesTableToken',
+              '$result$',
+              this.scope,
+              'Common Rules'
+            ),
+          ]
+          this.vizzLoaded = true
+        }
+      }
     }
 
     /**


### PR DESCRIPTION
Hi team,

this PR fixes agents FIM dashboard visualizations loading. Triggers visualizations init after the html wrapper is rendered.

Closes #1206 

To test it:

- Go to **_Agents_**
- Select an agent with FIM alerts
- Go to **_File integrity monitoring_**
- Click _**Show Alerts**_
- See FIM dashboard render its visualizations

- Go to **_Agents_**
- Select an agent with vulnerabilities alerts
- Go to **_Vulnerabilities_**
- See Vulnerabilities dashboard render its visualizations