### PR TITLE
Fix 'Unexpected Wazuh version' error

### DIFF
--- a/SplunkAppForWazuh/appserver/controllers/manager.py
+++ b/SplunkAppForWazuh/appserver/controllers/manager.py
@@ -244,9 +244,9 @@ class manager(controllers.BaseController):
         app_info = {}
         try:
             app_info = {
-                'version': cli.getConfStanza('app', 'launcher')['version'],
-                'revision': cli.getConfStanza('app', 'install')['build'],
-                'splunk_version': cli.getConfStanza('package', 'splunk')['version']
+                'version': utils.get_default_conf('app', 'launcher')['version'],
+                'revision': utils.get_default_conf('app', 'install')['build'],
+                'splunk_version': utils.get_default_conf('package', 'splunk')['version']
             }
         except Exception as e:
             self.logger.error("manager: error reading App's info." + str(e))
@@ -727,7 +727,7 @@ class manager(controllers.BaseController):
             )
 
             api_version = utils.get_parameter(response, 'data')['api_version']
-            app_version = cli.getConfStanza('app', 'launcher')['version']
+            app_version = utils.get_default_conf('app', 'launcher')['version']
 
             if api_version != app_version:
                 raise Exception(

--- a/SplunkAppForWazuh/appserver/controllers/report.py
+++ b/SplunkAppForWazuh/appserver/controllers/report.py
@@ -21,6 +21,7 @@ from operator import itemgetter
 
 import jsonbak
 import splunk.appserver.mrsparkle.controllers as controllers
+import utils
 from fpdf import FPDF
 from log import log
 from splunk.appserver.mrsparkle.lib.decorators import expose_page
@@ -872,7 +873,7 @@ class report(controllers.BaseController):
                             elif 'affected_items' not in conf_data['data']:
                                 self.setTableTitle(pdf)
                                 # Get Wazuh version for the documentation link
-                                docu_version = cli.getConfStanza('app', 'launcher')['version']
+                                docu_version = utils.get_default_conf('app', 'launcher')['version']
                                 docu_version = '.'.join(version.split('.')[:2])
                                 pdf.cell(
                                     0, 

--- a/SplunkAppForWazuh/bin/log.py
+++ b/SplunkAppForWazuh/bin/log.py
@@ -60,8 +60,7 @@ class log():
 
     def error(self, msg):
         """Error log message."""
-        enable_exc_info = True if self.debug_enabled else False
-        self.logger.error(msg, exc_info=enable_exc_info)
+        self.logger.error(msg, exc_info=self.debug_enabled)
 
     def info(self, msg):
         """Info log message."""

--- a/SplunkAppForWazuh/bin/utils/config.py
+++ b/SplunkAppForWazuh/bin/utils/config.py
@@ -16,11 +16,56 @@ Find more information about this on the LICENSE file.
 import json
 import os
 
+from log import log
 from splunk.clilib import cli_common as cli
 from splunk.clilib.control_exceptions import ParsingError
 
-splunk_home = os.path.normpath(os.environ['SPLUNK_HOME'])
+SPLUNK_HOME = os.path.normpath(os.environ['SPLUNK_HOME'])
+WAZUH_HOME = os.path.join(SPLUNK_HOME, "etc", "apps", "SplunkAppForWazuh")
 
+LOGGER = log()
+
+
+def get_default_conf_path(filename: str) -> str:
+    """Returns the absolute path to $WAZUH_HOME/default/${filename}"""
+    return os.path.join(WAZUH_HOME, "default", filename)
+
+
+def get_default_conf(filename: str, stanza: str) -> dict:
+    """
+    Reads the file $WAZUH_HOME/default/${file} and returns its contents as a 
+    dictionary.
+    
+    The absolute path of the file is built automatically using the 
+    get_default_conf_path() function, so simply provide the filename without 
+    extension.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to be read in the /default directory, without extension.
+    stanza : str
+        The configuration block to be returned from the conf file.
+
+    Returns
+    --------
+        A dictionary with the configuration block requested from the file.
+    """
+    try:
+        app_conf = cli.getAppConf(
+            confName="app", 
+            app="SplunkAppForWazuh", 
+            use_btool=False, 
+            app_path=WAZUH_HOME
+        )
+
+        file_path = get_default_conf_path(filename)
+        settings = cli.getConfStanza(file_path, stanza)
+        json_data = json.dumps(settings)
+        LOGGER.debug(f'Reading "{stanza}" from {file_path}: {json_data}')
+        return settings
+    except Exception as e:
+        raise e
 
 def getLocalConfPath(file):
     return os.path.join(

--- a/SplunkAppForWazuh/bin/utils/config.py
+++ b/SplunkAppForWazuh/bin/utils/config.py
@@ -52,12 +52,17 @@ def get_default_conf(filename: str, stanza: str) -> dict:
         A dictionary with the configuration block requested from the file.
     """
     try:
-        app_conf = cli.getAppConf(
-            confName="app", 
-            app="SplunkAppForWazuh", 
-            use_btool=False, 
-            app_path=WAZUH_HOME
-        )
+        # ------------------------------
+        # Interesting Splunk utility. Returned values can be seen at:
+        # https://github.com/wazuh/wazuh-splunk/pull/1340#discussion_r900338325
+        # ------------------------------
+        # app_conf = cli.getAppConf(
+        #     confName="app", 
+        #     app="SplunkAppForWazuh", 
+        #     use_btool=False, 
+        #     app_path=WAZUH_HOME
+        # )
+        # ------------------------------
 
         file_path = get_default_conf_path(filename)
         settings = cli.getConfStanza(file_path, stanza)


### PR DESCRIPTION
Solves an issue where the App read the wrong metadata as the absolute path to the App .conf files was to specified to the Splunk CLI