### PR TITLE
Roll back tags filtering on Manager Logs

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/managerLogsCtrl.js
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/managerLogsCtrl.js
@@ -196,26 +196,12 @@ define(['../../module', 'FileSaver'], function (app) {
             )
           : await this.apiReq('/manager/logs/summary')
 
-        // NOTE Remove on v4.4.0
-        const daemonsNotIncluded = [
-          'wazuh-modulesd:task-manager',
-          'wazuh-modulesd:agent-upgrade',
-        ]
-        // END NOTE
-
         const daemons = data.data.data.affected_items
-          // NOTE Remove on v4.4.0
-          .flatMap(Object.keys)
-          .filter((daemon) => !daemonsNotIncluded.includes(daemon))
 
-        this.scope.daemons = daemons.map((d) => ({ title: d }))
-        // END NOTE
+        this.scope.daemons = daemons.map((item) => ({
+          title: Object.keys(item)[0],
+        }))
 
-        // NOTE uncomment on v4.4.0
-        // this.scope.daemons = daemons.map((item) => ({
-        //   title: Object.keys(item)[0],
-        // }))
-        // END NOTE
         this.scope.$applyAsync()
         return
       } catch (err) {

--- a/SplunkAppForWazuh/bin/api_info/endpoints.json
+++ b/SplunkAppForWazuh/bin/api_info/endpoints.json
@@ -1352,38 +1352,7 @@
             "description": "Wazuh component that logged the event",
             "schema": {
               "type": "string",
-              "enum": [
-                "wazuh-agentlessd",
-                "wazuh-analysisd",
-                "wazuh-authd",
-                "wazuh-csyslogd",
-                "wazuh-dbd",
-                "wazuh-execd",
-                "wazuh-integratord",
-                "wazuh-maild",
-                "wazuh-monitord",
-                "wazuh-logcollector",
-                "wazuh-remoted",
-                "wazuh-reportd",
-                "wazuh-rootcheck",
-                "wazuh-syscheckd",
-                "sca",
-                "wazuh-db",
-                "wazuh-modulesd",
-                "wazuh-modulesd:agent-key-polling",
-                "wazuh-modulesd:aws-s3",
-                "wazuh-modulesd:azure-logs",
-                "wazuh-modulesd:ciscat",
-                "wazuh-modulesd:control",
-                "wazuh-modulesd:command",
-                "wazuh-modulesd:database",
-                "wazuh-modulesd:docker-listener",
-                "wazuh-modulesd:download",
-                "wazuh-modulesd:oscap",
-                "wazuh-modulesd:osquery",
-                "wazuh-modulesd:syscollector",
-                "wazuh-modulesd:vulnerability-detector"
-              ]
+              "format": "alphanumeric"
             }
           },
           {
@@ -4799,38 +4768,7 @@
             "description": "Wazuh component that logged the event",
             "schema": {
               "type": "string",
-              "enum": [
-                "wazuh-agentlessd",
-                "wazuh-analysisd",
-                "wazuh-authd",
-                "wazuh-csyslogd",
-                "wazuh-dbd",
-                "wazuh-execd",
-                "wazuh-integratord",
-                "wazuh-maild",
-                "wazuh-monitord",
-                "wazuh-logcollector",
-                "wazuh-remoted",
-                "wazuh-reportd",
-                "wazuh-rootcheck",
-                "wazuh-syscheckd",
-                "sca",
-                "wazuh-db",
-                "wazuh-modulesd",
-                "wazuh-modulesd:agent-key-polling",
-                "wazuh-modulesd:aws-s3",
-                "wazuh-modulesd:azure-logs",
-                "wazuh-modulesd:ciscat",
-                "wazuh-modulesd:control",
-                "wazuh-modulesd:command",
-                "wazuh-modulesd:database",
-                "wazuh-modulesd:docker-listener",
-                "wazuh-modulesd:download",
-                "wazuh-modulesd:oscap",
-                "wazuh-modulesd:osquery",
-                "wazuh-modulesd:syscollector",
-                "wazuh-modulesd:vulnerability-detector"
-              ]
+              "format": "alphanumeric"
             }
           },
           {
@@ -8775,6 +8713,14 @@
             }
           },
           {
+            "name": "severity",
+            "description": "Filter by CVE severity",
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          },
+          {
             "name": "sort",
             "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
             "schema": {
@@ -8783,11 +8729,150 @@
             }
           },
           {
+            "name": "status",
+            "description": "Filter by CVE status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "valid",
+                "pending",
+                "obsolete"
+              ]
+            }
+          },
+          {
+            "name": "type",
+            "description": "Filter by CVE type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "os",
+                "package"
+              ]
+            }
+          },
+          {
             "name": "version",
             "description": "Filter by CVE version",
             "schema": {
               "type": "string",
               "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/vulnerability/:agent_id/last_scan",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_last_scan_agent",
+        "description": "Return when the last full and partial vulnerability scan of a specified agent ended.",
+        "summary": "Get last scan datetime",
+        "tags": [
+          "Vulnerability"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/vulnerability/:agent_id/summary/:field",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_vulnerabilities_field_summary",
+        "description": "Return a summary of the vulnerabilities' field of an agent",
+        "summary": "Get agent vulnerabilities' field summary",
+        "tags": [
+          "Vulnerability"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": ":field",
+            "description": "Vulnerability inventory field",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "cve",
+                "name",
+                "version",
+                "architecture",
+                "detection_time",
+                "severity",
+                "cvss2_score",
+                "cvss3_score",
+                "external_references",
+                "type",
+                "status",
+                "condition",
+                "title",
+                "published",
+                "updated"
+              ]
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return. Although up to 100.000 can be specified, it is recommended not to exceed 500 elements. Responses may be slower the more this number is exceeded. ",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 100000
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
           },
           {

--- a/SplunkAppForWazuh/bin/api_info/security-actions.json
+++ b/SplunkAppForWazuh/bin/api_info/security-actions.json
@@ -928,6 +928,7 @@
     "related_endpoints": [
       "GET /security/users",
       "GET /security/roles",
+      "GET /security/rules",
       "GET /security/policies"
     ]
   },
@@ -1101,7 +1102,9 @@
       "effect": "allow"
     },
     "related_endpoints": [
-      "GET /vulnerability/{agent_id}"
+      "GET /vulnerability/{agent_id}",
+      "GET /vulnerability/{agent_id}/last_scan",
+      "GET /vulnerability/{agent_id}/summary/{field}"
     ]
   }
 }


### PR DESCRIPTION
## Summary
This PR removes the filtering of tags that did not work on the API, in order to filter the logs of the manager.

Every tag coming from the logs will be shown.

## Test

- Go to the `Management < Section` and test that all tags work.