### PR TITLE
Roll back filter on Daemons logs

### DIFF
--- a/SplunkAppForWazuh/appserver/static/css/styles/common.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/common.css
@@ -603,6 +603,11 @@ div.uil-ring-css {
 
 /* Custom input filter box styles */
 
+.wz-logs-select {
+  width: 100%;
+  max-width: 400px
+}
+
 .input-filter-box {
   box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1) !important;
   border: 1px solid #d9d9d9 !important;

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/manager-logs.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/manager-logs.html
@@ -59,10 +59,9 @@
     ng-show="!loading"
     layout="row"
     layout-align="start start"
-    class="wz-margin-left-10 wz-margin-right-600 less-25-side"
-    style="margin-left: 25px !important">
+    class="less-25-side">
     <select
-      class="input input-dropdown"
+      class="input input-dropdown wz-logs-select"
       flex
       id="categoryBox"
       ng-disabled="realtime"
@@ -78,7 +77,7 @@
     </select>
 
     <select
-      class="input input-dropdown wz-margin-left-10"
+      class="input input-dropdown wz-logs-select wz-margin-left-10"
       flex
       id="levelBox"
       ng-disabled="realtime"
@@ -98,7 +97,7 @@
     <select
       flex
       ng-show="nodeList && nodeList.length"
-      class="input input-dropdown wz-margin-left-10"
+      class="input input-dropdown wz-logs-select wz-margin-left-10"
       id="categoryBox"
       ng-model="selectedNode"
       ng-change="changeNode(selectedNode)"


### PR DESCRIPTION
Summary
----------

Closes #1263 

This PR rolls back the temporal fix included in v4.3, where some Daemons process were not filterable by the API on the Logs section of the App, causing an error. 

On our side, the un-filterable daemons were removed from the Daemons list, and are now included again on this PR as the API has provided a fix for their issue.

Also, some refactoring has been done on the code, including:

- The procedure to fetch the node logs from the API and update the view has been extracted to a new method, improving its reusability and enforcing the single responsibility principle.
- The API's response was transformed using the `map()`, `Object.keys()` and array access (`[]`). This 3-step flow has been simplified using the `flatMap()` method.
- Unnecessary `return` instructions have been removed.
- The error messages have been improved, as the error itself was ignored before in favor of a hard-coded string. The error messages are now displayed on the UI.
- Unnecessary styling (`wz-margin-left-10`, `margin-left: 25px !important`) have been removed from the container hosting the selector.
- The rendering of the selectors have been improved, as their width was being extremely shrunk on low window's width, making its text almost unreadable. A new CSS class has been created and added to the selectors, allowing them to take as much space as necessary on any window width. The 600px margin left class has been removed, as this was pushing the selects towards the left of the screen, crushing them.

To test
--------
- Check that the daemons `task-manager` and `agent-upgrade` are shown in the dropdown, and that clicking on them triggers the expected behavior without causing any error.
- Check that all daemons are filterable, without errors.
- Check that the selects are readable on low window width.

