### PR TITLE
Use POST method when requesting the API login endpoint

### DIFF
--- a/SplunkAppForWazuh/bin/api_info/endpoints.json
+++ b/SplunkAppForWazuh/bin/api_info/endpoints.json
@@ -6967,25 +6967,6 @@
         ]
       },
       {
-        "name": "/security/user/authenticate",
-        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
-        "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
-        "summary": "Login",
-        "tags": [
-          "Security"
-        ],
-        "query": [
-          {
-            "name": "raw",
-            "description": "Format response in plain text",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ]
-      },
-      {
         "name": "/security/users",
         "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.get_users",
         "description": "Get the information of a specified user",
@@ -10762,6 +10743,25 @@
                 "type": "object",
                 "description": "Rule body"
               }
+            }
+          }
+        ]
+      },
+      {
+        "name": "/security/user/authenticate",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
+        "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
+        "summary": "Login",
+        "tags": [
+          "Security"
+        ],
+        "query": [
+          {
+            "name": "raw",
+            "description": "Format response in plain text",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           }
         ]

--- a/SplunkAppForWazuh/bin/wazuhtoken.py
+++ b/SplunkAppForWazuh/bin/wazuhtoken.py
@@ -146,7 +146,7 @@ class wazuhtoken():
         """
         self.logger.debug("wazuh-token: using basic auth")
         try:
-            return self.session.get(
+            return self.session.post(
                 f"{self.api.get_url()}/security/user/authenticate",
                 auth=self.api.get_auth(),
                 timeout=self.timeout,

--- a/scripts/generate-api-info/generate-api-info.js
+++ b/scripts/generate-api-info/generate-api-info.js
@@ -147,6 +147,7 @@ const generateAPISecurityActionsInformation = async () => {
     const authenticationResponse = await request(
       `${WAZUH_API_URL}/security/user/authenticate`,
       {
+        method: 'POST',
         headers: {
           Authorization:
             "Basic " +


### PR DESCRIPTION
This PR closes https://github.com/wazuh/wazuh-splunk/issues/1297.

In this pull request, I have changed the method used when requesting the API login endpoint from GET to POST because as it was said in the related issue, the actual login endpoint (GET) is going to be deprecated.

New `generate-api-info.js` output (it works with the new changes):

```
# node generate-api-info.js https://localhost:55000
--------------- Configuration ---------------
Wazuh API url: https://localhost:55000
Output directory: /output
Output endpoints mode: Simple
----------------------------------------------
[SUCCESS] File was created! Path: /output/endpoints.json
[SUCCESS] File was created! Path: /output/security-actions.json
```
