### PR TITLE
Fix an error on the search string for the Overview Alerts Summary Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 - Fixed group report disabled configuration parameter error[#1271](https://github.com/wazuh/wazuh-splunk/pull/1271)
 - Fixed import CDB list file [#1266](https://github.com/wazuh/wazuh-splunk/pull/1266)
 - Fixed header menu height style issue [#1282](https://github.com/wazuh/wazuh-splunk/pull/1282)
+- Fixed an error on the search string used on the Alerts Summary table on the Overview > Vulnerability section, causing the table to showno data [#1283](https://github.com/wazuh/wazuh-splunk/issues/1264)
 
 ## Wazuh v4.2.5 - Splunk Enterprise v8.1.4, v8.2.2 - Revision 4206
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
@@ -129,14 +129,74 @@ define([
         ),
         new AreaChart(
           'alertsEvolution',
-          `${this.filters} rule.groups{}=vulnerability-detector data.vulnerability.severity=* | timechart count by data.vulnerability.severity`,
+          `${this.filters} rule.groups{}=vulnerability-detector ` +
+            'data.vulnerability.severity=* | timechart count by data.vulnerability.severity',
           'alertsEvolution',
           this.scope,
           { customAxisTitleX: 'Time span' }
         ),
         new ColumnChart(
           'severityDist',
-          `${this.filters} data.vulnerability.severity=*  | spath "agent.name"  | search "agent.name"=*   | rename agent.id AS RootObject.agent.id agent.ip AS RootObject.agent.ip agent.name AS RootObject.agent.name data.vulnerability.cve AS RootObject.data.vulnerability.cve data.vulnerability.package.condition AS RootObject.data.vulnerability.package.condition data.vulnerability.package.name AS RootObject.data.vulnerability.package.name data.vulnerability.package.version AS RootObject.data.vulnerability.package.version data.vulnerability.published AS RootObject.data.vulnerability.published data.vulnerability.references AS RootObject.data.vulnerability.references data.vulnerability.severity AS RootObject.data.vulnerability.severity data.vulnerability.state AS RootObject.data.vulnerability.state data.vulnerability.title AS RootObject.data.vulnerability.title data.vulnerability.updated AS RootObject.data.vulnerability.updated date_hour AS RootObject.date_hour date_mday AS RootObject.date_mday date_minute AS RootObject.date_minute date_month AS RootObject.date_month date_second AS RootObject.date_second date_wday AS RootObject.date_wday date_year AS RootObject.date_year date_zone AS RootObject.date_zone decoder.name AS RootObject.decoder.name id AS RootObject.id index AS RootObject.index linecount AS RootObject.linecount location AS RootObject.location manager.name AS RootObject.manager.name rule.description AS RootObject.rule.description rule.firedtimes AS RootObject.rule.firedtimes "rule.gdpr{}" AS "RootObject.rule.gdpr{}" rule.groups{} AS RootObject.rule.groups{} "rule.groups{}{}" AS "RootObject.rule.groups{}{}" rule.id AS RootObject.rule.id rule.level AS RootObject.rule.level rule.mail AS RootObject.rule.mail splunk_server AS RootObject.splunk_server timeendpos AS RootObject.timeendpos timestamp AS RootObject.timestamp timestartpos AS RootObject.timestartpos | fields "_time" "host" "source" "sourcetype" "RootObject.agent.id" "RootObject.agent.ip" "RootObject.agent.name" "RootObject.data.vulnerability.cve" "RootObject.data.vulnerability.package.condition" "RootObject.data.vulnerability.package.name" "RootObject.data.vulnerability.package.version" "RootObject.data.vulnerability.published" "RootObject.data.vulnerability.references" "RootObject.data.vulnerability.severity" "RootObject.data.vulnerability.state" "RootObject.data.vulnerability.title" "RootObject.data.vulnerability.updated" "RootObject.date_hour" "RootObject.date_mday" "RootObject.date_minute" "RootObject.date_month" "RootObject.date_second" "RootObject.date_wday" "RootObject.date_year" "RootObject.date_zone" "RootObject.decoder.name" "RootObject.id" "RootObject.index" "RootObject.linecount" "RootObject.location" "RootObject.manager.name" "RootObject.rule.description" "RootObject.rule.firedtimes" ""RootObject.rule.gdpr{}"" "RootObject.rule.groups{}" ""RootObject.rule.groups{}{}"" "RootObject.rule.id" "RootObject.rule.level" "RootObject.rule.mail" "RootObject.splunk_server" "RootObject.timeendpos" "RootObject.timestamp" "RootObject.timestartpos" | eval "RootObject.data.vulnerability.severity"='RootObject.data.vulnerability.severity', "agent.name"='RootObject.agent.name' | chart dedup_splitvals=t limit=100 useother=t count AS "Count of 1532686833.50"  by agent.name RootObject.data.vulnerability.severity format=$$VAL$$:::$$AGG$$ | sort limit=100 RootObject.agent.name | fields - _span  | fields agent.name *`,
+          `${this.filters} data.vulnerability.severity=* ` +
+            '| spath "agent.name" | search "agent.name"=* ' +
+            '| rename agent.id AS RootObject.agent.id ' +
+            'agent.ip AS RootObject.agent.ip ' +
+            'agent.name AS RootObject.agent.name ' +
+            'data.vulnerability.cve AS RootObject.data.vulnerability.cve ' +
+            'data.vulnerability.package.condition AS RootObject.data.vulnerability.package.condition ' +
+            'data.vulnerability.package.name AS RootObject.data.vulnerability.package.name ' +
+            'data.vulnerability.package.version AS RootObject.data.vulnerability.package.version ' +
+            'data.vulnerability.published AS RootObject.data.vulnerability.published ' +
+            'data.vulnerability.references{} AS RootObject.data.vulnerability.references{} ' +
+            'data.vulnerability.severity AS RootObject.data.vulnerability.severity ' +
+            'data.vulnerability.state AS RootObject.data.vulnerability.state ' +
+            'data.vulnerability.title AS RootObject.data.vulnerability.title ' +
+            'data.vulnerability.updated AS RootObject.data.vulnerability.updated ' +
+            'date_hour AS RootObject.date_hour ' +
+            'date_mday AS RootObject.date_mday ' +
+            'date_minute AS RootObject.date_minute ' +
+            'date_month AS RootObject.date_month ' +
+            'date_second AS RootObject.date_second ' +
+            'date_wday AS RootObject.date_wday ' +
+            'date_year AS RootObject.date_year ' +
+            'date_zone AS RootObject.date_zone ' +
+            'decoder.name AS RootObject.decoder.name ' +
+            'id AS RootObject.id ' +
+            'index AS RootObject.index ' +
+            'linecount AS RootObject.linecount ' +
+            'location AS RootObject.location ' +
+            'manager.name AS RootObject.manager.name ' +
+            'rule.description AS RootObject.rule.description ' +
+            'rule.firedtimes AS RootObject.rule.firedtimes ' +
+            '"rule.gdpr{}" AS "RootObject.rule.gdpr{}" ' +
+            'rule.groups{} AS RootObject.rule.groups{} ' +
+            '"rule.groups{}{}" AS "RootObject.rule.groups{}{}" ' +
+            'rule.id AS RootObject.rule.id ' +
+            'rule.level AS RootObject.rule.level ' +
+            'rule.mail AS RootObject.rule.mail ' +
+            'splunk_server AS RootObject.splunk_server ' +
+            'timeendpos AS RootObject.timeendpos ' +
+            'timestamp AS RootObject.timestamp ' +
+            'timestartpos AS RootObject.timestartpos ' +
+            '| fields "_time" "host" "source" "sourcetype" "RootObject.agent.id" ' +
+            '"RootObject.agent.ip" "RootObject.agent.name" "RootObject.data.vulnerability.cve" ' +
+            '"RootObject.data.vulnerability.package.condition" "RootObject.data.vulnerability.package.name" ' +
+            '"RootObject.data.vulnerability.package.version" "RootObject.data.vulnerability.published" ' +
+            '"RootObject.data.vulnerability.references{}" "RootObject.data.vulnerability.severity" ' +
+            '"RootObject.data.vulnerability.state" "RootObject.data.vulnerability.title" ' +
+            '"RootObject.data.vulnerability.updated" "RootObject.date_hour" "RootObject.date_mday" ' +
+            '"RootObject.date_minute" "RootObject.date_month" "RootObject.date_second" ' +
+            '"RootObject.date_wday" "RootObject.date_year" "RootObject.date_zone" ' +
+            '"RootObject.decoder.name" "RootObject.id" "RootObject.index" "RootObject.linecount" ' +
+            '"RootObject.location" "RootObject.manager.name" "RootObject.rule.description" ' +
+            '"RootObject.rule.firedtimes" ""RootObject.rule.gdpr{}"" "RootObject.rule.groups{}" ' +
+            '""RootObject.rule.groups{}{}"" "RootObject.rule.id" "RootObject.rule.level" ' +
+            '"RootObject.rule.mail" "RootObject.splunk_server" "RootObject.timeendpos" ' +
+            '"RootObject.timestamp" "RootObject.timestartpos" ' +
+            `| eval "RootObject.data.vulnerability.severity"='RootObject.data.vulnerability.severity', "agent.name"='RootObject.agent.name' ` +
+            '| chart dedup_splitvals=t limit=100 useother=t count AS "Count of 1532686833.50" ' +
+            'by agent.name RootObject.data.vulnerability.severity format=$$VAL$$:::$$AGG$$ ' +
+            '| sort limit=100 RootObject.agent.name | fields - _span  | fields agent.name *',
           'severityDist',
           this.scope
         ),
@@ -160,13 +220,23 @@ define([
         ),
         new Table(
           'alertsSummary',
-          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity, data.vulnerability.references | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, data.vulnerability.references as Reference, count as Count, sparkline as Sparkline`,
+          `${this.filters} | stats count sparkline by data.vulnerability.title, ` +
+            'data.vulnerability.severity, data.vulnerability.references{} | sort count DESC ' +
+            '| rename data.vulnerability.title as Title, ' +
+            'data.vulnerability.severity as Severity, ' +
+            'data.vulnerability.references{} as Reference, ' +
+            'count as Count, sparkline as Sparkline',
           'alertsSummary',
           this.scope
         ),
         new RawTableDataService(
           'alertsSummaryTable',
-          `${this.filters} | stats count sparkline by data.vulnerability.title, data.vulnerability.severity, data.vulnerability.references | sort count DESC  | rename data.vulnerability.title as Title, data.vulnerability.severity as Severity, data.vulnerability.references as Reference, count as Count, sparkline as Sparkline`,
+          `${this.filters} | stats count sparkline by data.vulnerability.title, ` +
+            'data.vulnerability.severity, data.vulnerability.references{} | sort count DESC ' +
+            '| rename data.vulnerability.title as Title, ' +
+            'data.vulnerability.severity as Severity, ' +
+            'data.vulnerability.references{} as Reference, ' +
+            'count as Count, sparkline as Sparkline',
           'alertsSummaryTableToken',
           '$result$',
           this.scope,


### PR DESCRIPTION
Summary
--------
Closes #1264 

This PR solves an error on the search string used on the Alerts Summary table used on `Overview < Vulnerabilities` section, causing the table to show no data, despite there are alerts to show in the indexes.

**Check the issue for images.**

To test
-----------

1. Go to Overview < Vulnerabilities.
2. Set search interval to All time.
3. Check that the table shows data.