### PR TITLE
Fix outdated documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Wazuh app for Splunk project will be documented in th
 
 ## Wazuh v4.4.0 - Splunk Enterprise v8.1.4, v8.2.2, v8.2.4 - Revision 4401
 
+### Added
+
+### Changed
+
+### Fixed
+- Outdated documentation links have been updated [#1290](https://github.com/wazuh/wazuh-splunk/pull/1290)
+
+
 ## Wazuh v4.3.0 - Splunk Enterprise v8.1.4, v8.2.2, v8.2.4 - Revision 4303
 
 ### Added

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration/agentConfigCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/configuration/agentConfigCtrl.js
@@ -24,6 +24,7 @@ define(['../../module', '../../../utils/config-handler'], function (
      * @param {*} $state
      * @param {*} $stateParams
      * @param {*} $currentDataService
+     * @param {*} $appVersionService
      * @param {*} $beautifierJson
      * @param {*} $notificationService
      * @param {*} $reportingService
@@ -36,6 +37,7 @@ define(['../../module', '../../../utils/config-handler'], function (
       $state,
       $stateParams,
       $currentDataService,
+      $appVersionService,
       $beautifierJson,
       $notificationService,
       $reportingService,
@@ -53,6 +55,7 @@ define(['../../module', '../../../utils/config-handler'], function (
       this.$scope.load = false
       this.id = $stateParams.id || $currentDataService.getCurrentAgent()
       this.$scope.isArray = Array.isArray
+      this.$scope.appDocuVersion = $appVersionService.getDocumentationVersion()
       this.configurationHandler = new ConfigHandler(
         this.apiReq,
         $beautifierJson,

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/azure-logs/azure-logs.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/azure-logs/azure-logs.html
@@ -203,13 +203,13 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/3.10/azure/index.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/azure/index.html"
           >Using Wazuh to monitor Microsoft Azure</md-list-item
         >
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/3.10/user-manual/reference/ossec-conf/wodle-azure-logs.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-azure-logs.html"
           >Azure Logs wodle reference</md-list-item
         >
       </md-list>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cluster/cluster.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cluster/cluster.html
@@ -132,7 +132,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/3.10/user-manual/configuring-cluster/index.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/configuring-cluster/index.html"
           >How to configure the Wazuh cluster</md-list-item
         >
         <md-list-item

--- a/SplunkAppForWazuh/appserver/static/js/controllers/security/roles-mapping/rolesMapping.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/security/roles-mapping/rolesMapping.html
@@ -77,7 +77,7 @@
                   <span class="tSize20">
                     Mapping rules: Assign roles to users who match these rules.
                     <a
-                      href="https://documentation.wazuh.com/current/user-manual/api/rbac/auth_context.html"
+                      href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/api/rbac/auth_context.html"
                       target="_blank"
                       rel="noopener noreferrer">
                       Learn more

--- a/SplunkAppForWazuh/appserver/static/js/controllers/security/roles-mapping/rolesMappingCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/security/roles-mapping/rolesMappingCtrl.js
@@ -28,9 +28,11 @@ define([
       splunkUsers,
       $notificationService,
       $ruleService,
-      $security_service
+      $security_service,
+      $appVersionService,
     ) {
       this.scope = $scope
+      this.scope.appDocuVersion = $appVersionService.getDocumentationVersion()
       this.scope.roles = this.getRolesList(roles.data.data.affected_items || [])
       this.scope.splunkUsersDropdown = this.getSplunkUsersList(
         splunkUsers.data || []


### PR DESCRIPTION
Summary
----------

Closes #1128 

This PR updates some of the documentation links that were pointing to old versions of the documentation.

These links are now generated depending on the App's version.

To test
--------

1. Go to `Agents < Configuration`
2. Click on **any** subsection
3. Click on the ❔ icon to open the documentation links section.
4. Check that the links point to the App version (4.4)
---

1. Go to `Management < Configuration`
2. Go to the **Azure** section
3. Click on the ❔ icon to open the documentation links section.
4. Check that the links point to the App version (4.4)
---

1. Go to `Management < Configuration`
2. Go to the **Cluster** section
3. Click on the ❔ icon to open the documentation links section.
4. Check that the links point to the App version (4.4)
---

1. Go to `Security < Roles Mapping`
2. Click on `Add new Role Mapping`
4. Check that the **Learn More** link point to the App version (4.4)