### PR TITLE
Fix log lines by removing their indentation on the backend

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -14,7 +14,6 @@ Find more information about this on the LICENSE file.
 
 
 import json
-import os
 
 import get_api_by_id as API_services
 import jsonbak
@@ -27,7 +26,6 @@ from log import log
 from splunk.appserver.mrsparkle.lib.decorators import expose_page
 from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
 from splunk.clilib import cli_common as cli
-from splunk.clilib.control_exceptions import ParsingError
 from wazuh_api import Wazuh_API
 
 
@@ -662,8 +660,8 @@ class manager(controllers.BaseController):
         except IndexError:
             # data.affected_items is empty
             self.logger.error(
-                f"manager::get_cluster_info(): {endpoint} did not return any data\n"
-                + json.dumps(response, indent=4)
+                f"manager::get_cluster_info(): {endpoint} did not return any data |-> "
+                + json.dumps(response)
             )
             return response  # API error response
         else:
@@ -698,8 +696,8 @@ class manager(controllers.BaseController):
         except (IndexError, KeyError):
             # data does not exist or data.affected_items is empty
             self.logger.error(
-                f"manager: {endpoint} did not return any data\n"
-                + json.dumps(response, indent=4)
+                f"manager: {endpoint} did not return any data |-> "
+                + json.dumps(response)
             )
         except Exception as e:
             self.logger.error(f"manager: error on get_cluster_info(): {e}")

--- a/SplunkAppForWazuh/bin/check_daemons.py
+++ b/SplunkAppForWazuh/bin/check_daemons.py
@@ -65,10 +65,7 @@ def check_daemons(api: API_model) -> bool:
 
     wazuh_ready = False
     if 'error' in daemons_status and daemons_status['error'] > 0:
-        logger.error(
-            "check_daemons():\n"
-            + json.dumps(daemons_status, indent=4)
-        )
+        logger.error("check_daemons(): " + json.dumps(daemons_status))
     else:
         d = daemons_status['data']['affected_items'][0]
         daemons = {

--- a/SplunkAppForWazuh/bin/check_queue.py
+++ b/SplunkAppForWazuh/bin/check_queue.py
@@ -42,7 +42,7 @@ class CheckQueue():
 
     def init(self):
         """Inits the job"""
-        self.logger.debug("bin.check_queue: Checking jobs queue.")
+        # self.logger.debug("bin.check_queue: Checking jobs queue.")
         try:
             jobs = self.q.get_jobs(self.auth_key)
             todo_jobs = self.get_todo_jobs(jobs)
@@ -62,7 +62,7 @@ class CheckQueue():
         str: jobs
             A dictionary in string format with the jobs
         """
-        self.logger.debug("bin.check_queue: Gettings todo jobs.")
+        # self.logger.debug("bin.check_queue: Gettings todo jobs.")
         try:
             jobs = jsonbak.loads(jobs)
             todo_jobs = filter(lambda j: j['done'] == False, jobs)
@@ -81,7 +81,7 @@ class CheckQueue():
         dic: jobs
             A dictionary with the todo jobs
         """
-        self.logger.debug("bin.check_queue: Checking todo jobs.")
+        # self.logger.debug("bin.check_queue: Checking todo jobs.")
         try:
             for job in jobs:
                 if job['exec_time'] < self.now:

--- a/SplunkAppForWazuh/bin/db.py
+++ b/SplunkAppForWazuh/bin/db.py
@@ -72,9 +72,9 @@ class database():
                 verify=False
             ).json()
             if not '_key' in result:
-                raise Exception('The new API could not be inserted\n' +
-                                jsonbak.dumps(result, indent=4)
-                                )
+                raise Exception(
+                    'The new API could not be inserted: ' + jsonbak.dumps(result)
+                )
             key = result['_key']
             return key
         except Exception as e:

--- a/SplunkAppForWazuh/bin/jobs_queue.py
+++ b/SplunkAppForWazuh/bin/jobs_queue.py
@@ -147,7 +147,7 @@ class JobsQueue():
             The authorized session key
         """
         try:
-            self.logger.debug("bin.jobs_queue: Getting all jobs.")
+            # self.logger.debug("bin.jobs_queue: Getting all jobs.")
             kvstoreUri = self.kvstoreUri+'?output_mode=json'
             auth_key = session_key if session_key else splunk.getSessionKey()
             result = self.session.get(

--- a/SplunkAppForWazuh/bin/wazuh_api.py
+++ b/SplunkAppForWazuh/bin/wazuh_api.py
@@ -112,8 +112,9 @@ class Wazuh_API():
                     }
 
                     self.logger.error(
-                        f"{method} {endpoint_url} request failed with status {status_code}\n"
-                        + json.dumps(response, indent=4))
+                        f"{method} {endpoint_url} request failed with status {status_code} |-> "
+                        + json.dumps(response)
+                    )
                 else:
                     response = response.json()
                 catch_exceptions.attempts = 0

--- a/SplunkAppForWazuh/bin/wazuhtoken.py
+++ b/SplunkAppForWazuh/bin/wazuhtoken.py
@@ -75,8 +75,8 @@ class wazuhtoken():
             raise Exception(error)
         else:
             self.logger.debug(
-                "wazuh-token: API object provided\n" +
-                json.dumps(api.__dict__, sort_keys=True, indent=4)
+                "wazuh-token: API object provided" 
+                # + json.dumps(api.__dict__)
             )
 
         # Init values
@@ -125,10 +125,10 @@ class wazuhtoken():
                 # If it fails, use the basic auth
                 if response.status_code != 200:
                     self.logger.error(
-                        f"wazuh-token: allow_run_as not enabled for user {self.api.get_auth()}\n"
-                        + "API response:\n"
-                        + f"Request failed with code {response.status_code}"
-                        + json.dumps(response.json(), indent=4)
+                        f"wazuh-token: allow_run_as not enabled for user {self.api.get_auth()}\t"
+                        + "API response:\t"
+                        + f"Request failed with code {response.status_code} |-> "
+                        + json.dumps(response.json())
                     )
                     response = self._basic_auth_login()
             else:
@@ -171,10 +171,7 @@ class wazuhtoken():
         auth_context['name'] = self.api._user
         auth_context['user_name'] = self.api._user
 
-        self.logger.debug(
-            "wazuh-token: using auth context\n"
-            + json.dumps(auth_context, indent=4)
-        )
+        self.logger.debug("wazuh-token: using auth context")
         try:
             return self.session.post(
                 f"{self.api.get_url()}/security/user/authenticate/run_as",


### PR DESCRIPTION
Summary
--------
Closes #1284 

This PR fixes some problems on the rendering of the app logs. In some cases, the log lines were not properly parsed due to the use of multi-line logs.

The multiline logs have been adapted as single-line logs, preventing these issues on the frontend.

To test
-----------

1. Set the App log level to DEBUG on `Settings < Configuration`
2. Use the App and check the logs at `Settings < Logs`
3. Make us of wrong requests with the DevTools to force logs of type ERROR.