### PR TITLE
Roll back tags filtering on Manager Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh App for Splunk project will be documented in th
 - Support for Wazuh 4.3.6
 
 ### Changed
-- Re-allow the use of all tags to filter Wazuh Server logs [#1263](https://github.com/wazuh/wazuh-splunk/issues/1263)
+- Re-allow the use of all tags to filter Wazuh Server logs [#1354](https://github.com/wazuh/wazuh-splunk/pull/1354)
 
 ## Wazuh v4.3.5 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4308
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Wazuh App for Splunk project will be documented in this file.
 
+## Wazuh v4.3.6 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4309
+### Added
+- Support for Wazuh 4.3.6
+
+### Changed
+- Re-allow the use of all tags to filter Wazuh Server logs [#1263](https://github.com/wazuh/wazuh-splunk/issues/1263)
+
 ## Wazuh v4.3.5 - Splunk Enterprise v8.1.[1-10], v8.2.x - Revision 4308
 ### Added
 - Support for Wazuh 4.3.5

--- a/SplunkAppForWazuh/appserver/static/css/styles/common.css
+++ b/SplunkAppForWazuh/appserver/static/css/styles/common.css
@@ -603,6 +603,11 @@ div.uil-ring-css {
 
 /* Custom input filter box styles */
 
+.wz-logs-select {
+  width: 100%;
+  max-width: 400px
+}
+
 .input-filter-box {
   box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1) !important;
   border: 1px solid #d9d9d9 !important;

--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/manager-logs.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/logs/manager-logs.html
@@ -59,10 +59,9 @@
     ng-show="!loading"
     layout="row"
     layout-align="start start"
-    class="wz-margin-left-10 wz-margin-right-600 less-25-side"
-    style="margin-left: 25px !important">
+    class="less-25-side">
     <select
-      class="input input-dropdown"
+      class="input input-dropdown wz-logs-select"
       flex
       id="categoryBox"
       ng-disabled="realtime"
@@ -78,7 +77,7 @@
     </select>
 
     <select
-      class="input input-dropdown wz-margin-left-10"
+      class="input input-dropdown wz-logs-select wz-margin-left-10"
       flex
       id="levelBox"
       ng-disabled="realtime"
@@ -98,7 +97,7 @@
     <select
       flex
       ng-show="nodeList && nodeList.length"
-      class="input input-dropdown wz-margin-left-10"
+      class="input input-dropdown wz-logs-select wz-margin-left-10"
       id="categoryBox"
       ng-model="selectedNode"
       ng-change="changeNode(selectedNode)"

--- a/SplunkAppForWazuh/bin/api_info/endpoints.json
+++ b/SplunkAppForWazuh/bin/api_info/endpoints.json
@@ -1352,38 +1352,7 @@
             "description": "Wazuh component that logged the event",
             "schema": {
               "type": "string",
-              "enum": [
-                "wazuh-agentlessd",
-                "wazuh-analysisd",
-                "wazuh-authd",
-                "wazuh-csyslogd",
-                "wazuh-dbd",
-                "wazuh-execd",
-                "wazuh-integratord",
-                "wazuh-maild",
-                "wazuh-monitord",
-                "wazuh-logcollector",
-                "wazuh-remoted",
-                "wazuh-reportd",
-                "wazuh-rootcheck",
-                "wazuh-syscheckd",
-                "sca",
-                "wazuh-db",
-                "wazuh-modulesd",
-                "wazuh-modulesd:agent-key-polling",
-                "wazuh-modulesd:aws-s3",
-                "wazuh-modulesd:azure-logs",
-                "wazuh-modulesd:ciscat",
-                "wazuh-modulesd:control",
-                "wazuh-modulesd:command",
-                "wazuh-modulesd:database",
-                "wazuh-modulesd:docker-listener",
-                "wazuh-modulesd:download",
-                "wazuh-modulesd:oscap",
-                "wazuh-modulesd:osquery",
-                "wazuh-modulesd:syscollector",
-                "wazuh-modulesd:vulnerability-detector"
-              ]
+              "format": "alphanumeric"
             }
           },
           {
@@ -4799,38 +4768,7 @@
             "description": "Wazuh component that logged the event",
             "schema": {
               "type": "string",
-              "enum": [
-                "wazuh-agentlessd",
-                "wazuh-analysisd",
-                "wazuh-authd",
-                "wazuh-csyslogd",
-                "wazuh-dbd",
-                "wazuh-execd",
-                "wazuh-integratord",
-                "wazuh-maild",
-                "wazuh-monitord",
-                "wazuh-logcollector",
-                "wazuh-remoted",
-                "wazuh-reportd",
-                "wazuh-rootcheck",
-                "wazuh-syscheckd",
-                "sca",
-                "wazuh-db",
-                "wazuh-modulesd",
-                "wazuh-modulesd:agent-key-polling",
-                "wazuh-modulesd:aws-s3",
-                "wazuh-modulesd:azure-logs",
-                "wazuh-modulesd:ciscat",
-                "wazuh-modulesd:control",
-                "wazuh-modulesd:command",
-                "wazuh-modulesd:database",
-                "wazuh-modulesd:docker-listener",
-                "wazuh-modulesd:download",
-                "wazuh-modulesd:oscap",
-                "wazuh-modulesd:osquery",
-                "wazuh-modulesd:syscollector",
-                "wazuh-modulesd:vulnerability-detector"
-              ]
+              "format": "alphanumeric"
             }
           },
           {
@@ -8775,6 +8713,14 @@
             }
           },
           {
+            "name": "severity",
+            "description": "Filter by CVE severity",
+            "schema": {
+              "type": "string",
+              "format": "names"
+            }
+          },
+          {
             "name": "sort",
             "description": "Sort the collection by a field or fields (separated by comma). Use +/- at the beggining to list in ascending or descending order. Use '.' for nested fields. For example, '{field1: field2}' may be selected with 'field1.field2'",
             "schema": {
@@ -8783,11 +8729,150 @@
             }
           },
           {
+            "name": "status",
+            "description": "Filter by CVE status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "valid",
+                "pending",
+                "obsolete"
+              ]
+            }
+          },
+          {
+            "name": "type",
+            "description": "Filter by CVE type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "os",
+                "package"
+              ]
+            }
+          },
+          {
             "name": "version",
             "description": "Filter by CVE version",
             "schema": {
               "type": "string",
               "format": "alphanumeric_symbols"
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/vulnerability/:agent_id/last_scan",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_last_scan_agent",
+        "description": "Return when the last full and partial vulnerability scan of a specified agent ended.",
+        "summary": "Get last scan datetime",
+        "tags": [
+          "Vulnerability"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "wait_for_complete",
+            "description": "Disable timeout response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "/vulnerability/:agent_id/summary/:field",
+        "documentation": "https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_vulnerabilities_field_summary",
+        "description": "Return a summary of the vulnerabilities' field of an agent",
+        "summary": "Get agent vulnerabilities' field summary",
+        "tags": [
+          "Vulnerability"
+        ],
+        "args": [
+          {
+            "name": ":agent_id",
+            "description": "Agent ID. All possible values from 000 onwards",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "Agent ID",
+              "format": "numbers"
+            }
+          },
+          {
+            "name": ":field",
+            "description": "Vulnerability inventory field",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "cve",
+                "name",
+                "version",
+                "architecture",
+                "detection_time",
+                "severity",
+                "cvss2_score",
+                "cvss3_score",
+                "external_references",
+                "type",
+                "status",
+                "condition",
+                "title",
+                "published",
+                "updated"
+              ]
+            }
+          }
+        ],
+        "query": [
+          {
+            "name": "limit",
+            "description": "Maximum number of elements to return. Although up to 100.000 can be specified, it is recommended not to exceed 500 elements. Responses may be slower the more this number is exceeded. ",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 100000
+            }
+          },
+          {
+            "name": "pretty",
+            "description": "Show results in human-readable format",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
           },
           {

--- a/SplunkAppForWazuh/bin/api_info/security-actions.json
+++ b/SplunkAppForWazuh/bin/api_info/security-actions.json
@@ -928,6 +928,7 @@
     "related_endpoints": [
       "GET /security/users",
       "GET /security/roles",
+      "GET /security/rules",
       "GET /security/policies"
     ]
   },
