### PR TITLE
Refactor search handler events refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the Wazuh app for Splunk project will be documented in this file.
 
+## Wazuh v4.3.4 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4307
+
+### Changed
+- Improved Splunk search-handler event management to avoid forwarder toast error mis-interpretation. [#1327](https://github.com/wazuh/wazuh-splunk/pull/1327)
+
+### Fixed
+- Fixed unhandled expired session when requesting Splunk DB documents. [#1329](https://github.com/wazuh/wazuh-splunk/pull/1329)
+
+## Wazuh v4.3.3 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4306
+
+### Added
+- Support for Wazuh 4.3.3
+
+## Wazuh v4.3.2 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4305
+
+### Added
+- Support for Wazuh 4.3.2
+
 ## Wazuh v4.3.1 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4304
 
 ### Added

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/agents/agents.html
@@ -119,13 +119,13 @@
                   <p>Most active agent</p>
                 </div>
                 <p
-                  ng-if="lastAgent && lastAgent.id && mostActiveAgent.id !== '000'"
+                  ng-if="lastAgent && lastAgent.id && mostActiveAgent.id !== '000' && mostActiveAgent"
                   ng-click="showAgent(mostActiveAgent)"
                   class="euiTitle euiTitle--small euiStat__title wz-text-link cursor-pointer">
                   {{mostActiveAgent}}
                 </p>
                 <p
-                  ng-if="!lastAgent || !lastAgent.id"
+                  ng-if="!lastAgent || !lastAgent.id || !mostActiveAgent"
                   class="euiTitle euiTitle--small euiStat__title">
                   -
                 </p>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agentsAuditCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/audit/agentsAuditCtrl.js
@@ -61,6 +61,13 @@ define([
         $urlTokenModel,
         $notificationService
       )
+      
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.newFiles = DEFAULT_METRIC_VALUES
+      this.scope.readFiles = DEFAULT_METRIC_VALUES
+      this.scope.filesModifiedToken = DEFAULT_METRIC_VALUES
+      this.scope.filesDeleted = DEFAULT_METRIC_VALUES
+
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions
       this.agent = agent

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agentsCiscatCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/ciscat/agentsCiscatCtrl.js
@@ -68,6 +68,16 @@ define([
         this.state.go('overview')
       }
 
+      const DEFAULT_KPI_VALUE = '-'
+      this.scope.lastNotChecked = DEFAULT_KPI_VALUE
+      this.scope.lastPass = DEFAULT_KPI_VALUE
+      this.scope.lastScanScore = DEFAULT_KPI_VALUE
+      this.scope.lastScanDate = DEFAULT_KPI_VALUE
+      this.scope.lastErrors = DEFAULT_KPI_VALUE
+      this.scope.lastFails = DEFAULT_KPI_VALUE
+      this.scope.lastUnknown = DEFAULT_KPI_VALUE
+      this.scope.lastScanBenchmark = DEFAULT_KPI_VALUE
+
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions
       this.agent = agent

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agentsGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/general/agentsGeneralCtrl.js
@@ -68,6 +68,13 @@ define([
         $urlTokenModel,
         $notificationService
       )
+      
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.totalAlerts = DEFAULT_METRIC_VALUES
+      this.scope.levelTwelve = DEFAULT_METRIC_VALUES
+      this.scope.authFailure = DEFAULT_METRIC_VALUES
+      this.scope.authSuccess = DEFAULT_METRIC_VALUES
+
       this.scope.reportingEnabled = reportingEnabled
       this.requestService = $requestService
       this.notification = $notificationService

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
@@ -66,7 +66,7 @@ define([
         $notificationService
       )
       
-      const DEFAULT_METRIC_VALUES = '-'
+      const DEFAULT_METRIC_VALUES = '0'
       this.scope.scapLastScore = DEFAULT_METRIC_VALUES
       this.scope.scapHighestScore = DEFAULT_METRIC_VALUES
       this.scope.scapLowestScore = DEFAULT_METRIC_VALUES

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/scap/agentsOpenScapCtrl.js
@@ -65,6 +65,12 @@ define([
         $urlTokenModel,
         $notificationService
       )
+      
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.scapLastScore = DEFAULT_METRIC_VALUES
+      this.scope.scapHighestScore = DEFAULT_METRIC_VALUES
+      this.scope.scapLowestScore = DEFAULT_METRIC_VALUES
+
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions
       this.agent = agent

--- a/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/agents/vulnerabilities/agentsVulnerabilitiesCtrl.js
@@ -63,6 +63,13 @@ define([
         $urlTokenModel,
         $notificationService
       )
+
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.criticalSeverity = DEFAULT_METRIC_VALUES
+      this.scope.highSeverity = DEFAULT_METRIC_VALUES
+      this.scope.mediumSeverity = DEFAULT_METRIC_VALUES
+      this.scope.lowSeverity = DEFAULT_METRIC_VALUES
+
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions
       this.currentDataService.addFilter(

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overviewAuditCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/audit/overviewAuditCtrl.js
@@ -60,6 +60,13 @@ define([
         $urlTokenModel,
         $notificationService
       )
+
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.newFiles = DEFAULT_METRIC_VALUES
+      this.scope.readFiles = DEFAULT_METRIC_VALUES
+      this.scope.filesModifiedToken = DEFAULT_METRIC_VALUES
+      this.scope.filesDeleted = DEFAULT_METRIC_VALUES
+
       this.notification = $notificationService
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/ciscatCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/ciscat/ciscatCtrl.js
@@ -57,6 +57,17 @@ define([
         $urlTokenModel,
         $notificationService
       )
+      
+      const DEFAULT_KPI_VALUE = '-'
+      this.scope.lastNotChecked = DEFAULT_KPI_VALUE
+      this.scope.lastPass = DEFAULT_KPI_VALUE
+      this.scope.lastScanScore = DEFAULT_KPI_VALUE
+      this.scope.lastScanDate = DEFAULT_KPI_VALUE
+      this.scope.lastErrors = DEFAULT_KPI_VALUE
+      this.scope.lastFails = DEFAULT_KPI_VALUE
+      this.scope.lastUnknown = DEFAULT_KPI_VALUE
+      this.scope.lastScanBenchmark = DEFAULT_KPI_VALUE
+
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions
       this.addFilter = $currentDataService.addFilter
@@ -178,6 +189,16 @@ define([
      */
     $onInit() {
       try {
+        const DEFAULT_KPI_VALUE = '-'
+        this.scope.lastNotChecked = DEFAULT_KPI_VALUE
+        this.scope.lastPass = DEFAULT_KPI_VALUE
+        this.scope.lastScanScore = DEFAULT_KPI_VALUE
+        this.scope.lastScanDate = DEFAULT_KPI_VALUE
+        this.scope.lastErrors = DEFAULT_KPI_VALUE
+        this.scope.lastFails = DEFAULT_KPI_VALUE
+        this.scope.lastUnknown = DEFAULT_KPI_VALUE
+        this.scope.lastScanBenchmark = DEFAULT_KPI_VALUE
+
         this.addFilter(`{"rule.groups{}":"ciscat", "implicit":true}`)
         /**
          * Generates report

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/general/overviewGeneralCtrl.js
@@ -66,6 +66,13 @@ define([
         $notificationService
       )
       this.rootScope = $rootScope
+      
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.totalAlerts = DEFAULT_METRIC_VALUES
+      this.scope.levelTwelve = DEFAULT_METRIC_VALUES
+      this.scope.authFailure = DEFAULT_METRIC_VALUES
+      this.scope.authSuccess = DEFAULT_METRIC_VALUES
+      
       this.scope.reportingEnabled = reportingEnabled
       this.scope.awsExtensionEnabled = awsExtensionEnabled
       this.apiReq = $requestService.apiReq

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overviewOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overviewOpenScapCtrl.js
@@ -68,7 +68,7 @@ define([
         $notificationService
       )
 
-      const DEFAULT_METRIC_VALUES = '-'
+      const DEFAULT_METRIC_VALUES = '0'
       this.scope.scapLastScore = DEFAULT_METRIC_VALUES
       this.scope.scapHighestScore = DEFAULT_METRIC_VALUES
       this.scope.scapLowestScore = DEFAULT_METRIC_VALUES

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overviewOpenScapCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/scap/overviewOpenScapCtrl.js
@@ -67,6 +67,12 @@ define([
         $urlTokenModel,
         $notificationService
       )
+
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.scapLastScore = DEFAULT_METRIC_VALUES
+      this.scope.scapHighestScore = DEFAULT_METRIC_VALUES
+      this.scope.scapLowestScore = DEFAULT_METRIC_VALUES
+
       this.notification = $notificationService
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/vulnerabilities/overviewVulnerabilitiesCtrl.js
@@ -59,6 +59,13 @@ define([
         $urlTokenModel,
         $notificationService
       )
+
+      const DEFAULT_METRIC_VALUES = '-'
+      this.scope.criticalSeverity = DEFAULT_METRIC_VALUES
+      this.scope.highSeverity = DEFAULT_METRIC_VALUES
+      this.scope.mediumSeverity = DEFAULT_METRIC_VALUES
+      this.scope.lowSeverity = DEFAULT_METRIC_VALUES
+
       this.scope.reportingEnabled = reportingEnabled
       this.scope.extensions = extensions
       this.currentDataService.addFilter(

--- a/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/app-version/appVersionService.js
@@ -1,6 +1,6 @@
 const UI_METADATA = {
-  "version": "4.3.4",
-  "revision": "4307"
+  "version": "4.3.3",
+  "revision": "4306"
 }
 
 define(['../module'], function (module) {

--- a/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
@@ -4,6 +4,9 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
 ) {
   'use strict'
 
+  const FORWARDER_ERROR = `Unable to retrieve results. 
+  It may be due to a connection problem with the Splunk forwarder,\nplease try restarting this service.`
+
   return class SearchHandler extends Viz {
     /**
      * Builds a SearchHandler (Metrics) instance
@@ -79,7 +82,6 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
           try {
             if (data.hasData()) {
               const result = this.submittedTokenModel.get(this.token)
-              this.fields = resultModel._data.fields
               this.scope[bindedValue] = result
               this.scope.$applyAsync()
             }
@@ -90,8 +92,9 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
         resultModel.on('error', (err) => {
           console.error('Search Handler - onError: ', err)
         })
+        if (!this.search.query?.changed?.data?.resultCount)
+          this.notification && this.notification.showErrorToast(FORWARDER_ERROR)
       })
-
 
       this.initSearch()
     }

--- a/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
@@ -4,7 +4,7 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
 ) {
   'use strict'
 
-  const FORWARDER_ERROR = `Unable to retrieve results. 
+  const FORWARDER_ERROR = `Unable to retrieve results.\n
   It may be due to a connection problem with the Splunk forwarder,\nplease try restarting this service.`
 
   return class SearchHandler extends Viz {
@@ -93,7 +93,7 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
           console.error('Search Handler - onError: ', err)
         })
         if (!this.search.query?.changed?.data?.resultCount)
-          this.notification && this.notification.showErrorToast(FORWARDER_ERROR)
+          this.notification && this.notification.showWarningToast(FORWARDER_ERROR)
       })
 
       this.initSearch()

--- a/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
@@ -74,7 +74,6 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
         
         // More info in:
         // https://docs.splunk.com/DocumentationStatic/WebFramework/1.5/compref_splunkresultsmodel.html#top
-        this.getSearch().finish = this.getSearch().attributes.data.isDone
         const resultModel = this.search.data('results')
         resultModel.on('data', (data) => {
           try {
@@ -93,7 +92,6 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
         })
       })
 
-      this.submittedTokenModel.on(`change:${this.token}`, () => {})
 
       this.initSearch()
     }

--- a/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/visualizations/search/search-handler.js
@@ -61,7 +61,7 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
       })
 
       this.getSearch().on('search:error', (error) => {
-        console.error(error)
+        console.error('search:error', error)
       })
 
       this.getSearch().on('search:progress', () => {
@@ -70,39 +70,65 @@ define(['splunkjs/mvc/simplexml/searcheventhandler', '../viz/viz'], function (
         }
       })
 
-      this.getSearch().on('search:done', () => {
+      this.getSearch().on('search:done', (param1, param2, param3) => {
         if (this.loading) {
           this.scope[this.loadingBindedValue] = false
         }
-        const result = this.submittedTokenModel.get(this.token)
-        if (
-          result &&
-          result !== value &&
-          typeof result !== 'undefined' &&
-          result !== 'undefined'
-        ) {
-          this.scope[bindedValue] = result
-        } else {
-          this.scope[bindedValue] = '0'
-          this.notification && this.notification.showErrorToast(FORWARDER_ERROR)
-        }
-        this.scope.$applyAsync()
+        
+        const tableData = this.search.data('results')
+        tableData.on('change', (param1, param2, param3) => {
+          const result = this.submittedTokenModel.get(this.token)
+          console.log('onChange', param1, param2, param3)
+        })
+        tableData.on('data', (data) => {
+          try {
+            if (data.hasData()) {
+              const result = this.submittedTokenModel.get(this.token)
+              
+              this.fields = tableData._data.fields
+              this.getSearch().finish = true
+              this.scope[bindedValue] = result
+              this.scope.$applyAsync()
+            } else {
+              this.getSearch().finish = false
+            }
+          } catch (err) {
+            console.error('Error fetching table data ', err)
+          }
+        })
+        tableData.on('error', (err) => {
+          console.error(err)
+        })
+        
+
+        // if (
+        //   result &&
+        //   result !== value &&
+        //   typeof result !== 'undefined' &&
+        //   result !== 'undefined'
+        // ) {
+        //   this.scope[bindedValue] = result
+        // } else {
+        //   this.scope[bindedValue] = '0'
+        //   this.notification && this.notification.showErrorToast(FORWARDER_ERROR)
+        // }
+        // this.scope.$applyAsync()
       })
 
-      this.submittedTokenModel.on(`change:${this.token}`, () => {
-        const loadedTokenJS = this.submittedTokenModel.get(this.token)
-        if (
-          loadedTokenJS &&
-          loadedTokenJS !== value &&
-          typeof loadedTokenJS !== 'undefined' &&
-          loadedTokenJS !== 'undefined'
-        ) {
-          this.scope[bindedValue] = loadedTokenJS
-        } else {
-          this.scope[bindedValue] = '0'
-          this.notification && this.notification.showErrorToast(FORWARDER_ERROR)
-        }
-        this.scope.$applyAsync()
+      this.submittedTokenModel.on(`change:${this.token}`, (param1, param2, param3) => {
+        // const loadedTokenJS = this.submittedTokenModel.get(this.token)
+        // if (
+        //   loadedTokenJS &&
+        //   loadedTokenJS !== value &&
+        //   typeof loadedTokenJS !== 'undefined' &&
+        //   loadedTokenJS !== 'undefined'
+        // ) {
+        //   this.scope[bindedValue] = loadedTokenJS
+        // } else {
+        //   this.scope[bindedValue] = '0'
+        //   this.notification && this.notification.showErrorToast(FORWARDER_ERROR)
+        // }
+        // this.scope.$applyAsync()
       })
 
       this.initSearch()

--- a/SplunkAppForWazuh/default/app.conf
+++ b/SplunkAppForWazuh/default/app.conf
@@ -3,7 +3,7 @@ is_visible = 1
 label = Wazuh
 
 [launcher]
-version = 4.3.4
+version = 4.3.3
 author = info@wazuh.com
 description = Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level.
 
@@ -12,7 +12,7 @@ id = SplunkAppForWazuh
 check_for_updates = 1
 
 [install]
-build = 4307
+build = 4306
 
 [triggers]
 reload.package = simple

--- a/SplunkAppForWazuh/default/app.conf
+++ b/SplunkAppForWazuh/default/app.conf
@@ -12,7 +12,7 @@ id = SplunkAppForWazuh
 check_for_updates = 1
 
 [install]
-build = 4306
+build = 4307
 
 [triggers]
 reload.package = simple

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pretty": "prettier --config .prettierrc --write SplunkAppForWazuh/**/*.js SplunkAppForWazuh/**/*.html SplunkAppForWazuh/**/*.css !SplunkAppForWazuh/appserver/static/js/libs/** !SplunkAppForWazuh/appserver/static/js/utils/codemirror/**",
     "test": "mocha tests/manager.js"
   },
-  "version": "4.3.4",
-  "revision": "4307",
+  "version": "4.3.3",
+  "revision": "4306",
   "splunk": "8.2.6"
 }


### PR DESCRIPTION
### Description

This PR refactors the the search-handler class, which is used to make queries for unique values like KPIs. The idea is to avoid hardcoding a value in the search-handler and instead initialize default values in the modules views. Also, it refactors the way it obtains the result according to Splunk documentation, improving the event handling.

Closes https://github.com/wazuh/wazuh-splunk/issues/1321