### PR TITLE
Fix broken link Wazuh documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Wazuh App for Splunk project will be documented in th
 - Fixed broken links that did not redirect correctly to the documentation [#1351](https://github.com/wazuh/wazuh-splunk/pull/1351)
 
 ### Changed
+- Updadted documenation links to match their respective title at the Wazuh documentation page [#1351](https://github.com/wazuh/wazuh-splunk/pull/1351)
 
 ## Wazuh v4.3.5 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4308
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Wazuh App for Splunk project will be documented in this file.
 
+## Wazuh v4.3.6 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4309
+### Added
+
+### Fixed
+- Fixed broken links that did not redirect correctly to the documentation [#1351](https://github.com/wazuh/wazuh-splunk/pull/1351)
+
+### Changed
+
 ## Wazuh v4.3.5 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4308
 ### Added
 - Support for Wazuh 4.3.5

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/agentless/agentless.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/agentless/agentless.html
@@ -146,7 +146,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/agentless-monitoring/index.html"
-          >How to monitor agentless devices</md-list-item
+          >Agentless monitoring</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
@@ -329,7 +329,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/getting-started/use-cases.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/getting-started/use-cases/index.html"
           >Use cases about alerts generation</md-list-item
         >
         <md-list-item

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/alerts/alerts.html
@@ -212,18 +212,18 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-email-report/index.html"
-          >How to configure email alerts</md-list-item
+          >Configuring email alerts</md-list-item
         >
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-email-report/smtp_authentication.html"
-          >How to configure authenticated SMTP server</md-list-item
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-email-report/smtp-authentication.html"
+          >SMTP server with authentication</md-list-item
         >
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/email_alerts.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/email-alerts.html"
           >Email alerts reference</md-list-item
         >
       </md-list>
@@ -444,7 +444,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/labels.html"
-          >Labels documentation</md-list-item
+          >Agent labels</md-list-item
         >
         <md-list-item
           target="_blank"
@@ -612,7 +612,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/automatic-reports.html"
-          >How to generate automatic reports</md-list-item
+          >Generating automatic reports</md-list-item
         >
         <md-list-item
           target="_blank"
@@ -742,7 +742,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-syslog-output.html"
-          >How to configure the syslog output</md-list-item
+          >Configuring syslog output</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cis-cat/cis-cat.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cis-cat/cis-cat.html
@@ -251,7 +251,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html"
-          >CIS-CAT module documentation</md-list-item
+          >CIS-CAT integration</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/client-buffer/client-buffer.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/client-buffer/client-buffer.html
@@ -128,7 +128,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/agent_buffer.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/client-buffer.html"
           >Client buffer reference</md-list-item
         >
       </md-list>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cluster/cluster.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/cluster/cluster.html
@@ -133,7 +133,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/configuring-cluster/index.html"
-          >How to configure the Wazuh cluster</md-list-item
+          >Configuring a Wazuh cluster</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/docker-listener/docker-listener.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/docker-listener/docker-listener.html
@@ -120,8 +120,8 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/docker/index.html"
-          >Docker information</md-list-item
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/container-security/docker-monitor/monitoring-containers-activity.html"
+          >Monitoring containers activity</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/global-configuration/global-configuration.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/global-configuration/global-configuration.html
@@ -422,7 +422,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/daemons/ossec-remoted.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/daemons/wazuh-remoted.html"
           >Remote daemon reference</md-list-item
         >
         <md-list-item

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrations/integrations.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrations/integrations.html
@@ -152,13 +152,13 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/manual-integration.html"
-          >How to integrate Wazuh with external APIs</md-list-item
+          >Integration with external APIs</md-list-item
         >
         <md-list-item
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/virustotal-scan/index.html"
-          >VirusTotal integration documentation</md-list-item
+          >VirusTotal integration</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrity-monitoring/integrity-monitoring.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/integrity-monitoring/integrity-monitoring.html
@@ -844,7 +844,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/file-integrity/index.html"
-          >Integrity monitoring documentation</md-list-item
+          >File integrity monitoring</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/log-collection/log-collection.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/log-collection/log-collection.html
@@ -184,7 +184,7 @@
         target="_blank"
         class="wz-text-link"
         ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/log-data-collection/index.html"
-        >Log data collection documentation</md-list-item
+        >Log data collection</md-list-item
       >
       <md-list-item
         target="_blank"
@@ -339,7 +339,7 @@
         target="_blank"
         class="wz-text-link"
         ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/log-data-collection/index.html"
-        >Log data collection documentation</md-list-item
+        >Log data collection</md-list-item
       >
       <md-list-item
         target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/policy-monitoring/policy-monitoring.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/policy-monitoring/policy-monitoring.html
@@ -469,13 +469,13 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/anomalies-detection/index.html"
-          >Anomaly and malware detection documentation</md-list-item
+          >Anomaly and malware detection</md-list-item
         >
         <md-list-item
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/policy-monitoring/index.html"
-          >Policy monitoring documentation</md-list-item
+          >Monitoring security policies</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
@@ -198,7 +198,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/agent-enrollment/index.html"
-          >How to use the registration service</md-list-item
+          >Wazuh agent enrollment</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
@@ -197,7 +197,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/registering/use-registration-service.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/agent-enrollment/index.html"
           >How to use the registration service</md-list-item
         >
         <md-list-item

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/syscollector/syscollector.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/syscollector/syscollector.html
@@ -167,7 +167,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/syscollector.html"
-          >Syscollector module documentation</md-list-item
+          >System inventory</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
@@ -257,7 +257,7 @@
           target="_blank"
           class="wz-text-link"
           ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/vulnerability-detection/index.html"
-          >Vulnerability detector documentation</md-list-item
+          >Vulnerability detection</md-list-item
         >
         <md-list-item
           target="_blank"

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
@@ -262,7 +262,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/wodle-vuln-detector.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/reference/ossec-conf/vuln-detector.html"
           >Vulnerability detector reference</md-list-item
         >
       </md-list>

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/vulnerabilities/vulnerabilities.html
@@ -256,7 +256,7 @@
         <md-list-item
           target="_blank"
           class="wz-text-link"
-          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/vulnerability-detection.html"
+          ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/vulnerability-detection/index.html"
           >Vulnerability detector documentation</md-list-item
         >
         <md-list-item

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/welcome/welcome.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/welcome/welcome.html
@@ -427,13 +427,13 @@
             target="_blank"
             class="wz-text-link"
             ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/manager/index.html"
-            >Wazuh administration documentation</md-list-item
+            >Wazuh server administration</md-list-item
           >
           <md-list-item
             target="_blank"
             class="wz-text-link"
             ng-href="https://documentation.wazuh.com/{{appDocuVersion}}/user-manual/capabilities/index.html"
-            >Wazuh capabilities documentation</md-list-item
+            >Wazuh capabilities</md-list-item
           >
           <md-list-item
             target="_blank"


### PR DESCRIPTION
The broken links in all these routes have been replaced, now the links work.

**To test, go to these routes:**

- Management < Configuration < Registration Service < "How to use the registration service"

- Management < Configuration < Alerts < "Use cases about alerts generation"

- Management < Configuration < Vulnerabilities-Detector < "Vulnerabilities detection documentation"

- Management < Configuration < Vulnerabilities-Detector < "Vulnerabilities detection reference"

The documentation links in these sections must be valid (must not redirect to the 404 page), useful (they redirect to the expected documentation page) and match the App's version.