@@ -1101,7 +1102,9 @@
       "effect": "allow"
     },
     "related_endpoints": [
-      "GET /vulnerability/{agent_id}"
+      "GET /vulnerability/{agent_id}",
+      "GET /vulnerability/{agent_id}/last_scan",
+      "GET /vulnerability/{agent_id}/summary/{field}"
     ]
   }
 }


### PR DESCRIPTION
Summary
----------

Closes #1263 

This PR rolls back the temporal fix included in v4.3, where some Daemons process were not filterable by the API on the Logs section of the App, causing an error. 

On our side, the un-filterable daemons were removed from the Daemons list, and are now included again on this PR as the API has provided a fix for their issue.

Also, some refactoring has been done on the code, including:

- The procedure to fetch the node logs from the API and update the view has been extracted to a new method, improving its reusability and enforcing the single responsibility principle.
- The API's response was transformed using the `map()`, `Object.keys()` and array access (`[]`). This 3-step flow has been simplified using the `flatMap()` method.
- Unnecessary `return` instructions have been removed.
- The error messages have been improved, as the error itself was ignored before in favor of a hard-coded string. The error messages are now displayed on the UI.
- Unnecessary styling (`wz-margin-left-10`, `margin-left: 25px !important`) have been removed from the container hosting the selector.
- The rendering of the selectors have been improved, as their width was being extremely shrunk on low window's width, making its text almost unreadable. A new CSS class has been created and added to the selectors, allowing them to take as much space as necessary on any window width. The 600px margin left class has been removed, as this was pushing the selects towards the left of the screen, crushing them.

To test
--------
- Check that the daemons `task-manager` and `agent-upgrade` are shown in the dropdown, and that clicking on them triggers the expected behavior without causing any error.
- Check that all daemons are filterable, without errors.
- Check that the selects are readable on low window width.

