### PR TITLE
Added authd key request on registration service

### DIFF
--- a/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
+++ b/SplunkAppForWazuh/appserver/static/js/controllers/management/configuration/registration-service/registration-service.html
@@ -125,6 +125,51 @@
           <!-- End configuration block -->
 
           <div class="wz-margin-top-10">
+            <span class="font-size-16">Key request settings</span>
+            <div class="wz-margin-top-10">
+              <span class="md-subheader small"
+                >The key request feature allows fetching the agent keys stored on an external database</span
+              >
+            </div>
+          </div>
+          <md-divider class="wz-margin-top-10"></md-divider>
+
+          <!-- Configuration block -->
+          <div class="wz-padding-top-10">
+            <wz-config-item
+              label="Key request status"
+              value="currentConfig['auth-auth'].auth.key_request.enabled === 'no' ? 'disabled' : 'enabled'">
+            </wz-config-item>
+            <wz-config-item
+              label="Full path to the executable"
+              value="currentConfig['auth-auth'].auth.key_request.exec_path"
+              ng-if="currentConfig['auth-auth'].auth.key_request.exec_path != undefined">
+            </wz-config-item>
+            <wz-config-item
+              label="Full path to the Unix domain socket"
+              value="currentConfig['auth-auth'].auth.key_request.socket"
+              ng-if="currentConfig['auth-auth'].auth.key_request.socket != undefined">
+            </wz-config-item>
+            <wz-config-item
+              label="Maximum time for waiting a response from the executable"
+              value="currentConfig['auth-auth'].auth.key_request.timeout"
+              ng-if="currentConfig['auth-auth'].auth.key_request.timeout != undefined">
+            </wz-config-item>
+            <wz-config-item
+              label="Number of threads for dispatching the external keys requests"
+              value="currentConfig['auth-auth'].auth.key_request.threads"
+              ng-if="currentConfig['auth-auth'].auth.key_request.threads != undefined">
+            </wz-config-item>
+            <wz-config-item
+              label="Indicates the maximum size of the queue for fetching external keys"
+              value="currentConfig['auth-auth'].auth.key_request.queue_size"
+              ng-if="currentConfig['auth-auth'].auth.key_request.queue_size != undefined">
+            </wz-config-item>
+          </div>
+
+          <!-- End configuration block -->
+
+          <div class="wz-margin-top-10">
             <span class="font-size-16">SSL settings</span>
             <div class="wz-margin-top-10">
               <span class="md-subheader small"


### PR DESCRIPTION
Hi Team,
This PR adds a new configuration setting in the Registration service section.
Go to `Management > Configuration > Registration service`

Closes #1175 

## For manual testing

### - Check when auth key_request is `disabled`

![Selección_017](https://user-images.githubusercontent.com/6089438/187719889-881a7cab-2c4a-4d44-9ac9-e032319f7657.png)

### - Check when auth key_request is `enabled`
Steps:
1. Go to Management > Configuration > Edit configuration
2. Enable key request. Add key request tag on auth block
```xml
<auth>
   .........
     <key_request>
	<enabled>yes</enabled>
     </key_request>
</auth>
```

![Selección_018](https://user-images.githubusercontent.com/6089438/187720934-4e487e70-ef25-4ab1-bd74-00fd5c788351.png)
