### PR TITLE
Fix the MITRE view error due to API timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh App for Splunk project will be documented in th
 
 ### Fixed
 - Outdated documentation links have been updated [#1290](https://github.com/wazuh/wazuh-splunk/pull/1290)
+- The Alerts view from the MITRE section has been hardened in case of errors during the requests to the API (for example timeouts) [#1343](https://github.com/wazuh/wazuh-splunk/pull/1343)
 
 ### Changed
 - Added the status `Pending` to the Agents sections. [#1292](https://github.com/wazuh/wazuh-splunk/pull/1292)

--- a/SplunkAppForWazuh/appserver/static/js/app.js
+++ b/SplunkAppForWazuh/appserver/static/js/app.js
@@ -10,6 +10,7 @@ define([
   './factories/index',
   './run/index',
   './config/index',
+  './models/index',
   'chart',
   'angularChart',
 ], function (ng) {
@@ -25,5 +26,6 @@ define([
     'app.factories',
     'app.run',
     'app.config',
+    'app.models'
   ])
 })

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -9,12 +9,7 @@ define(['../module'], function (module) {
     '$stateProvider',
     '$mdThemingProvider',
     'BASE_URL',
-    function (
-      $locationProvider,
-      $stateProvider,
-      $mdThemingProvider,
-      BASE_URL
-    ) {
+    function ($locationProvider, $stateProvider, $mdThemingProvider, BASE_URL) {
       $mdThemingProvider
         .theme('default')
         .primaryPalette('blue')
@@ -843,78 +838,24 @@ define(['../module'], function (module) {
             ],
             mitre_tactics: [
               '$requestService',
+              '$modelFactory',
               async ($requestService) => {
-                let responseModel = {
-                  error: false,
-                  message: "",
-                  data: []
-                }
                 const fields = ['name'].join()
 
-                try {
-                  const results = await $requestService.apiReq(
-                    `/mitre/tactics?select=${fields}`
-                  )
-                  
-                  //* --------------- *//
-                  //* Error handling  *//
-                  //* --------------- *//
-                  // No response (timeout exceeded or similar)
-                  if (results.data.error) {
-                    throw new Error(results.data.error)
-                  }
-                  // Response arrived, but with errors.
-                  if (results.data.data.error) {
-                    throw new Error(results.data.data.message)
-                  }
-                  //* --------------- *//
-
-                  responseModel.message = results.data.message
-                  responseModel.data = results.data.data.affected_items
-                } catch (error) {
-                  responseModel.error = true
-                  responseModel.message = error
-                }
-
-                return responseModel
+                return await $requestService.apiReqInModel(
+                  `/mitre/tactics?select=${fields}`
+                )
               },
             ],
             mitre_techniques: [
               '$requestService',
+              '$modelFactory',
               async ($requestService) => {
-                let responseModel = {
-                  error: false,
-                  message: "",
-                  data: []
-                }
                 const fields = ['name', 'external_id'].join()
 
-                try {
-                  const results = await $requestService.apiReq(
-                    `/mitre/techniques?select=${fields}&limit=1000`
-                  )
-                  
-                  //* --------------- *//
-                  //* Error handling  *//
-                  //* --------------- *//
-                  // No response (timeout exceeded or similar)
-                  if (results.data.error) {
-                    throw new Error(results.data.error)
-                  }
-                  // Response arrived, but with errors.
-                  if (results.data.data.error) {
-                    throw new Error(results.data.data.message)
-                  }
-                  //* --------------- *//
-
-                  responseModel.message = results.data.message
-                  responseModel.data = results.data.data.affected_items
-                } catch (error) {
-                  responseModel.error = true
-                  responseModel.message = error
-                }
-
-                return responseModel
+                return await $requestService.apiReqInModel(
+                  `/mitre/techniques?select=${fields}&limit=1000`
+                )
               },
             ],
             extensions: [

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -843,7 +843,6 @@ define(['../module'], function (module) {
             ],
             mitre_tactics: [
               '$requestService',
-              '$modelFactory',
               async ($requestService) => {
                 const fields = ['name'].join()
 
@@ -854,7 +853,6 @@ define(['../module'], function (module) {
             ],
             mitre_techniques: [
               '$requestService',
-              '$modelFactory',
               async ($requestService) => {
                 const fields = ['name', 'external_id'].join()
 

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -9,7 +9,12 @@ define(['../module'], function (module) {
     '$stateProvider',
     '$mdThemingProvider',
     'BASE_URL',
-    function ($locationProvider, $stateProvider, $mdThemingProvider, BASE_URL) {
+    function (
+      $locationProvider,
+      $stateProvider,
+      $mdThemingProvider,
+      BASE_URL
+    ) {
       $mdThemingProvider
         .theme('default')
         .primaryPalette('blue')

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -852,9 +852,10 @@ define(['../module'], function (module) {
                   const results = await $requestService.apiReq(
                     `/mitre/tactics?select=${fields}`
                   )
-                  return results.data.data.affected_items
-                } catch (err) {
-                  return false
+                  return results?.data?.data?.affected_items || []
+                } catch (error) {
+                  console.error(error)
+                  return []
                 }
               },
             ],
@@ -865,11 +866,12 @@ define(['../module'], function (module) {
                   const fields = ['name', 'external_id'].join()
 
                   const results = await $requestService.apiReq(
-                    `/mitre/techniques?select=${fields}&limit=1000`
+                    `/mitre/techniques?select=${fields}`
                   )
-                  return results.data.data.affected_items
-                } catch (err) {
-                  return false
+                  return results?.data?.data?.affected_items || []
+                } catch (error) {
+                  console.error(error)
+                  return []
                 }
               },
             ],

--- a/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
+++ b/SplunkAppForWazuh/appserver/static/js/config/routes/overview-states.js
@@ -5,13 +5,11 @@ define(['../module'], function (module) {
   }
   module.constant('BASE_URL', module.paths.root)
   module.config([
-    '$mdIconProvider',
     '$locationProvider',
     '$stateProvider',
     '$mdThemingProvider',
     'BASE_URL',
     function (
-      $mdIconProvider,
       $locationProvider,
       $stateProvider,
       $mdThemingProvider,
@@ -846,33 +844,77 @@ define(['../module'], function (module) {
             mitre_tactics: [
               '$requestService',
               async ($requestService) => {
-                try {
-                  const fields = ['name'].join()
+                let responseModel = {
+                  error: false,
+                  message: "",
+                  data: []
+                }
+                const fields = ['name'].join()
 
+                try {
                   const results = await $requestService.apiReq(
                     `/mitre/tactics?select=${fields}`
                   )
-                  return results?.data?.data?.affected_items || []
+                  
+                  //* --------------- *//
+                  //* Error handling  *//
+                  //* --------------- *//
+                  // No response (timeout exceeded or similar)
+                  if (results.data.error) {
+                    throw new Error(results.data.error)
+                  }
+                  // Response arrived, but with errors.
+                  if (results.data.data.error) {
+                    throw new Error(results.data.data.message)
+                  }
+                  //* --------------- *//
+
+                  responseModel.message = results.data.message
+                  responseModel.data = results.data.data.affected_items
                 } catch (error) {
-                  console.error(error)
-                  return []
+                  responseModel.error = true
+                  responseModel.message = error
                 }
+
+                return responseModel
               },
             ],
             mitre_techniques: [
               '$requestService',
               async ($requestService) => {
-                try {
-                  const fields = ['name', 'external_id'].join()
-
-                  const results = await $requestService.apiReq(
-                    `/mitre/techniques?select=${fields}`
-                  )
-                  return results?.data?.data?.affected_items || []
-                } catch (error) {
-                  console.error(error)
-                  return []
+                let responseModel = {
+                  error: false,
+                  message: "",
+                  data: []
                 }
+                const fields = ['name', 'external_id'].join()
+
+                try {
+                  const results = await $requestService.apiReq(
+                    `/mitre/techniques?select=${fields}&limit=1000`
+                  )
+                  
+                  //* --------------- *//
+                  //* Error handling  *//
+                  //* --------------- *//
+                  // No response (timeout exceeded or similar)
+                  if (results.data.error) {
+                    throw new Error(results.data.error)
+                  }
+                  // Response arrived, but with errors.
+                  if (results.data.data.error) {
+                    throw new Error(results.data.data.message)
+                  }
+                  //* --------------- *//
+
+                  responseModel.message = results.data.message
+                  responseModel.data = results.data.data.affected_items
+                } catch (error) {
+                  responseModel.error = true
+                  responseModel.message = error
+                }
+
+                return responseModel
               },
             ],
             extensions: [

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/mitre-ids/overviewMitreIdsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/mitre-ids/overviewMitreIdsCtrl.js
@@ -28,8 +28,8 @@ define([
      * @param {*} $state
      * @param {*} $notificationService
      * @param {*} $requestService
-     * @param {*} mitre_tactics
-     * @param {*} mitre_techniques
+     * @param {*} mitre_tactics any of the response models.
+     * @param {*} mitre_techniques any of the response models.
      * @param {*} $mdDialog
      * @param {*} $dateDiffService
      * @param {*} $urlTokenModel
@@ -46,6 +46,7 @@ define([
       $mdDialog,
       $dateDiffService,
       $urlTokenModel,
+      $modelFactory,
       extensions
     ) {
       this.scope = $scope
@@ -101,30 +102,34 @@ define([
     }
 
     /**
-     * Initialize the data estructures related to MITRE from the responses
+     * Initialize the data structures related to MITRE from the responses
      * processed on the route resolver. Also checks for the presence of errors
-     * on the responses, and creates an error toats for each of them.
+     * on the responses, and creates error toasts for each of them.
      *
-     * @param {responseModel} mitre_tactics {error: Bool, message: String, data: Array}
-     * @param {responseModel} mitre_techniques {error: Bool, message: String, data: Array}
+     * @param {responseModel} mitre_tactics any of the response models.
+     * @param {responseModel} mitre_techniques any of the response models.
      */
     #initMitre(mitre_tactics, mitre_techniques) {
-      this.scope.tactics = (mitre_tactics.data || []).map((tactic) => {
+      this.scope.tactics = mitre_tactics
+        .getAffectedItems()
+        .map((tactic) => {
         return {
           name: tactic.name,
           count: 0,
         }
       })
-      this.scope.techniques = (mitre_techniques.data || []).map((technique) => {
-        return {
-          ...technique,
-          count: 0,
-        }
-      })
+      this.scope.techniques = mitre_techniques
+        .getAffectedItems()
+        .map((technique) => {
+          return {
+            ...technique,
+            count: 0,
+          }
+        })
 
       const errors = [mitre_tactics, mitre_techniques]
-        .filter((x) => x.error)
-        .map((x) => x.message)
+        .filter((x) => x.hasError())
+        .map((x) => x.getMessage())
 
       for (const e of errors) {
         console.error(e)
@@ -315,7 +320,7 @@ define([
       this.scope.$on('$destroy', () => {
         this.destroy()
         this.cleanModalTable()
-        this.timePicker.destroy()
+        this?.timePicker.destroy()
       })
       this.scope.reloadList = () => this.reloadList()
       this.loadTacticsTechniques()

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/mitre-ids/overviewMitreIdsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/mitre-ids/overviewMitreIdsCtrl.js
@@ -46,7 +46,6 @@ define([
       $mdDialog,
       $dateDiffService,
       $urlTokenModel,
-      $modelFactory,
       extensions
     ) {
       this.scope = $scope

--- a/SplunkAppForWazuh/appserver/static/js/controllers/overview/mitre-ids/overviewMitreIdsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/overview/mitre-ids/overviewMitreIdsCtrl.js
@@ -21,19 +21,20 @@ define([
 
   class OverviewMitreIds {
     /**
-     * Class constructor
-     * @param {Object} $scope
-     * @param {Object} $currentDataService
-     * @param {Object} $state
-     * @param {Object} $notificationService
-     * @param {Object} $requestService
-     * @param {Object} mitre_tactics
+     * Constructor
+     *
+     * @param {*} $scope
+     * @param {*} $currentDataService
+     * @param {*} $state
+     * @param {*} $notificationService
+     * @param {*} $requestService
+     * @param {*} mitre_tactics
+     * @param {*} mitre_techniques
      * @param {*} $mdDialog
      * @param {*} $dateDiffService
      * @param {*} $urlTokenModel
      * @param {*} extensions
      */
-
     constructor(
       $scope,
       $currentDataService,
@@ -59,18 +60,7 @@ define([
       this.scope.extensions = extensions
       this.notification = $notificationService
       this.filters = this.currentDataService.getSerializedFilters(false)
-      this.scope.tactics = mitre_tactics.map((tactic) => {
-        return {
-          name: tactic.name,
-          count: 0,
-        }
-      })
-      this.scope.techniques = mitre_techniques.map((technique) => {
-        return {
-          ...technique,
-          count: 0,
-        }
-      })
+      this.#initMitre(mitre_tactics, mitre_techniques)
       this.scope.sortedTactics = this.scope.tactics
       this.scope.sortedTechniques = this.scope.techniques
       this.$mdDialog = $mdDialog
@@ -108,6 +98,38 @@ define([
       }
 
       this.scope.$applyAsync()
+    }
+
+    /**
+     * Initialize the data estructures related to MITRE from the responses
+     * processed on the route resolver. Also checks for the presence of errors
+     * on the responses, and creates an error toats for each of them.
+     *
+     * @param {responseModel} mitre_tactics {error: Bool, message: String, data: Array}
+     * @param {responseModel} mitre_techniques {error: Bool, message: String, data: Array}
+     */
+    #initMitre(mitre_tactics, mitre_techniques) {
+      this.scope.tactics = (mitre_tactics.data || []).map((tactic) => {
+        return {
+          name: tactic.name,
+          count: 0,
+        }
+      })
+      this.scope.techniques = (mitre_techniques.data || []).map((technique) => {
+        return {
+          ...technique,
+          count: 0,
+        }
+      })
+
+      const errors = [mitre_tactics, mitre_techniques]
+        .filter((x) => x.error)
+        .map((x) => x.message)
+
+      for (const e of errors) {
+        console.error(e)
+        this.notification.showErrorToast(e)
+      }
     }
 
     /**

--- a/SplunkAppForWazuh/appserver/static/js/models/index.js
+++ b/SplunkAppForWazuh/appserver/static/js/models/index.js
@@ -1,5 +1,5 @@
 define([
-    // BasicResponseModel
+    // Response models and Factory Method
     './modelFactory',
   ], function () {})
   

--- a/SplunkAppForWazuh/appserver/static/js/models/index.js
+++ b/SplunkAppForWazuh/appserver/static/js/models/index.js
@@ -1,0 +1,5 @@
+define([
+    // BasicResponseModel
+    './modelFactory',
+  ], function () {})
+  

--- a/SplunkAppForWazuh/appserver/static/js/models/modelFactory.js
+++ b/SplunkAppForWazuh/appserver/static/js/models/modelFactory.js
@@ -1,0 +1,178 @@
+define(['./module'], function (app) {
+  app.factory('$modelFactory', function () {
+    // TODO: analize code coverage of setters.
+
+    /**
+     * Success model class.
+     *
+     * Intended for being used when the Wazuh API replies with status codes:
+     *   - 200 OK
+     *
+     * NOTE: this is the base model, so the fields and methods of this class
+     * are inherited on the rest of the models.
+     */
+    class SuccessResponseModel {
+      #data
+      #message
+      #error
+
+      /**
+       *
+       * @param {Object} api_response response.data
+       */
+      constructor(api_response = {}) {
+        this.#data = api_response?.data ?? {}
+        this.#message = api_response?.message ?? ''
+        this.#error = api_response?.error ?? 0
+      }
+
+      getError() {
+        return this.#error
+      }
+
+      hasError() {
+        return this.#error > 0
+      }
+
+      getMessage() {
+        return this.#message
+      }
+
+      getData() {
+        return this.#data
+      }
+
+      getAffectedItems() {
+        return this.getData()?.affected_items ?? []
+      }
+
+      setError(error_code = 1) {
+        this.#error = error_code
+      }
+
+      setMessage(msg) {
+        this.#message = msg
+      }
+
+      setData(data) {
+        this.#data = data
+      }
+    }
+
+    /**
+     * Generic model class.
+     *
+     * Intended for being usec for any unexpected reply, as a server side error
+     * or similar. Otherwise, use the concrete classes for Wazuh API responses.
+     */
+    class GenericResponseModel extends SuccessResponseModel {
+      constructor(api_response = {}) {
+        super(api_response)
+      }
+    }
+
+    /**
+     * Simple error model.
+     *
+     * Intended for use when the Wazuh API replies with status codes:
+     *   - 400 Bad Request
+     *   - 401 Unauthorized
+     *   - 405 Method Not Allowed
+     */
+    class ErrorResponseModel extends GenericResponseModel {
+      #title
+      #detail
+
+      constructor(api_response = {}) {
+        super(api_response)
+        this.#title = api_response?.title ?? ''
+        this.#detail = api_response?.detail ?? ''
+        this.setMessage(`${this.getTitle()}: ${this.getDetail()}`)
+      }
+
+      /**
+       * @override
+       */
+      hasError() {
+        return true
+      }
+
+      getTitle() {
+        return this.#title
+      }
+
+      getDetail() {
+        return this.#detail
+      }
+
+      setTitle(t) {
+        this.#title = t
+      }
+
+      setDetail(d) {
+        this.#detail = d
+      }
+    }
+
+    /**
+     * Extended error model.
+     *
+     * Intended for use when the Wazuh API replies with status codes:
+     *   - 403 Forbidden
+     *   - 429 Too Many Requests
+     */
+    class ExtendedErrorResponseModel extends ErrorResponseModel {
+      #remediation
+      #dapi_errors
+
+      constructor(api_response = {}) {
+        super(api_response)
+        this.#remediation = api_response?.remediation ?? ''
+        this.#dapi_errors = api_response?.dapi_errors ?? ''
+        this.setError(api_response?.error ?? api_response?.code ?? 1)
+      }
+
+      getRemediation() {
+        return this.#remediation
+      }
+
+      getDapiErrors() {
+        return this.#dapi_errors
+      }
+
+      setRemediation(remediation) {
+        this.#remediation = remediation
+      }
+
+      setDapiErrors(errors) {
+        this.#dapi_errors = errors
+      }
+    }
+
+    return {
+      /**
+       * Factory method.
+       * @param {Object} opt response.data
+       */
+      getResponse(opt = {}) {
+        // Only responses with status_code 200 have the 'data' property
+        if ('data' in opt) {
+          return new SuccessResponseModel(opt)
+        }
+        // Only responses with status_code 403, 429 have the 'remediation' property
+        if ('remediation' in opt) {
+          return new ExtendedErrorResponseModel(opt)
+        }
+        // If the response does not have the 'remediation' property but has
+        // the 'title' property, then its status_code must be 400, 401 or 405.
+        if ('title' in opt) {
+          return new ErrorResponseModel(opt)
+        }
+        // Any other case (timeouts, server side error, unreachable API...)
+        else {
+          return new GenericResponseModel(opt)
+        }
+      },
+    }
+  })
+})

--- a/SplunkAppForWazuh/appserver/static/js/models/modelFactory.js
+++ b/SplunkAppForWazuh/appserver/static/js/models/modelFactory.js
@@ -12,9 +12,9 @@ define(['./module'], function (app) {
      * are inherited on the rest of the models.
      */
     class SuccessResponseModel {
-      #data
-      #message
-      #error
+      #data     // Object
+      #message  // String
+      #error    // Int
 
       /**
        *
@@ -80,8 +80,8 @@ define(['./module'], function (app) {
      *   - 405 Method Not Allowed
      */
     class ErrorResponseModel extends GenericResponseModel {
-      #title
-      #detail
+      #title  // String
+      #detail // String
 
       constructor(api_response = {}) {
         super(api_response)
@@ -122,13 +122,13 @@ define(['./module'], function (app) {
      *   - 429 Too Many Requests
      */
     class ExtendedErrorResponseModel extends ErrorResponseModel {
-      #remediation
-      #dapi_errors
+      #remediation  // String
+      #dapi_errors  // Object
 
       constructor(api_response = {}) {
         super(api_response)
         this.#remediation = api_response?.remediation ?? ''
-        this.#dapi_errors = api_response?.dapi_errors ?? ''
+        this.#dapi_errors = api_response?.dapi_errors ?? {}
         this.setError(api_response?.error ?? api_response?.code ?? 1)
       }
 
@@ -151,7 +151,7 @@ define(['./module'], function (app) {
 
     return {
       /**
-       * Factory method.
+       * Factory Method pattern.
        * @param {Object} opt response.data
        */
       getResponse(opt = {}) {

--- a/SplunkAppForWazuh/appserver/static/js/models/module.js
+++ b/SplunkAppForWazuh/appserver/static/js/models/module.js
@@ -1,0 +1,5 @@
+define(['angular'], function (ng) {
+  'use strict'
+
+  return ng.module('app.models', [])
+})

--- a/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
+++ b/SplunkAppForWazuh/appserver/static/js/services/requestService/requestService.js
@@ -5,7 +5,8 @@ define(['../module'], function (module) {
     '$http',
     '$apiIndexStorageService',
     '$q',
-    function ($https, $apiIndexStorageService, $q) {
+    '$modelFactory',
+    function ($https, $apiIndexStorageService, $q, $modelFactory) {
       constructor
       /**
        * Generated and returns the browser base URL + Splunk Port
@@ -184,6 +185,32 @@ define(['../module'], function (module) {
         }
       }
 
+      /**
+       * Performs a request to the Wazuh API and returns its response in a model.
+       * @param {String} endpoint 
+       * @param {Object} opts body parameters
+       * @param {String} method any Http method - GET, POST, PUT, DELETE
+       * @returns 
+       */
+      const apiReqInModel = async (endpoint, opts = null, method = 'GET') => {
+        let responseModel = $modelFactory.getResponse()
+        try {
+          const results = await apiReq(endpoint, opts, method)
+          
+          // No response (timeout exceeded or similar)
+          if (results.data.error) {
+            throw new Error(results.data.error)
+          }
+
+          // Response arrived
+          responseModel = $modelFactory.getResponse(results.data)
+        } catch (error) {
+          responseModel.setError()
+          responseModel.setMessage(error)
+        }
+        return responseModel
+      }
+
       const service = {
         getBaseUrl: getBaseUrl,
         getWellFormedUri: getWellFormedUri,
@@ -193,6 +220,7 @@ define(['../module'], function (module) {
         sendGroupConfiguration: sendGroupConfiguration,
         getConfiguration: getConfiguration,
         wazuhIsReady: wazuhIsReady,
+        apiReqInModel: apiReqInModel,
       }
       return service
     },


### PR DESCRIPTION
## Summary
This PR solves several issues on the MITRE IDS view due to timeouts on the requests of the API.

![splunl_mitre](https://user-images.githubusercontent.com/15186973/174595351-379e99da-1b11-4182-9110-035d8cafaf45.gif)


### Before

![image](https://user-images.githubusercontent.com/15186973/171883459-dffbd332-9cf2-4493-8652-0a81c937ea14.png)

### After

![image](https://user-images.githubusercontent.com/15186973/174592695-66ebd758-a80d-4ba6-97c0-d60cd30bf070.png)

## How to Test

1. Build a fresh environment.
2. Go to MITRE.
3. Click on `Show Alerts`
4. Check that the error shown is related to a timeout, as seen on the image above.
5. Check that the view do not break, as seen on the comparison above.
6. Re-enter the same view or refresh. Check that no timeout error happens, and the view is rendered correctly.

### How to reproduce once the API response has been cached

1. Remove the `manager_forwarder` container in VS code (Docker plugin) --> Right click --> Remove.
2. Rebuild the container: `docker-compose up -d`.
3. Add the forwarder: `addForwarder` utility.
4. Continue from step 2 on `How to test`.

![Screenshot from 2022-06-20 13-44-28](https://user-images.githubusercontent.com/15186973/174594860-e381a0a3-686c-4aa2-8b53-c5f71478b728.png)
