### PR TITLE
[UI][Agents] Fixed the appearance of a toast message related to the forwarder when there  is no data of agents and the agent deployment guide is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v4.3.1 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4302
+
+### Fixed
+
+- Fixed the appearance of a toast message related to the forwarder when there is no data of agents and the agent deployment guide is displayed in the `Agents` section [#1320](https://github.com/wazuh/wazuh-splunk/pull/1320)
 
 ## Wazuh v4.3.0 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4301
 

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agentsCtrl.js
@@ -75,6 +75,24 @@ define([
         let groups = parsedResult.groups
 
         this.scope.noAgents = summary.Total < 1
+        
+        // When there are agents, the view will display the agents details (table, stat: most active agent).
+        // Only when the most active agent indicator will be displayed, the search should be started.
+        if(!this.scope.noAgents){
+          this.topAgent = new SearchHandler(
+            'searchTopAgent',
+            `${this.filters} earliest=-1w NOT agent.id=000 | top agent.name`,
+            'activeAgentToken',
+            '$result.agent.name$',
+            'mostActiveAgent',
+            this.submittedTokenModel,
+            this.scope,
+            true,
+            'loadingSearch',
+            this.notification
+          )
+        }
+        
         this.scope.agentsCountActive = summary.Active
         this.scope.lastAgent = lastAgent || 'Unknown'
         const os = parsedResult.agent_os
@@ -154,18 +172,6 @@ define([
         }
       } catch (error) {} //eslint-disable-line
 
-      this.topAgent = new SearchHandler(
-        'searchTopAgent',
-        `${this.filters} earliest=-1w NOT agent.id=000 | top agent.name`,
-        'activeAgentToken',
-        '$result.agent.name$',
-        'mostActiveAgent',
-        this.submittedTokenModel,
-        this.scope,
-        true,
-        'loadingSearch',
-        this.notification
-      )
 
       /* RBAC flags */
       this.isAllowed = (action, resource, params = ['*']) => {
@@ -198,7 +204,7 @@ define([
       this.scope.downloadCsv = () => this.downloadCsv()
       this.scope.$on('$destroy', () => {
         this.linearChartAgent && this.linearChartAgent.destroy()
-        this.topAgent.destroy()
+        this.topAgent && this.topAgent.destroy()
       })
       this.scope.reloadList = () => this.reloadList()
 


### PR DESCRIPTION
# Description
This PR fixed the appearance of a toast message related to the forwarder when there is no data of agents and the agent deployment guide is displayed

# Changes
- Do the search for the `Most active agent` when the view of agents' details will be displayed.

# Test
- Without registered agents or no permission to get data of any agent, go to the `Agents` section. The agent deployment guide should appear and not the toast message related to the forwarder.
- With registered agents or permission to get data of any agent, go to the `Agents` section. The agent details should be displayed and not the toast message related to the forwarder. It is important that the `wazuh` index contains data, so secure that the forwarder is working and connected correctly.

Closes  #1299 